### PR TITLE
feat: add AI agent system design docs, tests, and execution timeouts

### DIFF
--- a/core/agent_factory.py
+++ b/core/agent_factory.py
@@ -612,11 +612,25 @@ class AgentFactory:
                             payload=task_item,
                         )
                         await self.message_bus.send(task_msg)
-                # 子 Agent 并行执行
-                results = await asyncio.gather(
-                    *[self._run_agent(c.id) for c in children],
-                    return_exceptions=True,
-                )
+                # 子 Agent 并行执行（带总超时保护）
+                try:
+                    results = await asyncio.wait_for(
+                        asyncio.gather(
+                            *[self._run_agent(c.id) for c in children],
+                            return_exceptions=True,
+                        ),
+                        timeout=self.TASK_TIMEOUT_SECONDS * 2,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(f"子 Agent 并行执行整体超时 ({self.TASK_TIMEOUT_SECONDS * 2}s)")
+                    for child in children:
+                        child.state = AgentState.ERROR
+                    agent.state = AgentState.ERROR
+                    return {
+                        "strategy": "split_and_parallel",
+                        "error": f"Parallel execution timed out after {self.TASK_TIMEOUT_SECONDS * 2}s",
+                        "children": [c.id for c in children],
+                    }
                 # 收集执行结果，区分成功和失败
                 child_results = []
                 success_count = 0
@@ -668,6 +682,8 @@ class AgentFactory:
         result = await self._run_agent(agent_id)
         return result
 
+    TASK_TIMEOUT_SECONDS = 300  # 单个任务超时（秒）
+
     async def _run_agent(self, agent_id: str) -> Dict:
         """执行 Agent 的当前任务队列"""
         agent = self.agents.get(agent_id)
@@ -682,32 +698,10 @@ class AgentFactory:
             t0 = time.monotonic()
 
             try:
-                if self.llm_router:
-                    # 用 LLM 执行（带熔断器保护）
-                    messages = [
-                        {"role": "system", "content": agent.config.system_prompt},
-                        {"role": "user", "content": json.dumps(task, ensure_ascii=False)},
-                    ]
-
-                    async def _llm_call():
-                        return await self.llm_router.chat(
-                            messages=messages,
-                            task_type="agent_control",
-                        )
-
-                    if self._llm_circuit_breaker:
-                        resp = await self._llm_circuit_breaker.execute(_llm_call)
-                    else:
-                        resp = await _llm_call()
-                    result = {"task": task, "output": resp.content, "provider": resp.provider}
-                else:
-                    # 无 LLM，模拟执行
-                    result = {
-                        "task": task,
-                        "output": f"Agent {agent.config.name} 已处理任务（无 LLM 模式）",
-                        "simulated": True,
-                        "status": "simulated",
-                    }
+                result = await asyncio.wait_for(
+                    self._execute_single_task(agent, task),
+                    timeout=self.TASK_TIMEOUT_SECONDS,
+                )
 
                 latency = (time.monotonic() - t0) * 1000
                 result["latency_ms"] = latency
@@ -722,6 +716,20 @@ class AgentFactory:
                         f"{task.get('description', str(task)[:80])}"
                     )
 
+            except asyncio.TimeoutError:
+                latency = (time.monotonic() - t0) * 1000
+                agent.metrics["tasks_failed"] += 1
+                results.append({
+                    "task": task,
+                    "error": f"Task timed out after {self.TASK_TIMEOUT_SECONDS}s",
+                    "error_type": "TimeoutError",
+                    "latency_ms": latency,
+                })
+                logger.error(
+                    f"Agent {agent_id} task timed out after {self.TASK_TIMEOUT_SECONDS}s: "
+                    f"{task.get('description', str(task)[:80])}"
+                )
+
             except Exception as e:
                 agent.metrics["tasks_failed"] += 1
                 results.append({"task": task, "error": str(e)})
@@ -734,6 +742,35 @@ class AgentFactory:
             "results": results,
             "status": "simulated" if any_simulated else "completed",
         }
+
+    async def _execute_single_task(self, agent: TaskAgent, task: Dict) -> Dict:
+        """执行单个任务（可被 wait_for 超时包装）"""
+        if self.llm_router:
+            # 用 LLM 执行（带熔断器保护）
+            messages = [
+                {"role": "system", "content": agent.config.system_prompt},
+                {"role": "user", "content": json.dumps(task, ensure_ascii=False)},
+            ]
+
+            async def _llm_call():
+                return await self.llm_router.chat(
+                    messages=messages,
+                    task_type="agent_control",
+                )
+
+            if self._llm_circuit_breaker:
+                resp = await self._llm_circuit_breaker.execute(_llm_call)
+            else:
+                resp = await _llm_call()
+            return {"task": task, "output": resp.content, "provider": resp.provider}
+        else:
+            # 无 LLM，模拟执行
+            return {
+                "task": task,
+                "output": f"Agent {agent.config.name} 已处理任务（无 LLM 模式）",
+                "simulated": True,
+                "status": "simulated",
+            }
 
     # ─────── 内部工具 ─────────
 

