### PR TITLE
fix: resolve 18 critical issues across system - crash fixes, agent-memory integration, hardcoded paths, error handling

### DIFF
--- a/config/capabilities.json
+++ b/config/capabilities.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": "2026-03-08T03:49:14.446723",
+  "timestamp": "2026-03-08T09:25:25.131377",
   "capabilities": [
     {
       "name": "Node_00_StateMachine",

--- a/core/auth.py
+++ b/core/auth.py
@@ -23,8 +23,9 @@ from fastapi import Header, HTTPException, status
 
 logger = logging.getLogger("UFO-Galaxy.Auth")
 
-# Module-level flag: dev-mode warning has been issued at most once per process
+# Module-level flags: warnings issued at most once per process
 _dev_mode_warning_issued: bool = False
+_no_token_warning_issued: bool = False
 
 # ---------------------------------------------------------------------------
 # Dev-mode detection & startup warning
@@ -43,6 +44,18 @@ def _warn_dev_mode_once():
         logger.warning(
             "⚠️  UFO Galaxy is running in DEV MODE (UFO_DEV_MODE=1). "
             "Authentication is DISABLED. Do NOT use this mode in production."
+        )
+
+
+def _warn_no_token_once():
+    """Emit a one-time warning when no API token is configured."""
+    global _no_token_warning_issued
+    if not _no_token_warning_issued:
+        _no_token_warning_issued = True
+        logger.warning(
+            "UFO_API_TOKEN is not set and UFO_DEV_MODE is not enabled. "
+            "Authentication is disabled. Set UFO_API_TOKEN for production "
+            "or UFO_DEV_MODE=1 to suppress this warning."
         )
 
 
@@ -106,7 +119,10 @@ async def require_auth(
 
     # Dev mode: token not set → allow through without authentication
     if not expected_token:
-        logger.debug("UFO_API_TOKEN 未设置，跳过鉴权（开发模式）")
+        if _is_dev_mode():
+            _warn_dev_mode_once()
+        else:
+            _warn_no_token_once()
         return {
             "authenticated": True,
             "device_id": x_device_id,

--- a/core/galaxy_core.py
+++ b/core/galaxy_core.py
@@ -71,6 +71,7 @@ class GalaxyCore:
         self.devices: Dict[str, Dict] = {}
         self._http_client: Optional[httpx.AsyncClient] = None
         self._protocol_client: Optional[NodeProtocolClient] = None
+        self._node_host = os.getenv("UFO_NODE_HOST", "localhost")
         
         # 加载节点注册表
         self._load_node_registry()
@@ -132,7 +133,7 @@ class GalaxyCore:
         
         node = self.nodes[node_id]
         port = node.get("port", 8000)
-        endpoint = f"http://localhost:{port}"
+        endpoint = f"http://{self._node_host}:{port}"
         
         params = params or {}
         
@@ -203,7 +204,7 @@ class GalaxyCore:
             client = await self._get_http_client()
             
             response = await client.post(
-                f"http://localhost:{port}/protocol/message",
+                f"http://{self._node_host}:{port}/protocol/message",
                 json=message.to_dict()
             )
             

--- a/core/rag_memory.py
+++ b/core/rag_memory.py
@@ -264,19 +264,19 @@ class RAGMemory:
         """
         chunks = []
 
-        # 尝试 Node_105
+        # 尝试 Node_105 (UnifiedKnowledgeBase)
         try:
-            from nodes.Node_105_UnifiedKnowledgeBase.main import search_knowledge
+            from nodes.Node_105_UnifiedKnowledgeBase.main import kb as node105_kb
             results = await asyncio.get_running_loop().run_in_executor(
-                None, search_knowledge, query, top_k
+                None, node105_kb.search_hybrid, query, top_k
             )
             for r in (results or []):
                 chunks.append(KnowledgeChunk(
-                    chunk_id=r.get("id", ""),
-                    content=r.get("content", ""),
+                    chunk_id=getattr(r, "id", ""),
+                    content=getattr(r, "content", ""),
                     source="Node_105",
-                    relevance_score=r.get("score", 0.0),
-                    metadata=r.get("metadata", {}),
+                    relevance_score=0.8,
+                    metadata=getattr(r, "metadata", {}),
                 ))
         except Exception as e:
             logger.debug(f"Node_105 query failed: {e}")
@@ -295,6 +295,28 @@ class RAGMemory:
                     ))
             except Exception as e:
                 logger.debug(f"Node_72 query failed: {e}")
+
+        # 尝试 Node_80 Memos 长期记忆
+        if len(chunks) < top_k:
+            try:
+                import httpx
+                async with httpx.AsyncClient(timeout=5) as client:
+                    response = await client.post(
+                        "http://localhost:8080/memory/recall",
+                        json={"query": query, "limit": top_k - len(chunks)},
+                    )
+                    if response.status_code == 200:
+                        data = response.json()
+                        for mem in data.get("memories", []):
+                            chunks.append(KnowledgeChunk(
+                                chunk_id=mem.get("id", ""),
+                                content=mem.get("content", ""),
+                                source="Node_80_Memos",
+                                relevance_score=mem.get("relevance_score", 0.5),
+                                metadata=mem.get("metadata", {}),
+                            ))
+            except Exception as e:
+                logger.debug(f"Node_80 memory recall failed: {e}")
 
         return chunks[:top_k]
 

--- a/core/routes/_helpers.py
+++ b/core/routes/_helpers.py
@@ -86,4 +86,4 @@ async def _execute_node(node_info: dict, action: str, params: dict):
             return await asyncio.get_running_loop().run_in_executor(
                 None, lambda: method(action, **params)
             )
-    return None
+    raise ValueError(f"Unsupported node type: {node_info.get('type')}")

--- a/core/routes/_shared.py
+++ b/core/routes/_shared.py
@@ -103,8 +103,8 @@ class ConnectionManager:
                             "online": True,
                             "source": "gateway_ws",
                         }
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Gateway ws_manager 设备合并不可用: {e}")
 
         # 合并 device_router 的设备
         try:
@@ -118,8 +118,8 @@ class ConnectionManager:
                     all_devices[did]["status"] = "online"
                     if device.device_type:
                         all_devices[did]["device_type"] = device.device_type
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"DeviceRouter 设备合并不可用: {e}")
 
         return all_devices
 
@@ -128,7 +128,8 @@ class ConnectionManager:
         for device_id, ws in self.active_devices.items():
             try:
                 await ws.send_json(message)
-            except Exception:
+            except Exception as e:
+                logger.debug(f"广播消息到设备 {device_id} 失败: {e}")
                 disconnected.append(device_id)
         for d in disconnected:
             self.disconnect_device(d)
@@ -145,7 +146,8 @@ class ConnectionManager:
         for ws in self.status_subscribers:
             try:
                 await ws.send_json(status)
-            except Exception:
+            except Exception as e:
+                logger.debug(f"状态推送到订阅者失败: {e}")
                 disconnected.append(ws)
         for ws in disconnected:
             self.status_subscribers.discard(ws)

--- a/core/routes/nodes.py
+++ b/core/routes/nodes.py
@@ -74,8 +74,8 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                         try:
                             with open(config_file, encoding="utf-8") as f:
                                 node_config = json.load(f)
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.warning(f"加载节点配置失败 {config_file}: {e}")
 
                     status = node_status_cache.get(name, {})
                     nodes.append({
@@ -103,8 +103,8 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             try:
                 with open(config_file, encoding="utf-8") as f:
                     node_config = json.load(f)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"加载节点配置失败 {config_file}: {e}")
 
         status = node_status_cache.get(node_name, {})
         return JSONResponse({

--- a/enhancements/coding/autonomous_coding_engine_v2.py
+++ b/enhancements/coding/autonomous_coding_engine_v2.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from pathlib import Path
 
 # 添加项目路径
-sys.path.insert(0, '/home/ubuntu/code_audit/ufo-galaxy-realization')
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 from enhancements.coding.llm_code_generator import (
     LLMCodeGenerator,

--- a/knowledge_db/knowledge_entries.json
+++ b/knowledge_db/knowledge_entries.json
@@ -6,7 +6,7 @@
       "metadata": {
         "category": "tech"
       },
-      "timestamp": 1772941791.4605489
+      "timestamp": 1772961934.3402786
     }
   ]
 }

--- a/nodes/Node_106_GitHubFlow/main.py
+++ b/nodes/Node_106_GitHubFlow/main.py
@@ -180,8 +180,8 @@ class GitHubFlow:
     def __init__(self, github_token: Optional[str] = None, kb_url: str = "http://localhost:8105"):
         self.github = GitHubClient(github_token)
         self.kb_url = kb_url
-        self.use_mock = True  # Mock 模式（无需 LLM）
-        
+        self.use_mock = not bool(github_token)  # 有 token 时使用真实模式
+
         print(f"✅ GitHub 工作流已初始化 (Mock 模式: {self.use_mock})")
     
     async def create_issue_from_task(self, repo: str, task: str, labels: List[str] = None) -> Dict:

--- a/nodes/Node_108_MetaCognition/main.py
+++ b/nodes/Node_108_MetaCognition/main.py
@@ -258,7 +258,7 @@ class MetaCognitionEngine:
         # 简化的相关性评估
         keywords = ["urgent", "important", "critical", "error", "success"]
         text = str(data).lower()
-        score = sum(1 for k in keywords if k in text) / len(keywords)
+        score = sum(1 for k in keywords if k in text) / max(len(keywords), 1)
         return min(1.0, score + 0.3)
     
     def _determine_attention(self, data: Dict) -> bool:

--- a/nodes/Node_11_GitHub/main.py
+++ b/nodes/Node_11_GitHub/main.py
@@ -27,7 +27,7 @@ import aiohttp
 
 # --- 常量定义 ---
 NODE_NAME = "Node_11_GitHub"
-CONFIG_FILE_PATH = "config.json"
+CONFIG_FILE_PATH = os.path.join(os.path.dirname(__file__), "config.json")
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 # --- 枚举类型定义 ---

--- a/nodes/Node_120_File/main.py
+++ b/nodes/Node_120_File/main.py
@@ -47,7 +47,7 @@ NODE_NAME = os.getenv("NODE_NAME", "FileOperations")
 NODE_PORT = int(os.getenv("NODE_PORT", "8120"))
 STATE_MACHINE_URL = os.getenv("STATE_MACHINE_URL", "http://localhost:8000")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-WORKSPACE_ROOT = os.getenv("WORKSPACE_ROOT", "/home/ubuntu/workspace")
+WORKSPACE_ROOT = os.getenv("WORKSPACE_ROOT", str(Path.home() / "workspace"))
 MAX_FILE_SIZE = int(os.getenv("MAX_FILE_SIZE", str(100 * 1024 * 1024)))  # 100MB
 
 logging.basicConfig(

--- a/nodes/Node_121_Web/main.py
+++ b/nodes/Node_121_Web/main.py
@@ -44,7 +44,7 @@ NODE_NAME = os.getenv("NODE_NAME", "WebOperations")
 NODE_PORT = int(os.getenv("NODE_PORT", "8121"))
 STATE_MACHINE_URL = os.getenv("STATE_MACHINE_URL", "http://localhost:8000")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-DOWNLOAD_DIR = os.getenv("DOWNLOAD_DIR", "/home/ubuntu/downloads")
+DOWNLOAD_DIR = os.getenv("DOWNLOAD_DIR", str(Path.home() / "downloads"))
 DEFAULT_TIMEOUT = int(os.getenv("DEFAULT_TIMEOUT", "30"))
 MAX_DOWNLOAD_SIZE = int(os.getenv("MAX_DOWNLOAD_SIZE", str(500 * 1024 * 1024)))  # 500MB
 

--- a/nodes/Node_122_Shell/main.py
+++ b/nodes/Node_122_Shell/main.py
@@ -45,7 +45,7 @@ STATE_MACHINE_URL = os.getenv("STATE_MACHINE_URL", "http://localhost:8000")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 DEFAULT_TIMEOUT = int(os.getenv("DEFAULT_TIMEOUT", "300"))
 DEFAULT_SHELL = os.getenv("DEFAULT_SHELL", "/bin/bash")
-WORKSPACE_ROOT = os.getenv("WORKSPACE_ROOT", "/home/ubuntu")
+WORKSPACE_ROOT = os.getenv("WORKSPACE_ROOT", str(Path.home()))
 
 # Security: blocked commands
 BLOCKED_COMMANDS = [

--- a/nodes/Node_125_MediaGen/main.py
+++ b/nodes/Node_125_MediaGen/main.py
@@ -14,6 +14,7 @@ import os
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Dict, Any, Optional, Type
 
 # 1. 日志配置
@@ -60,11 +61,11 @@ class MediaGenConfig:
     """媒体生成节点的配置"""
     node_id: str = "Node_125_MediaGen"
     api_keys: Dict[str, str] = field(default_factory=lambda: {
-        "image_gen_api_key": "dummy_image_api_key_xxxxxxxx",
-        "audio_gen_api_key": "dummy_audio_api_key_xxxxxxxx",
-        "video_gen_api_key": "dummy_video_api_key_xxxxxxxx",
+        "image_gen_api_key": os.getenv("IMAGE_GEN_API_KEY", ""),
+        "audio_gen_api_key": os.getenv("AUDIO_GEN_API_KEY", ""),
+        "video_gen_api_key": os.getenv("VIDEO_GEN_API_KEY", ""),
     })
-    output_directory: str = "/home/ubuntu/media_output"
+    output_directory: str = field(default_factory=lambda: os.getenv("MEDIA_OUTPUT_DIR", str(Path.home() / "media_output")))
     max_concurrent_tasks: int = 10
     default_image_model: str = "stable-diffusion-v1.5"
     default_audio_model: str = "tts-1"

--- a/nodes/Node_31_Reserved/main.py
+++ b/nodes/Node_31_Reserved/main.py
@@ -300,7 +300,7 @@ async def main():
 
 if __name__ == "__main__":
     # 为了演示，创建一个示例插件
-    plugin_dir = "/home/ubuntu/plugins"
+    plugin_dir = os.path.expanduser("~/ufo-plugins")
     os.makedirs(plugin_dir, exist_ok=True)
     sample_plugin_code = """
 from typing import Any

--- a/nodes/Node_50_Transformer/main.py
+++ b/nodes/Node_50_Transformer/main.py
@@ -12,7 +12,10 @@ from typing import Dict, Any, Optional, List
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+import logging
 from nodes.common.cors_config import get_cors_origins
+
+logger = logging.getLogger("Node_50_Transformer")
 
 app = FastAPI(title="Node 50 - Transformer NLU", version="2.0.0")
 app.add_middleware(CORSMiddleware, allow_origins=get_cors_origins(), allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
@@ -52,9 +55,18 @@ def call_llm(messages: List[Dict], max_tokens: int = 1000) -> Optional[str]:
                 timeout=30
             )
             if response.status_code == 200:
-                return response.json()["choices"][0]["message"]["content"]
-        except: pass
-    
+                data = response.json()
+                choices = data.get("choices")
+                if choices and len(choices) > 0:
+                    content = choices[0].get("message", {}).get("content")
+                    if content:
+                        return content
+                logger.warning(f"Groq 返回格式异常: {response.status_code}")
+            else:
+                logger.warning(f"Groq API 返回 {response.status_code}")
+        except Exception as e:
+            logger.warning(f"Groq API 调用失败: {e}")
+
     # 智谱 (中文好)
     if ZHIPU_API_KEY:
         try:
@@ -65,9 +77,18 @@ def call_llm(messages: List[Dict], max_tokens: int = 1000) -> Optional[str]:
                 timeout=30
             )
             if response.status_code == 200:
-                return response.json()["choices"][0]["message"]["content"]
-        except: pass
-    
+                data = response.json()
+                choices = data.get("choices")
+                if choices and len(choices) > 0:
+                    content = choices[0].get("message", {}).get("content")
+                    if content:
+                        return content
+                logger.warning(f"智谱 返回格式异常: {response.status_code}")
+            else:
+                logger.warning(f"智谱 API 返回 {response.status_code}")
+        except Exception as e:
+            logger.warning(f"智谱 API 调用失败: {e}")
+
     # OpenRouter
     if OPENROUTER_API_KEY:
         try:
@@ -78,9 +99,18 @@ def call_llm(messages: List[Dict], max_tokens: int = 1000) -> Optional[str]:
                 timeout=30
             )
             if response.status_code == 200:
-                return response.json()["choices"][0]["message"]["content"]
-        except: pass
-    
+                data = response.json()
+                choices = data.get("choices")
+                if choices and len(choices) > 0:
+                    content = choices[0].get("message", {}).get("content")
+                    if content:
+                        return content
+                logger.warning(f"OpenRouter 返回格式异常: {response.status_code}")
+            else:
+                logger.warning(f"OpenRouter API 返回 {response.status_code}")
+        except Exception as e:
+            logger.warning(f"OpenRouter API 调用失败: {e}")
+
     # OneAPI (本地)
     if ONEAPI_API_KEY:
         try:
@@ -91,9 +121,18 @@ def call_llm(messages: List[Dict], max_tokens: int = 1000) -> Optional[str]:
                 timeout=30
             )
             if response.status_code == 200:
-                return response.json()["choices"][0]["message"]["content"]
-        except: pass
-    
+                data = response.json()
+                choices = data.get("choices")
+                if choices and len(choices) > 0:
+                    content = choices[0].get("message", {}).get("content")
+                    if content:
+                        return content
+                logger.warning(f"OneAPI 返回格式异常: {response.status_code}")
+            else:
+                logger.warning(f"OneAPI API 返回 {response.status_code}")
+        except Exception as e:
+            logger.warning(f"OneAPI API 调用失败: {e}")
+
     return None
 
 def parse_json_response(result: str) -> Dict:

--- a/nodes/Node_70_AutonomousLearning/main.py
+++ b/nodes/Node_70_AutonomousLearning/main.py
@@ -262,13 +262,22 @@ class AutonomousLearningEngine:
             session.completed_at = datetime.now()
     
     def _update_q_values(self, experience: Experience):
-        """更新 Q 值"""
-        # 简化的 Q-learning 更新
+        """更新 Q 值 - 简化的 Q-learning"""
         state_key = hashlib.md5(str(experience.context).encode()).hexdigest()[:8]
         action_key = experience.action
-        
-        # 这里应该有一个 Q 表，简化处理
-        pass
+
+        if not hasattr(self, '_q_table'):
+            self._q_table = {}
+
+        if state_key not in self._q_table:
+            self._q_table[state_key] = {}
+
+        old_value = self._q_table[state_key].get(action_key, 0.0)
+        learning_rate = 0.1
+
+        # Q(s,a) = Q(s,a) + α * (reward - Q(s,a))
+        new_value = old_value + learning_rate * (experience.reward - old_value)
+        self._q_table[state_key][action_key] = new_value
     
     def _calculate_avg_reward(self) -> float:
         """计算平均奖励"""

--- a/nodes/Node_72_KnowledgeBase/main.py
+++ b/nodes/Node_72_KnowledgeBase/main.py
@@ -14,13 +14,15 @@ import json
 import logging
 import os
 import uuid
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 # --- 配置和常量 --- #
 
 LOG_LEVEL = logging.INFO
-DEFAULT_CONFIG_PATH = "/home/ubuntu/kb_config.json"
-DEFAULT_KB_PATH = "/home/ubuntu/knowledge_base.json"
+DEFAULT_CONFIG_PATH = os.getenv("KB_CONFIG_PATH", os.path.join(str(Path.home()), "kb_config.json"))
+DEFAULT_KB_PATH = os.getenv("KB_FILE_PATH", os.path.join(str(Path.home()), "knowledge_base.json"))
 
 # 配置日志记录器
 logging.basicConfig(
@@ -70,8 +72,8 @@ class KnowledgeEntry:
     metadata: Dict[str, Any]
     status: KnowledgeStatus = KnowledgeStatus.ACTIVE
     embedding: Optional[List[float]] = None  # 存储文本内容的向量表示
-    created_at: str = dataclasses.field(default_factory=lambda: asyncio.get_event_loop().time().__str__())
-    updated_at: str = dataclasses.field(default_factory=lambda: asyncio.get_event_loop().time().__str__())
+    created_at: str = dataclasses.field(default_factory=lambda: datetime.now().isoformat())
+    updated_at: str = dataclasses.field(default_factory=lambda: datetime.now().isoformat())
 
 
 # --- 核心服务类 --- #
@@ -218,7 +220,7 @@ class KnowledgeBaseService:
         """更新知识条目的状态（如归档）"""
         if entry_id in self._knowledge_base:
             self._knowledge_base[entry_id].status = status
-            self._knowledge_base[entry_id].updated_at = str(asyncio.get_event_loop().time())
+            self._knowledge_base[entry_id].updated_at = datetime.now().isoformat()
             await self._save_knowledge_base()
             logger.info(f"知识条目 {entry_id} 状态已更新为 {status.value}")
             return True
@@ -229,7 +231,7 @@ class KnowledgeBaseService:
         return {
             "node_id": self.config.node_id,
             "service_status": self.status.value,
-            "timestamp": asyncio.get_event_loop().time(),
+            "timestamp": datetime.now().isoformat(),
             "knowledge_count": len(self._knowledge_base),
             "kb_file_path": self.config.kb_file_path,
             "config_file_path": self.config_path

--- a/nodes/Node_80_MemorySystem/main.py
+++ b/nodes/Node_80_MemorySystem/main.py
@@ -790,129 +790,127 @@ if __name__ == "__main__":
 
 
 # =============================================================================
-# Academic Extension API Endpoints
+# Academic Extension API Endpoints (optional)
 # =============================================================================
 
-from academic_extension import academic_manager, PaperNote, CitationNetwork
-from nodes.common.cors_config import get_cors_origins
+try:
+    from academic_extension import academic_manager, PaperNote, CitationNetwork
 
-@app.post("/academic/paper_note")
-async def save_academic_paper_note(paper: PaperNote):
-    """保存论文笔记"""
-    success = await academic_manager.save_paper_note(paper)
-    return {
-        "success": success,
-        "paper_id": paper.paper_id,
-        "title": paper.title
-    }
+    @app.post("/academic/paper_note")
+    async def save_academic_paper_note(paper: PaperNote):
+        """保存论文笔记"""
+        success = await academic_manager.save_paper_note(paper)
+        return {
+            "success": success,
+            "paper_id": paper.paper_id,
+            "title": paper.title
+        }
 
-@app.get("/academic/paper_notes")
-async def search_academic_paper_notes(
-    query: str = Query(default="", description="搜索关键词"),
-    tags: Optional[str] = Query(default=None, description="标签（逗号分隔）")
-):
-    """搜索论文笔记"""
-    tag_list = tags.split(",") if tags else None
-    memos = await academic_manager.search_paper_notes(query, tag_list)
-    return {
-        "query": query,
-        "tags": tag_list,
-        "count": len(memos),
-        "papers": memos
-    }
+    @app.get("/academic/paper_notes")
+    async def search_academic_paper_notes(
+        query: str = Query(default="", description="搜索关键词"),
+        tags: Optional[str] = Query(default=None, description="标签（逗号分隔）")
+    ):
+        """搜索论文笔记"""
+        tag_list = tags.split(",") if tags else None
+        memos = await academic_manager.search_paper_notes(query, tag_list)
+        return {
+            "query": query,
+            "tags": tag_list,
+            "count": len(memos),
+            "papers": memos
+        }
 
-@app.get("/academic/citation_network/{paper_id}")
-async def get_academic_citation_network(paper_id: str):
-    """获取论文引用网络"""
-    network = await academic_manager.get_citation_network(paper_id)
-    return network.dict()
+    @app.get("/academic/citation_network/{paper_id}")
+    async def get_academic_citation_network(paper_id: str):
+        """获取论文引用网络"""
+        network = await academic_manager.get_citation_network(paper_id)
+        return network.dict()
 
-@app.get("/academic/papers_by_tag/{tag}")
-async def get_academic_papers_by_tag(tag: str):
-    """根据标签获取论文"""
-    papers = await academic_manager.get_papers_by_tag(tag)
-    return {
-        "tag": tag,
-        "count": len(papers),
-        "papers": papers
-    }
+    @app.get("/academic/papers_by_tag/{tag}")
+    async def get_academic_papers_by_tag(tag: str):
+        """根据标签获取论文"""
+        papers = await academic_manager.get_papers_by_tag(tag)
+        return {
+            "tag": tag,
+            "count": len(papers),
+            "papers": papers
+        }
 
-@app.get("/academic/recent_papers")
-async def get_academic_recent_papers(days: int = Query(default=7, ge=1, le=30)):
-    """获取最近的论文笔记"""
-    papers = await academic_manager.get_recent_papers(days)
-    return {
-        "days": days,
-        "count": len(papers),
-        "papers": papers
-    }
+    @app.get("/academic/recent_papers")
+    async def get_academic_recent_papers(days: int = Query(default=7, ge=1, le=30)):
+        """获取最近的论文笔记"""
+        papers = await academic_manager.get_recent_papers(days)
+        return {
+            "days": days,
+            "count": len(papers),
+            "papers": papers
+        }
 
-@app.post("/academic/export_bibtex")
-async def export_academic_bibtex(paper_ids: List[str]):
-    """导出论文为 BibTeX 格式"""
-    bibtex = await academic_manager.export_papers_to_bibtex(paper_ids)
-    return {
-        "count": len(paper_ids),
-        "bibtex": bibtex
-    }
+    @app.post("/academic/export_bibtex")
+    async def export_academic_bibtex(paper_ids: List[str]):
+        """导出论文为 BibTeX 格式"""
+        bibtex = await academic_manager.export_papers_to_bibtex(paper_ids)
+        return {
+            "count": len(paper_ids),
+            "bibtex": bibtex
+        }
 
+    @app.get("/academic/keywords/{paper_id:path}")
+    async def extract_paper_keywords(paper_id: str, top_n: int = Query(default=10, ge=1, le=30)):
+        """自动提取论文关键词"""
+        memos = await academic_manager.search_paper_notes(paper_id)
+        if not memos:
+            raise HTTPException(status_code=404, detail="未找到该论文笔记")
+        keywords = await academic_manager.extract_keywords_from_memo(memos[0], top_n)
+        return {
+            "paper_id": paper_id,
+            "keywords": keywords,
+            "count": len(keywords)
+        }
 
-@app.get("/academic/keywords/{paper_id:path}")
-async def extract_paper_keywords(paper_id: str, top_n: int = Query(default=10, ge=1, le=30)):
-    """自动提取论文关键词"""
-    memos = await academic_manager.search_paper_notes(paper_id)
-    if not memos:
-        raise HTTPException(status_code=404, detail="未找到该论文笔记")
-    keywords = await academic_manager.extract_keywords_from_memo(memos[0], top_n)
-    return {
-        "paper_id": paper_id,
-        "keywords": keywords,
-        "count": len(keywords)
-    }
+    @app.get("/academic/similarity")
+    async def compute_paper_similarity(
+        paper_id_a: str = Query(..., description="第一篇论文 ID"),
+        paper_id_b: str = Query(..., description="第二篇论文 ID")
+    ):
+        """计算两篇论文的相似度（基于关键词 Jaccard 相似度）"""
+        similarity = await academic_manager.compute_similarity(paper_id_a, paper_id_b)
+        return {
+            "paper_id_a": paper_id_a,
+            "paper_id_b": paper_id_b,
+            "similarity": similarity
+        }
 
+    @app.get("/academic/recommend/{paper_id:path}")
+    async def recommend_related_papers(
+        paper_id: str,
+        top_n: int = Query(default=5, ge=1, le=20)
+    ):
+        """推荐与目标论文相关的论文（基于关键词相似度）"""
+        recommendations = await academic_manager.recommend_related_papers(paper_id, top_n)
+        return {
+            "paper_id": paper_id,
+            "recommendations": recommendations,
+            "count": len(recommendations)
+        }
 
-@app.get("/academic/similarity")
-async def compute_paper_similarity(
-    paper_id_a: str = Query(..., description="第一篇论文 ID"),
-    paper_id_b: str = Query(..., description="第二篇论文 ID")
-):
-    """计算两篇论文的相似度（基于关键词 Jaccard 相似度）"""
-    similarity = await academic_manager.compute_similarity(paper_id_a, paper_id_b)
-    return {
-        "paper_id_a": paper_id_a,
-        "paper_id_b": paper_id_b,
-        "similarity": similarity
-    }
+    class LiteratureReviewRequest(BaseModel):
+        paper_ids: List[str]
+        topic: Optional[str] = ""
 
+    @app.post("/academic/literature_review")
+    async def generate_literature_review(request: LiteratureReviewRequest):
+        """自动生成文献综述（Markdown 格式）"""
+        review = await academic_manager.generate_literature_review(
+            request.paper_ids,
+            request.topic or ""
+        )
+        return {
+            "topic": request.topic,
+            "paper_count": len(request.paper_ids),
+            "review": review
+        }
 
-@app.get("/academic/recommend/{paper_id:path}")
-async def recommend_related_papers(
-    paper_id: str,
-    top_n: int = Query(default=5, ge=1, le=20)
-):
-    """推荐与目标论文相关的论文（基于关键词相似度）"""
-    recommendations = await academic_manager.recommend_related_papers(paper_id, top_n)
-    return {
-        "paper_id": paper_id,
-        "recommendations": recommendations,
-        "count": len(recommendations)
-    }
-
-
-class LiteratureReviewRequest(BaseModel):
-    paper_ids: List[str]
-    topic: Optional[str] = ""
-
-
-@app.post("/academic/literature_review")
-async def generate_literature_review(request: LiteratureReviewRequest):
-    """自动生成文献综述（Markdown 格式）"""
-    review = await academic_manager.generate_literature_review(
-        request.paper_ids,
-        request.topic or ""
-    )
-    return {
-        "topic": request.topic,
-        "paper_count": len(request.paper_ids),
-        "review": review
-    }
+except ImportError:
+    logger.info("academic_extension 模块未安装，学术功能路由已跳过")


### PR DESCRIPTION
Crash-level fixes:
- Node_80_MemorySystem: wrap academic_extension import in try/except to prevent ImportError crash
- Node_72_KnowledgeBase: replace asyncio.get_event_loop().time() with datetime.now() (Python 3.10+ compat)
- core/rag_memory.py: fix non-existent search_knowledge import from Node_105, use kb.search_hybrid()
- autonomous_coding_engine_v2: replace hardcoded developer path with Path-relative resolution

Agent-memory integration:
- core/rag_memory.py: add Node_80 Memos long-term memory as third knowledge source in query_knowledge()

Functionality fixes:
- Node_50_Transformer: replace 4 bare except:pass with safe JSON parsing and logged warnings
- core/routes/_helpers.py: raise ValueError instead of silent None return for unsupported node types
- Node_70_AutonomousLearning: implement Q-learning _update_q_values() (was empty pass)
- Node_108_MetaCognition: fix division-by-zero when keywords list is empty
- core/galaxy_core.py: replace hardcoded localhost with configurable UFO_NODE_HOST env var
- Node_106_GitHubFlow: fix mock mode always-on even with valid token

Hardcoded path fixes:
- Node_120_File, Node_121_Web, Node_122_Shell, Node_31_Reserved: replace /home/ubuntu paths with Path.home()
- Node_125_MediaGen: replace hardcoded path + dummy API keys with env var lookups
- Node_72_KnowledgeBase: replace /home/ubuntu paths with env var + Path.home() defaults
- Node_11_GitHub: fix relative config.json path to use __file__-relative

Error handling improvements:
- core/routes/_shared.py: add logging to 4 bare except blocks
- core/routes/nodes.py: add logging to config loading exceptions
- core/auth.py: add one-time warning when UFO_API_TOKEN not set outside dev mode

https://claude.ai/code/session_01EsdE4pasEFFfuGiLvQq7bZ