--- a/data/agent_state.json
+++ b/data/agent_state.json
@@ -1,59 +1,7 @@
 {
   "agents": {
-    "agent_6686d34189a0": {
-      "id": "agent_6686d34189a0",
-      "config": {
-        "role": "coordinator",
-        "name": "协调 Agent",
-        "description": "负责接收复杂任务，分解为子任务并分配给子 Agent",
-        "system_prompt": "你是一个协调 Agent。你的职责是：\n1. 接收用户的复杂任务\n2. 将任务分解为可独立执行的子任务\n3. 为每个子任务分配合适的执行 Agent\n4. 监控执行进度并汇总结果\n\n返回 JSON 格式的任务分解方案。",
-        "max_subtasks": 10,
-        "max_depth": 3,
-        "split_threshold": 3,
-        "ttl": 3600
-      },
-      "state": "idle",
-      "parent_id": null,
-      "children_ids": [],
-      "creation_mode": "template",
-      "depth": 0,
-      "created_at": 1772874274.0880747,
-      "last_active": 1772874274.0880756,
-      "metrics": {
-        "tasks_completed": 0,
-        "tasks_failed": 0,
-        "total_latency_ms": 0,
-        "splits": 0
-      }
-    },
-    "agent_b420179c218e": {
-      "id": "agent_b420179c218e",
-      "config": {
-        "role": "coordinator",
-        "name": "协调 Agent",
-        "description": "负责接收复杂任务，分解为子任务并分配给子 Agent",
-        "system_prompt": "你是一个协调 Agent。你的职责是：\n1. 接收用户的复杂任务\n2. 将任务分解为可独立执行的子任务\n3. 为每个子任务分配合适的执行 Agent\n4. 监控执行进度并汇总结果\n\n返回 JSON 格式的任务分解方案。",
-        "max_subtasks": 10,
-        "max_depth": 3,
-        "split_threshold": 3,
-        "ttl": 3600
-      },
-      "state": "idle",
-      "parent_id": null,
-      "children_ids": [],
-      "creation_mode": "template",
-      "depth": 0,
-      "created_at": 1772874282.5844874,
-      "last_active": 1772874282.5844877,
-      "metrics": {
-        "tasks_completed": 0,
-        "tasks_failed": 0,
-        "total_latency_ms": 0,
-        "splits": 0
-      }
-    },
-    "agent_1c4b25a434db": {
-      "id": "agent_1c4b25a434db",
+    "agent_3c8b8bfdabea": {
+      "id": "agent_3c8b8bfdabea",
       "config": {
         "role": "analyst",
         "name": "数据分析 Agent",
@@ -69,112 +17,8 @@
       "children_ids": [],
       "creation_mode": "template",
       "depth": 0,
-      "created_at": 1772874282.5853515,
-      "last_active": 1772874282.5853517,
-      "metrics": {
-        "tasks_completed": 0,
-        "tasks_failed": 0,
-        "total_latency_ms": 0,
-        "splits": 0
-      }
-    },
-    "agent_a54485d82678": {
-      "id": "agent_a54485d82678",
-      "config": {
-        "role": "executor",
-        "name": "代码执行 Agent",
-        "description": "负责生成和执行代码",
-        "system_prompt": "你是一个代码执行 Agent。根据需求生成代码并执行。\n返回 JSON: {\"code\": ..., \"language\": ..., \"explanation\": ...}",
-        "max_subtasks": 5,
-        "max_depth": 3,
-        "split_threshold": 3,
-        "ttl": 3600
-      },
-      "state": "idle",
-      "parent_id": null,
-      "children_ids": [],
-      "creation_mode": "template",
-      "depth": 0,
-      "created_at": 1772874282.5857952,
-      "last_active": 1772874282.5857956,
-      "metrics": {
-        "tasks_completed": 0,
-        "tasks_failed": 0,
-        "total_latency_ms": 0,
-        "splits": 0
-      }
-    },
-    "agent_3d799f602042": {
-      "id": "agent_3d799f602042",
-      "config": {
-        "role": "analyst",
-        "name": "调研 Agent",
-        "description": "负责信息收集和研究",
-        "system_prompt": "你是一个调研 Agent。负责收集和整理信息。\n返回 JSON: {\"findings\": [...], \"sources\": [...], \"summary\": ...}",
-        "max_subtasks": 5,
-        "max_depth": 3,
-        "split_threshold": 3,
-        "ttl": 3600
-      },
-      "state": "idle",
-      "parent_id": null,
-      "children_ids": [],
-      "creation_mode": "template",
-      "depth": 0,
-      "created_at": 1772874282.586397,
-      "last_active": 1772874282.5863974,
-      "metrics": {
-        "tasks_completed": 0,
-        "tasks_failed": 0,
-        "total_latency_ms": 0,
-        "splits": 0
-      }
-    },
-    "agent_4caaacf5e049": {
-      "id": "agent_4caaacf5e049",
-      "config": {
-        "role": "planner",
-        "name": "规划 Agent",
-        "description": "负责制定执行计划和策略",
-        "system_prompt": "你是一个规划 Agent。根据目标制定详细的执行计划。\n返回 JSON: {\"plan\": {\"steps\": [...], \"resources\": [...], \"risks\": [...]}}",
-        "max_subtasks": 5,
-        "max_depth": 3,
-        "split_threshold": 3,
-        "ttl": 3600
-      },
-      "state": "idle",
-      "parent_id": null,
-      "children_ids": [],
-      "creation_mode": "template",
-      "depth": 0,
-      "created_at": 1772874282.5871599,
-      "last_active": 1772874282.58716,
-      "metrics": {
-        "tasks_completed": 0,
-        "tasks_failed": 0,
-        "total_latency_ms": 0,
-        "splits": 0
-      }
-    },
-    "agent_4e1f6d6f68bc": {
-      "id": "agent_4e1f6d6f68bc",
-      "config": {
-        "role": "executor",
-        "name": "设备控制 Agent",
-        "description": "负责与物理设备交互",
-        "system_prompt": "你是一个设备控制 Agent。负责安全地控制物理设备。\n在执行任何操作前，先进行安全检查。\n返回 JSON: {\"action\": ..., \"device\": ..., \"safety_check\": ..., \"result\": ...}",
-        "max_subtasks": 5,
-        "max_depth": 3,
-        "split_threshold": 3,
-        "ttl": 3600
-      },
-      "state": "idle",
-      "parent_id": null,
-      "children_ids": [],
-      "creation_mode": "template",
-      "depth": 0,
-      "created_at": 1772874282.5876133,
-      "last_active": 1772874282.5876133,
+      "created_at": 1772991110.9223711,
+      "last_active": 1772991110.9223714,
       "metrics": {
         "tasks_completed": 0,
         "tasks_failed": 0,
@@ -184,5 +28,5 @@
     }
   },
   "agent_tree": {},
-  "timestamp": 1772874282.5885592
+  "timestamp": 1772991110.9224055
 }

--- a/docs/AI_AGENT_SYSTEM_DESIGN.md
+++ b/docs/AI_AGENT_SYSTEM_DESIGN.md
@@ -1,0 +1,552 @@
+# Galaxy AI Agent System Design
+
+> Architecture specification for the Galaxy multi-agent system — a fractal, self-organizing agent ecosystem with digital twin integration.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Agent Lifecycle](#agent-lifecycle)
+- [Three Creation Modes](#three-creation-modes)
+- [Message Bus Protocol](#message-bus-protocol)
+- [Team Collaboration Strategies](#team-collaboration-strategies)
+- [Fractal Decomposition](#fractal-decomposition)
+- [Agent Manifest & Migration](#agent-manifest--migration)
+- [System Integration Layer](#system-integration-layer)
+- [Digital Twin Integration](#digital-twin-integration)
+- [Production Safeguards](#production-safeguards)
+- [Decision Guide](#decision-guide)
+- [API Reference](#api-reference)
+
+---
+
+## Overview
+
+Galaxy's Agent System implements an L4-autonomy multi-agent architecture with three core design principles:
+
+1. **Fractal Self-Similarity** — Every agent follows the same receive → decompose → execute → aggregate loop, from leaf executors to the root coordinator.
+2. **Dynamic Creation** — Agents are created on-demand via templates, LLM generation, or runtime splitting — no static wiring.
+3. **Digital Twin Coupling** — Each agent can optionally mirror its state to a twin model, enabling predictive simulation and deviation detection.
+
+### Key Components
+
+| Module | File | Purpose |
+|--------|------|---------|
+| Agent Factory | `core/agent_factory.py` | Agent lifecycle management, 3 creation modes |
+| Agent Team | `core/agent_team.py` | Multi-agent collaboration strategies |
+| Fractal Agent | `core/fractal_agent.py` | Recursive task decomposition |
+| Agent Manifest | `core/agent_manifest.py` | Serializable deployment package for edge devices |
+| System Integration | `core/system_integration.py` | Unified capability registry |
+| Agent Context | `core/agent_context.py` | Passive context loading from AGENTS.md |
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         REST / WebSocket API                     │
+│                     core/routes/agents.py                         │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                   │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────────────┐     │
+│  │ Agent Factory │  │  Agent Team  │  │  Fractal Executor  │     │
+│  │   3 modes     │  │ 3 strategies │  │ recursive decomp   │     │
+│  └──────┬───────┘  └──────┬───────┘  └────────┬───────────┘     │
+│         │                  │                    │                  │
+│  ┌──────┴──────────────────┴────────────────────┴───────────┐    │
+│  │                    Agent Message Bus                        │    │
+│  │          (async queues, broadcast, request-reply)          │    │
+│  └────────────────────────────┬───────────────────────────────┘    │
+│                               │                                    │
+│  ┌────────────────────────────┴───────────────────────────────┐    │
+│  │                  System Integration Layer                    │    │
+│  │         Unified Capability Registry (6 types)               │    │
+│  │     DEVICE | MCP | SKILL | NODE | AGENT | BUILTIN           │    │
+│  └─────────────────────────────────────────────────────────────┘    │
+│                                                                   │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌──────────────┐  ┌──────────────┐  ┌─────────────────────┐   │
+│  │ Multi-LLM    │  │ Twin Model   │  │ Circuit Breaker     │   │
+│  │ Router       │  │ Manager      │  │ (Monitoring)        │   │
+│  └──────────────┘  └──────────────┘  └─────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Agent Lifecycle
+
+### State Machine
+
+```
+                    ┌──────────┐
+         create()   │   IDLE   │◄──────────── task complete
+         ─────────►│          │
+                    └────┬─────┘
+                         │ execute_agent_task()
+                         ▼
+                    ┌──────────┐
+                    │ WORKING  │──────────────────────────┐
+                    └────┬─────┘                          │
+                         │ queue > threshold               │ error
+                         ▼                                 ▼
+                    ┌──────────┐                    ┌──────────┐
+                    │SPLITTING │                    │  ERROR   │
+                    └────┬─────┘                    └──────────┘
+                         │ children created
+                         ▼
+                    ┌──────────┐
+                    │ WAITING  │── children done ──► IDLE
+                    └──────────┘
+
+         Termination: any state ──► TERMINATED (TTL expired / manual)
+         Completion:  any state ──► COMPLETED  (all tasks done)
+```
+
+### States
+
+| State | Value | Description |
+|-------|-------|-------------|
+| `IDLE` | `idle` | No active tasks, ready to accept work |
+| `WORKING` | `working` | Actively processing tasks |
+| `WAITING` | `waiting` | Waiting for child agents to complete |
+| `SPLITTING` | `splitting` | In the process of creating child agents |
+| `COMPLETED` | `completed` | All tasks finished successfully |
+| `ERROR` | `error` | Encountered an unrecoverable error |
+| `TERMINATED` | `terminated` | Cleaned up by TTL or manual termination |
+
+### Roles
+
+| Role | Use Case |
+|------|----------|
+| `COORDINATOR` | Decomposes complex tasks, manages sub-agents |
+| `EXECUTOR` | Runs concrete tasks (code, device control) |
+| `ANALYST` | Data analysis, research, information extraction |
+| `PLANNER` | Strategic planning, risk assessment |
+| `MONITOR` | Observes and reports on execution |
+| `COMMUNICATOR` | Handles external communication |
+| `SPECIALIST` | Domain-specific expert |
+
+---
+
+## Three Creation Modes
+
+### Mode 1: Template Creation
+
+**When:** Known task types with predictable requirements.
+
+```python
+agent = factory.create_from_template("coordinator")
+agent = factory.create_from_template("data_analyst", overrides={"name": "Sales Analyst"})
+```
+
+**Available templates:** `coordinator`, `data_analyst`, `code_executor`, `research`, `device_controller`, `planner`
+
+**Behavior:** Instantiates from `AGENT_TEMPLATES` dict. Fast, deterministic, no LLM call.
+
+### Mode 2: LLM Generation
+
+**When:** Novel tasks that don't fit templates; need dynamic capability configuration.
+
+```python
+agent = await factory.create_from_llm(
+    task_description="Analyze satellite imagery for deforestation patterns",
+    context={"data_format": "GeoTIFF", "region": "Amazon"}
+)
+```
+
+**Behavior:**
+1. Builds a structured prompt from the task description
+2. Calls LLM via `MultiLLMRouter.chat_json()` to generate `AgentConfig`
+3. On LLM failure → falls back to template matching via keyword heuristics
+4. Protected by circuit breaker (5 failures → 30s recovery)
+
+### Mode 3: Split / Reproduction
+
+**When:** Agent's task queue exceeds `split_threshold` (default: 3 pending tasks).
+
+```python
+children = await factory.split_agent(agent_id, num_children=3)
+```
+
+**Behavior:**
+1. Parent enters `SPLITTING` state
+2. Creates N child agents inheriting parent's capabilities (with strength variation)
+3. Distributes parent's task queue evenly among children
+4. Children execute in parallel via `asyncio.gather()`
+5. If ALL children fail → fallback to parent serial execution
+6. Child TTL = parent TTL / 2 (prevents infinite growth)
+7. Respects `max_depth` limit (default: 3)
+
+### Decision Tree
+
+```
+New Task Arrives
+    │
+    ├── Known task type? ──── YES ──► Template Creation (Mode 1)
+    │                                  Fast, predictable
+    │
+    ├── LLM available? ──── YES ──► LLM Generation (Mode 2)
+    │                                Dynamic, adaptive
+    │
+    └── Queue overloaded? ── YES ──► Split / Reproduction (Mode 3)
+                                     Scales horizontally
+```
+
+---
+
+## Message Bus Protocol
+
+### Architecture
+
+The `AgentMessageBus` is an in-memory async queue system. Each agent gets a dedicated `asyncio.Queue` (max 1000 messages).
+
+### Message Format
+
+```python
+@dataclass
+class AgentMessage:
+    id: str           # "msg_{12-char-hex}"
+    sender_id: str    # Source agent ID
+    receiver_id: str  # Target agent ID
+    msg_type: str     # Message type (see below)
+    payload: Dict     # Arbitrary data
+    timestamp: float  # Unix timestamp
+    ack: bool         # Acknowledgement flag
+```
+
+### Message Types
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| `task_assign` | Parent → Child | Assign a task to a child agent |
+| `task_result` | Child → Parent | Report task execution result |
+| `heartbeat` | Any → Any | Liveness check |
+| `status_query` | Any → Any | Request current status |
+| `status_response` | Any → Any | Reply with current status |
+
+### Communication Patterns
+
+1. **Point-to-Point:** `bus.send(msg)` — direct message to one agent
+2. **Broadcast:** `bus.broadcast(sender_id, msg_type, payload)` — to all registered agents
+3. **Request-Reply:** `bus.request(msg, timeout=10.0)` — send and wait for response with timeout
+
+---
+
+## Team Collaboration Strategies
+
+### Strategy 1: PARALLEL (Perplexity-style)
+
+**When:** Need diverse perspectives on the same problem; want to compare model outputs.
+
+```
+Task ──► Agent A (GPT-4) ──┐
+     ──► Agent B (Claude) ──┼──► Synthesize ──► Final Answer
+     ──► Agent C (Gemini) ──┘
+```
+
+- Same task dispatched to N agents, each using a different LLM
+- Results synthesized by coordinator using LLM summarization
+- Best for: open-ended questions, creative tasks, fact verification
+
+### Strategy 2: SPECIALIZED (Task Decomposition)
+
+**When:** Complex task that benefits from role-based division of labor.
+
+```
+Task ──► Coordinator decomposes ──► Researcher (finds data)
+                                 ──► Analyst (processes data)
+                                 ──► Writer (generates report)
+                                          │
+                                          ▼
+                                    Coordinator merges
+```
+
+- Coordinator uses LLM to decompose task into sub-tasks
+- Each sub-task matched to optimal agent template + LLM provider
+- Results aggregated by coordinator
+- Best for: multi-step workflows, reports, data pipelines
+
+### Strategy 3: SWARM (Collective Intelligence)
+
+**When:** Repetitive tasks that benefit from parallel execution and voting.
+
+```
+Task ──► Agent 1 (same type) ──┐
+     ──► Agent 2 (same type) ──┼──► Vote/Merge ──► Result
+     ──► Agent 3 (same type) ──┘
+```
+
+- Multiple agents of the same type process variations of the task
+- Results combined via voting (for discrete answers) or merging (for text)
+- Best for: classification, batch processing, consensus-building
+
+### Strategy Comparison
+
+| Factor | PARALLEL | SPECIALIZED | SWARM |
+|--------|----------|-------------|-------|
+| LLM diversity | Multiple models | Best model per sub-task | Same model |
+| Task type | Same task, different angles | Different sub-tasks | Same task, batch |
+| Cost | High (N x full task) | Medium (optimized routing) | Medium (N x task) |
+| Latency | Max of all agents | Sum of critical path | Max of all agents |
+| Best for | Quality/verification | Complex workflows | Scale/consensus |
+
+---
+
+## Fractal Decomposition
+
+### Algorithm
+
+```
+function execute(task, depth=0):
+    complexity = assess_complexity(task)
+
+    if complexity == ATOMIC or depth >= MAX_DEPTH:
+        return execute_directly(task)
+
+    subtasks = decompose(task, complexity)
+    results = parallel_execute([
+        execute(subtask, depth+1)
+        for subtask in subtasks
+    ])
+
+    return synthesize(results)
+```
+
+### Complexity Levels
+
+| Level | Description | Max Subtasks | Action |
+|-------|-------------|--------------|--------|
+| `ATOMIC` | Indivisible task | 0 | Execute directly |
+| `SIMPLE` | 2-3 steps | 3 | May decompose |
+| `MODERATE` | Needs decomposition | 4 | Decompose |
+| `COMPLEX` | Multi-layer | 5 | Decompose recursively |
+| `EPIC` | Large-scale collaboration | 6 | Deep decomposition |
+
+### Safety Limits
+
+- **MAX_DEPTH = 4** — Prevents infinite recursion
+- **MAX_SUBTASKS = 6** — Limits branching factor per level
+- **Worst case agents:** 6^4 = 1,296 (bounded by factory MAX_AGENTS = 500)
+
+### Decomposition Methods
+
+1. **LLM-based** (preferred): Sends task to LLM with structured prompt, gets JSON subtask list
+2. **Rule-based** (fallback): Keyword-based splitting (e.g., "and", "then", sentence boundaries)
+
+---
+
+## Agent Manifest & Migration
+
+### Purpose
+
+`AgentManifest` is a serializable deployment package — an agent's complete "soul" that can be transmitted to edge devices for local execution.
+
+### Structure
+
+```json
+{
+    "manifest_id": "uuid",
+    "agent_name": "device_control_phone01",
+    "agent_role": "executor",
+    "system_prompt": "You are a device control agent...",
+    "execution_mode": "react",
+    "tools": [
+        {"name": "click", "description": "Click at coordinates", "parameters": {...}}
+    ],
+    "tasks": [
+        {"id": "abc", "instruction": "Open Settings app", "priority": 5}
+    ],
+    "max_react_turns": 10,
+    "timeout_seconds": 300,
+    "source_device": "server",
+    "target_device": "phone01",
+    "discover_local_tools": true
+}
+```
+
+### Execution Modes
+
+| Mode | Behavior |
+|------|----------|
+| `react` | ReAct loop: Thought → Action → Observation, up to `max_react_turns` |
+| `sequential` | Execute predefined action list in order |
+| `autonomous` | Self-discovers tools on target device, makes independent decisions |
+
+### Migration Flow
+
+```
+Server                          Edge Device
+  │                                │
+  ├── Create AgentManifest ──────►│
+  │   (serialize to JSON)          │
+  │                                ├── Deserialize manifest
+  │                                ├── Discover local MCP tools
+  │                                ├── Execute in LocalAgentRuntime
+  │                                ├── Report results back
+  │◄───────────────────────────────┤
+```
+
+---
+
+## System Integration Layer
+
+### Capability Registry
+
+The `SystemIntegration` singleton maintains a unified registry of all system capabilities across 6 types:
+
+```python
+class CapabilityType(Enum):
+    DEVICE = "device"     # Hardware device actions
+    MCP = "mcp"           # MCP server tools
+    SKILL = "skill"       # Loaded skills
+    NODE = "node"         # Distributed nodes
+    AGENT = "agent"       # Agent capabilities
+    BUILTIN = "builtin"   # Built-in functions
+```
+
+### Capability Discovery & Routing
+
+```
+User Request: "Turn on the living room light"
+    │
+    ├── SystemIntegration.discover_capability("device_control")
+    │       │
+    │       ├── Search DEVICE capabilities → found: smart_hub_001
+    │       ├── Search MCP capabilities → found: home-assistant-mcp
+    │       └── Select highest priority match
+    │
+    └── SystemIntegration.execute("device_control", params)
+            │
+            └── Routes to matched capability handler
+```
+
+### Priority-Based Selection
+
+When multiple capabilities match, selection uses:
+1. **Priority score** (1-10, higher wins)
+2. **Online status** (only online sources considered)
+3. **Type preference** (configurable per request)
+
+---
+
+## Digital Twin Integration
+
+### Coupling Modes
+
+| Mode | Sync | Use Case |
+|------|------|----------|
+| `TIGHT` | Real-time bidirectional | Critical operations, safety-required |
+| `LOOSE` | Periodic snapshot sync | Default for team members |
+| `DECOUPLED` | No sync | Independent simulation |
+| `SHADOW` | Read-only mirror | Monitoring and analytics |
+
+### Integration Points
+
+- **Agent Team:** Each team member auto-creates a digital twin (default: LOOSE)
+- **Deviation Detection:** Twin compares predicted vs actual state, flags anomalies
+- **Predictive Simulation:** Twin runs ahead to predict outcomes before real execution
+
+---
+
+## Production Safeguards
+
+| Safeguard | Value | Purpose |
+|-----------|-------|---------|
+| Max agents | 500 | Prevents resource exhaustion |
+| Max creates/min | 50 | Rate limits agent creation |
+| Queue size/agent | 1,000 | Bounds memory per agent |
+| TTL cleanup interval | 60s | Reclaims expired agents |
+| Child TTL | Parent/2 | Prevents infinite growth |
+| Max depth | 3-4 | Limits recursion |
+| Circuit breaker | 5 failures → 30s cooldown | Protects LLM calls |
+| State persistence | `data/agent_state.json` | Recovery on restart |
+
+---
+
+## Decision Guide
+
+### When to Use Each Component
+
+| Scenario | Component | Strategy |
+|----------|-----------|----------|
+| Simple known task | Agent Factory (Template) | Direct execution |
+| Novel/unique task | Agent Factory (LLM) | Dynamic generation |
+| Overloaded agent | Agent Factory (Split) | Auto-scaling |
+| Need model comparison | Agent Team | PARALLEL |
+| Complex multi-step workflow | Agent Team | SPECIALIZED |
+| Batch processing | Agent Team | SWARM |
+| Deep task decomposition | Fractal Agent | Recursive |
+| Edge/mobile execution | Agent Manifest | Serialized deployment |
+| Cross-system capability lookup | System Integration | Capability registry |
+
+### Scaling Considerations
+
+- **Vertical:** Increase `max_subtasks`, `max_depth` for deeper decomposition
+- **Horizontal:** Use Agent Team SWARM for batch parallelism
+- **Edge:** Use Agent Manifest to offload to devices
+- **Cost:** SPECIALIZED strategy minimizes LLM calls by routing to optimal models
+
+---
+
+## API Reference
+
+### REST Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/agents/` | Create agent (template or LLM) |
+| `GET` | `/api/v1/agents/` | List all agents |
+| `GET` | `/api/v1/agents/{id}` | Get agent details |
+| `POST` | `/api/v1/agents/{id}/execute` | Execute task on agent |
+| `DELETE` | `/api/v1/agents/{id}` | Terminate agent |
+| `POST` | `/api/v1/agents/team` | Create agent team |
+| `POST` | `/api/v1/agents/team/{id}/execute` | Execute team task |
+| `GET` | `/api/v1/agents/factory/templates` | List available templates |
+
+### Python API
+
+```python
+from core.agent_factory import AgentFactory, get_message_bus
+
+# Initialize
+factory = AgentFactory(llm_router=router)
+
+# Mode 1: Template
+agent = factory.create_from_template("coordinator")
+
+# Mode 2: LLM Generation
+agent = await factory.create_from_llm("Analyze sales data for Q4")
+
+# Mode 3: Split
+children = await factory.split_agent(agent.id, num_children=3)
+
+# Execute
+result = await factory.execute_agent_task(agent.id, {"task": "analyze", "data": [...]})
+
+# Message Bus
+bus = get_message_bus()
+bus.register(agent.id)
+await bus.send(AgentMessage(id="msg_001", sender_id="a", receiver_id="b", msg_type="task_assign", payload={}))
+
+# Team
+from core.agent_team import AgentTeam, TeamStrategy
+team = AgentTeam(name="analysis", strategy=TeamStrategy.PARALLEL, factory=factory, llm_router=router)
+result = await team.execute("Compare market trends across regions")
+
+# Fractal
+from core.fractal_agent import FractalExecutor
+executor = FractalExecutor(llm_router=router, agent_factory=factory)
+result = await executor.execute("Build a comprehensive market analysis report")
+
+# Manifest (for edge deployment)
+from core.agent_manifest import AgentManifest
+manifest = AgentManifest.create_device_control_agent(
+    target_device="phone01",
+    instruction="Open Settings and enable Bluetooth"
+)
+json_payload = manifest.to_json()  # Send via WebSocket
+```

--- a/tests/test_agent_system.py
+++ b/tests/test_agent_system.py
@@ -1,0 +1,599 @@
+"""
+Tests for the AI Agent System
+=============================
+
+Covers: AgentFactory, AgentMessageBus, AgentTeam, FractalAgent,
+        AgentManifest, and SystemIntegration.
+"""
+
+import asyncio
+import json
+import time
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ──────────────────────────── Imports ────────────────────────────
+
+from core.agent_factory import (
+    AgentFactory,
+    AgentMessageBus,
+    AgentMessage,
+    AgentRole,
+    AgentState,
+    CreationMode,
+    AgentConfig,
+    AgentCapability,
+    TaskAgent,
+    AGENT_TEMPLATES,
+    get_message_bus,
+)
+from core.agent_manifest import (
+    AgentManifest,
+    ExecutionMode,
+    AgentPriority,
+    ToolDeclaration,
+    TaskItem,
+)
+
+
+# ──────────────────────────── Fixtures ────────────────────────────
+
+
+@pytest.fixture
+def factory():
+    """AgentFactory without LLM router."""
+    f = AgentFactory(llm_router=None)
+    f.agents.clear()
+    f.agent_tree.clear()
+    return f
+
+
+@pytest.fixture
+def mock_llm_router():
+    """Mock LLM router for testing LLM-dependent features."""
+    router = MagicMock()
+    router.chat = AsyncMock(return_value=MagicMock(
+        content='{"analysis": "test result"}',
+        provider="mock",
+    ))
+    router.chat_json = AsyncMock(return_value={
+        "role": "analyst",
+        "name": "Test Analyst",
+        "description": "Analyzes test data",
+        "capabilities": [
+            {"name": "analysis", "description": "Data analysis", "strength": 0.9}
+        ],
+        "system_prompt": "You are a test analyst.",
+        "max_subtasks": 3,
+        "max_depth": 2,
+    })
+    return router
+
+
+@pytest.fixture
+def factory_with_llm(mock_llm_router):
+    """AgentFactory with mock LLM router."""
+    f = AgentFactory(llm_router=mock_llm_router)
+    f.agents.clear()
+    f.agent_tree.clear()
+    return f
+
+
+@pytest.fixture
+def message_bus():
+    """Fresh message bus instance."""
+    return AgentMessageBus()
+
+
+# ============================================================================
+# AgentMessageBus Tests
+# ============================================================================
+
+
+class TestAgentMessageBus:
+    """Tests for the Agent message bus communication system."""
+
+    def test_register_unregister(self, message_bus):
+        message_bus.register("agent_001")
+        assert "agent_001" in message_bus._queues
+        message_bus.unregister("agent_001")
+        assert "agent_001" not in message_bus._queues
+
+    @pytest.mark.asyncio
+    async def test_send_receive(self, message_bus):
+        message_bus.register("sender")
+        message_bus.register("receiver")
+
+        msg = AgentMessage(
+            id="msg_test001",
+            sender_id="sender",
+            receiver_id="receiver",
+            msg_type="task_assign",
+            payload={"task": "analyze data"},
+        )
+        result = await message_bus.send(msg)
+        assert result is True
+
+        received = await message_bus.receive("receiver", timeout=1.0)
+        assert received is not None
+        assert received.id == "msg_test001"
+        assert received.payload == {"task": "analyze data"}
+
+    @pytest.mark.asyncio
+    async def test_send_to_nonexistent_agent(self, message_bus):
+        msg = AgentMessage(
+            id="msg_test002",
+            sender_id="sender",
+            receiver_id="nonexistent",
+            msg_type="heartbeat",
+        )
+        result = await message_bus.send(msg)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout(self, message_bus):
+        message_bus.register("lonely_agent")
+        received = await message_bus.receive("lonely_agent", timeout=0.1)
+        assert received is None
+
+    @pytest.mark.asyncio
+    async def test_broadcast(self, message_bus):
+        message_bus.register("broadcaster")
+        message_bus.register("listener_1")
+        message_bus.register("listener_2")
+
+        await message_bus.broadcast("broadcaster", "heartbeat", {"status": "alive"})
+
+        msg1 = await message_bus.receive("listener_1", timeout=1.0)
+        msg2 = await message_bus.receive("listener_2", timeout=1.0)
+
+        assert msg1 is not None
+        assert msg2 is not None
+        assert msg1.msg_type == "heartbeat"
+        assert msg2.payload == {"status": "alive"}
+
+    @pytest.mark.asyncio
+    async def test_broadcast_excludes_sender(self, message_bus):
+        message_bus.register("broadcaster")
+        message_bus.register("listener")
+
+        await message_bus.broadcast("broadcaster", "heartbeat", {})
+
+        # Sender should NOT receive its own broadcast
+        msg = await message_bus.receive("broadcaster", timeout=0.1)
+        assert msg is None
+
+    @pytest.mark.asyncio
+    async def test_receive_from_unregistered(self, message_bus):
+        received = await message_bus.receive("unregistered_agent", timeout=0.1)
+        assert received is None
+
+
+# ============================================================================
+# AgentFactory - Template Creation Tests
+# ============================================================================
+
+
+class TestAgentFactoryTemplateCreation:
+    """Tests for Mode 1: Template-based agent creation."""
+
+    def test_create_all_templates(self, factory):
+        for template_name in AGENT_TEMPLATES:
+            agent = factory.create_from_template(template_name)
+            assert agent.id.startswith("agent_")
+            assert agent.creation_mode == CreationMode.TEMPLATE
+            assert agent.state == AgentState.IDLE
+            assert agent.depth == 0
+
+    def test_create_with_overrides(self, factory):
+        agent = factory.create_from_template(
+            "coordinator",
+            overrides={"name": "Custom Coordinator"}
+        )
+        assert agent.config.name == "Custom Coordinator"
+
+    def test_create_unknown_template_raises(self, factory):
+        with pytest.raises(ValueError, match="未知模板"):
+            factory.create_from_template("nonexistent_template")
+
+    def test_parent_child_relationship(self, factory):
+        parent = factory.create_from_template("coordinator")
+        child = factory.create_from_template("code_executor", parent_id=parent.id)
+
+        assert child.parent_id == parent.id
+        assert child.depth == 1
+
+    def test_agent_registration(self, factory):
+        agent = factory.create_from_template("coordinator")
+        assert agent.id in factory.agents
+        assert agent.id in factory.message_bus._queues
+
+    def test_agent_to_dict(self, factory):
+        agent = factory.create_from_template("coordinator")
+        d = agent.to_dict()
+        assert d["role"] == "coordinator"
+        assert d["state"] == "idle"
+        assert d["creation_mode"] == "template"
+        assert "metrics" in d
+
+
+# ============================================================================
+# AgentFactory - LLM Generation Tests
+# ============================================================================
+
+
+class TestAgentFactoryLLMGeneration:
+    """Tests for Mode 2: LLM-based agent generation."""
+
+    @pytest.mark.asyncio
+    async def test_create_from_llm(self, factory_with_llm):
+        agent = await factory_with_llm.create_from_llm("Analyze sales data")
+        assert agent.creation_mode == CreationMode.LLM_GENERATED
+        assert agent.config.name == "Test Analyst"
+        assert len(agent.config.capabilities) == 1
+
+    @pytest.mark.asyncio
+    async def test_llm_fallback_to_template(self, factory_with_llm, mock_llm_router):
+        mock_llm_router.chat_json.side_effect = Exception("LLM unavailable")
+
+        agent = await factory_with_llm.create_from_llm("分析数据趋势")
+        # Should fall back to data_analyst template
+        assert agent.creation_mode == CreationMode.TEMPLATE
+
+    @pytest.mark.asyncio
+    async def test_create_from_llm_without_router_raises(self, factory):
+        with pytest.raises(RuntimeError, match="LLM Router 未配置"):
+            await factory.create_from_llm("Some task")
+
+    def test_template_matching_keywords(self, factory):
+        assert factory._match_template("分析数据") == "data_analyst"
+        assert factory._match_template("编程实现") == "code_executor"
+        assert factory._match_template("搜索信息") == "research"
+        assert factory._match_template("控制设备") == "device_controller"
+        assert factory._match_template("制定计划") == "planner"
+        assert factory._match_template("random gibberish") == "coordinator"
+
+
+# ============================================================================
+# AgentFactory - Split Tests
+# ============================================================================
+
+
+class TestAgentFactorySplit:
+    """Tests for Mode 3: Agent splitting / reproduction."""
+
+    @pytest.mark.asyncio
+    async def test_split_agent(self, factory):
+        parent = factory.create_from_template("coordinator")
+        parent.task_queue = [
+            {"task": "task_1"},
+            {"task": "task_2"},
+            {"task": "task_3"},
+            {"task": "task_4"},
+        ]
+
+        children = await factory.split_agent(parent.id, num_children=2)
+
+        assert len(children) == 2
+        assert parent.state == AgentState.WAITING
+        assert len(parent.task_queue) == 0
+        for child in children:
+            assert child.parent_id == parent.id
+            assert child.creation_mode == CreationMode.SPLIT
+            assert child.depth == parent.depth + 1
+
+    @pytest.mark.asyncio
+    async def test_split_respects_max_depth(self, factory):
+        parent = factory.create_from_template("coordinator")
+        parent.depth = parent.config.max_depth  # Already at max
+
+        children = await factory.split_agent(parent.id)
+        assert len(children) == 0
+
+    @pytest.mark.asyncio
+    async def test_split_nonexistent_agent_raises(self, factory):
+        with pytest.raises(ValueError, match="Agent 不存在"):
+            await factory.split_agent("nonexistent_id")
+
+    @pytest.mark.asyncio
+    async def test_child_ttl_halved(self, factory):
+        parent = factory.create_from_template("coordinator")
+        parent.task_queue = [{"task": "a"}, {"task": "b"}]
+        parent_ttl = parent.config.ttl
+
+        children = await factory.split_agent(parent.id, num_children=2)
+        for child in children:
+            assert child.config.ttl == parent_ttl // 2
+
+    @pytest.mark.asyncio
+    async def test_split_distributes_tasks(self, factory):
+        parent = factory.create_from_template("coordinator")
+        parent.task_queue = [{"task": f"task_{i}"} for i in range(6)]
+
+        children = await factory.split_agent(parent.id, num_children=3)
+        total_tasks = sum(len(c.task_queue) for c in children)
+        assert total_tasks == 6
+
+    @pytest.mark.asyncio
+    async def test_split_updates_metrics(self, factory):
+        parent = factory.create_from_template("coordinator")
+        parent.task_queue = [{"task": "a"}, {"task": "b"}]
+
+        await factory.split_agent(parent.id, num_children=2)
+        assert parent.metrics["splits"] == 1
+
+
+# ============================================================================
+# Agent Execution Tests
+# ============================================================================
+
+
+class TestAgentExecution:
+    """Tests for agent task execution."""
+
+    @pytest.mark.asyncio
+    async def test_execute_without_llm(self, factory):
+        agent = factory.create_from_template("coordinator")
+        result = await factory.execute_agent_task(agent.id, {"task": "test"})
+
+        assert result is not None
+        assert agent.metrics["tasks_completed"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_llm(self, factory_with_llm):
+        agent = factory_with_llm.create_from_template("data_analyst")
+        result = await factory_with_llm.execute_agent_task(
+            agent.id, {"task": "analyze", "data": [1, 2, 3]}
+        )
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_execute_nonexistent_agent_raises(self, factory):
+        with pytest.raises(ValueError, match="Agent 不存在"):
+            await factory.execute_agent_task("nonexistent", {"task": "test"})
+
+
+# ============================================================================
+# AgentManifest Tests
+# ============================================================================
+
+
+class TestAgentManifest:
+    """Tests for the agent manifest serialization/deserialization."""
+
+    def test_create_manifest(self):
+        manifest = AgentManifest(
+            agent_name="test_agent",
+            agent_role="executor",
+            system_prompt="You are a test agent.",
+        )
+        assert manifest.agent_name == "test_agent"
+        assert manifest.execution_mode == "react"
+        assert manifest.timeout_seconds == 300
+
+    def test_serialize_deserialize(self):
+        original = AgentManifest(
+            agent_name="roundtrip_test",
+            agent_role="analyst",
+            system_prompt="Analyze data.",
+            tools=[ToolDeclaration("search", "Search the web").to_dict()],
+            tasks=[TaskItem(instruction="Find sales data").to_dict()],
+        )
+
+        json_str = original.to_json()
+        restored = AgentManifest.from_json(json_str)
+
+        assert restored.agent_name == "roundtrip_test"
+        assert restored.agent_role == "analyst"
+        assert len(restored.tools) == 1
+        assert len(restored.tasks) == 1
+
+    def test_checksum_consistency(self):
+        manifest = AgentManifest(agent_name="checksum_test")
+        c1 = manifest.checksum()
+        c2 = manifest.checksum()
+        assert c1 == c2
+        assert len(c1) == 16
+
+    def test_checksum_changes_on_modification(self):
+        m1 = AgentManifest(agent_name="original")
+        m2 = AgentManifest(agent_name="modified")
+        assert m1.checksum() != m2.checksum()
+
+    def test_device_control_factory(self):
+        manifest = AgentManifest.create_device_control_agent(
+            target_device="phone01",
+            instruction="Open Settings",
+        )
+        assert manifest.target_device == "phone01"
+        assert manifest.source_device == "server"
+        assert manifest.execution_mode == ExecutionMode.REACT.value
+        assert len(manifest.tools) == 7  # 7 default tools
+        assert len(manifest.tasks) == 1
+
+    def test_multi_step_factory(self):
+        steps = [
+            {"instruction": "Step 1", "action": "click", "params": {"x": 100}},
+            {"instruction": "Step 2", "action": "type_text", "params": {"text": "hi"}},
+        ]
+        manifest = AgentManifest.create_multi_step_agent(
+            agent_name="multi_step",
+            steps=steps,
+        )
+        assert manifest.execution_mode == ExecutionMode.SEQUENTIAL.value
+        assert len(manifest.tasks) == 2
+
+    def test_to_dict_roundtrip(self):
+        original = AgentManifest(
+            agent_name="dict_test",
+            priority=AgentPriority.HIGH.value,
+            ttl_seconds=7200,
+        )
+        d = original.to_dict()
+        restored = AgentManifest.from_dict(d)
+        assert restored.agent_name == "dict_test"
+        assert restored.priority == "high"
+        assert restored.ttl_seconds == 7200
+
+
+# ============================================================================
+# Data Model Tests
+# ============================================================================
+
+
+class TestDataModels:
+    """Tests for agent data models and enums."""
+
+    def test_agent_roles(self):
+        assert len(AgentRole) == 7
+        assert AgentRole.COORDINATOR.value == "coordinator"
+
+    def test_agent_states(self):
+        assert len(AgentState) == 7
+        assert AgentState.IDLE.value == "idle"
+
+    def test_creation_modes(self):
+        assert len(CreationMode) == 3
+        assert CreationMode.TEMPLATE.value == "template"
+        assert CreationMode.LLM_GENERATED.value == "llm_generated"
+        assert CreationMode.SPLIT.value == "split"
+
+    def test_agent_config_defaults(self):
+        config = AgentConfig(
+            role=AgentRole.EXECUTOR,
+            name="test",
+            description="test",
+            capabilities=[],
+            system_prompt="test",
+        )
+        assert config.max_subtasks == 5
+        assert config.max_depth == 3
+        assert config.split_threshold == 3
+        assert config.ttl == 3600
+
+    def test_agent_capability(self):
+        cap = AgentCapability("test_cap", "A test capability", strength=0.75)
+        assert cap.name == "test_cap"
+        assert cap.strength == 0.75
+
+    def test_execution_modes(self):
+        assert ExecutionMode.REACT.value == "react"
+        assert ExecutionMode.SEQUENTIAL.value == "sequential"
+        assert ExecutionMode.AUTONOMOUS.value == "autonomous"
+
+
+# ============================================================================
+# Fractal Agent Tests
+# ============================================================================
+
+
+class TestFractalAgent:
+    """Tests for the fractal agent decomposition system."""
+
+    def test_import_fractal_modules(self):
+        from core.fractal_agent import (
+            FractalAgent,
+            FractalTask,
+            FractalResult,
+            Complexity,
+        )
+        assert Complexity.ATOMIC.value == "atomic"
+        assert Complexity.EPIC.value == "epic"
+
+    def test_fractal_task_creation(self):
+        from core.fractal_agent import FractalTask, Complexity
+        task = FractalTask(
+            id="task_001",
+            description="Analyze market data",
+            complexity=Complexity.MODERATE,
+        )
+        assert task.id == "task_001"
+        assert task.depth == 0
+        assert task.parent_task_id is None
+        assert task.subtask_ids == []
+
+    def test_fractal_result_creation(self):
+        from core.fractal_agent import FractalResult
+        result = FractalResult(
+            task_id="task_001",
+            success=True,
+            output="Analysis complete",
+            depth=0,
+        )
+        assert result.success is True
+        assert result.subtask_results == []
+        assert result.decomposition_used is False
+
+    def test_fractal_agent_limits(self):
+        from core.fractal_agent import FractalAgent
+        assert FractalAgent.MAX_DEPTH == 4
+        assert FractalAgent.MAX_SUBTASKS == 6
+
+
+# ============================================================================
+# System Integration Tests
+# ============================================================================
+
+
+class TestSystemIntegration:
+    """Tests for the system integration capability registry."""
+
+    def test_import_system_integration(self):
+        from core.system_integration import (
+            SystemIntegration,
+            CapabilityType,
+            Capability,
+        )
+        assert CapabilityType.DEVICE.value == "device"
+        assert CapabilityType.MCP.value == "mcp"
+        assert CapabilityType.AGENT.value == "agent"
+
+    def test_capability_to_dict(self):
+        from core.system_integration import Capability, CapabilityType
+        cap = Capability(
+            id="cap_001",
+            name="device_control",
+            type=CapabilityType.DEVICE,
+            description="Control IoT devices",
+            source="smart_hub_001",
+            priority=8,
+        )
+        d = cap.to_dict()
+        assert d["id"] == "cap_001"
+        assert d["type"] == "device"
+        assert d["priority"] == 8
+        assert d["enabled"] is True
+
+
+# ============================================================================
+# Agent Team Tests
+# ============================================================================
+
+
+class TestAgentTeam:
+    """Tests for the agent team collaboration system."""
+
+    def test_import_team_modules(self):
+        from core.agent_team import (
+            AgentTeam,
+            TeamStrategy,
+            TeamStatus,
+            TeamMember,
+        )
+        assert TeamStrategy.PARALLEL.value == "parallel"
+        assert TeamStrategy.SPECIALIZED.value == "specialized"
+        assert TeamStrategy.SWARM.value == "swarm"
+
+    def test_team_member_to_dict(self):
+        from core.agent_team import TeamMember
+        member = TeamMember(
+            agent_id="agent_001",
+            agent_name="Analyst",
+            provider="openai",
+            model="gpt-4",
+            role_in_team="data_analysis",
+        )
+        d = member.to_dict()
+        assert d["agent_id"] == "agent_001"
+        assert d["provider"] == "openai"
+        assert d["model"] == "gpt-4"


### PR DESCRIPTION
- Add comprehensive AI Agent System Design document covering architecture,
  lifecycle, creation modes, message bus, team strategies, fractal
  decomposition, manifest migration, and production safeguards
- Add 47 unit tests for AgentFactory, AgentMessageBus, AgentManifest,
  FractalAgent, SystemIntegration, and AgentTeam
- Add per-task execution timeout (300s) with asyncio.wait_for wrapping
- Add parallel child execution timeout (600s) with error state handling
- Refactor _run_agent to extract _execute_single_task for timeout support

https://claude.ai/code/session_016WuEzNYejeGef5ub8ZuraL