### PR TITLE
feat(perception): desktop camera/mic capture → native multimodal to the model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -231,6 +231,13 @@ API_HOST=0.0.0.0
 API_PORT=9000                           # Same as PORT — all services run in the same process on port 9000
 WEB_UI_PORT=8085                        # Unified Dashboard port (Galaxy unified launcher)
 
+# --- Desktop Perception (摄像头/麦克风/屏幕 连续感知, 默认关闭/隐私优先) ---
+# 开启后 Electron 壳会用 getUserMedia 周期采集摄像头(+麦克风)帧, POST 到
+# /api/perception/desktop/* ; 模型在下一次普通请求时按 TTL 取用(原生看到画面)。
+GALAXY_DESKTOP_PERCEPTION=0                  # 1/true 启用桌面摄像头+麦克风采集
+GALAXY_DESKTOP_PERCEPTION_INTERVAL_MS=2000   # 采集间隔(毫秒)
+GALAXY_DESKTOP_PERCEPTION_TTL=10             # 后端帧新鲜度 TTL(秒); 超时不注入
+
 # CORS allowed origins (comma-separated)
 # Default: http://localhost:3000,http://localhost:8085,http://localhost:9000
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8085,http://localhost:9000

--- a/core/api_routes.py
+++ b/core/api_routes.py
@@ -300,6 +300,7 @@ def create_api_routes(service_manager=None, config=None) -> APIRouter:
     from core.routes import system, devices, nodes, vision, tasks, command as cmd_routes
     from core.routes import chat, ai, monitoring, relay, hybrid, vault, cost, channels, federation
     from core.routes import compat, twin, sessions, config as config_route
+    from core.routes import perception as perception_routes
     # Batch PR-4: dedicated health and diagnostics domain modules
     from core.routes import health as health_routes
     from core.routes import diagnostics as diagnostics_routes
@@ -346,6 +347,7 @@ def create_api_routes(service_manager=None, config=None) -> APIRouter:
     # Exempt routes: no auth required (health, docs, observability, device registration)
     router.include_router(devices.create_router(service_manager=service_manager, config=config))
     router.include_router(vision.create_router(service_manager=service_manager, config=config))
+    router.include_router(perception_routes.create_router(service_manager=service_manager, config=config))
     router.include_router(chat.create_router(service_manager=service_manager, config=config))
     router.include_router(ai.create_router(service_manager=service_manager, config=config))
     router.include_router(monitoring.create_router(service_manager=service_manager, config=config))

--- a/core/audio_pipeline.py
+++ b/core/audio_pipeline.py
@@ -1,0 +1,181 @@
+"""
+core/audio_pipeline.py
+======================
+原生音频理解管道 —— 把麦克风音频「原生」送给具备音频能力的模型。
+
+设计与 ``core/vision_pipeline.py`` 对齐：统一路由的 chat() 只收文本 messages、
+不携带原生媒体 content block；图像是经各自的 provider 专用调用（VisionPipeline）
+原生送出的。音频此前**完全没有**原生通路。本模块补上：
+
+- Gemini：``contents[].parts[].inline_data{mime_type,data}`` —— 与图像完全相同的
+  inline_data 结构，原生支持音频字节。
+- OpenAI 兼容（gpt-4o-audio 等）：``content:[{"type":"input_audio","input_audio":
+  {"data","format"}}, {"type":"text"}]`` —— 原生音频 content block。
+
+按已配置的 API Key 选择 provider；都没配置则优雅降级返回未配置错误。
+payload 构造抽成纯函数（``build_gemini_payload`` / ``build_openai_audio_payload``）
+以便单测。任何网络/解析失败都返回结构化错误，绝不抛出影响主流程。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Galaxy.AudioPipeline")
+
+
+# ── 纯函数：原生音频 payload 构造（可单测，不依赖网络）────────────────────────
+
+def _openai_audio_format(mime: str) -> str:
+    """从 mime 推断 OpenAI input_audio 的 format 字段。"""
+    m = (mime or "").lower()
+    if "wav" in m:
+        return "wav"
+    if "mp3" in m or "mpeg" in m:
+        return "mp3"
+    if "webm" in m:
+        return "webm"
+    if "ogg" in m:
+        return "ogg"
+    if "m4a" in m or "mp4" in m or "aac" in m:
+        return "m4a"
+    return "wav"
+
+
+def build_gemini_payload(audio_base64: str, mime: str, prompt: str) -> Dict[str, Any]:
+    """Gemini generateContent 原生音频 payload（inline_data，与图像同构）。"""
+    return {
+        "contents": [
+            {
+                "parts": [
+                    {"inline_data": {"mime_type": mime or "audio/webm", "data": audio_base64}},
+                    {"text": prompt},
+                ]
+            }
+        ],
+        "generationConfig": {"temperature": 0.2, "maxOutputTokens": 2048},
+    }
+
+
+def build_openai_audio_payload(audio_base64: str, mime: str, prompt: str, model: str) -> Dict[str, Any]:
+    """OpenAI 兼容 chat/completions 原生音频 payload（input_audio content block）。"""
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": audio_base64, "format": _openai_audio_format(mime)},
+                    },
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+        "max_tokens": 2048,
+        "temperature": 0.2,
+    }
+
+
+_DEFAULT_PROMPT = "请听这段音频并简要描述/转写其内容（说话人在说什么、关键意图）。"
+
+
+class AudioPipeline:
+    """原生音频理解：把音频字节送给音频能力模型，返回文本理解/转写。"""
+
+    def __init__(self, config: Optional[Dict] = None):
+        self.config = config or {}
+        # Gemini（与 VisionPipeline 同源 key）
+        self.gemini_api_key = self.config.get(
+            "gemini_api_key", os.getenv("GEMINI_API_KEY", os.getenv("GOOGLE_API_KEY", ""))
+        )
+        self.gemini_model = self.config.get(
+            "gemini_audio_model", os.getenv("GEMINI_AUDIO_MODEL", "gemini-2.0-flash")
+        )
+        # OpenAI 兼容音频模型
+        self.openai_api_key = self.config.get("openai_api_key", os.getenv("OPENAI_API_KEY", ""))
+        self.openai_api_base = self.config.get(
+            "openai_api_base", os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1")
+        )
+        self.openai_audio_model = self.config.get(
+            "openai_audio_model", os.getenv("OPENAI_AUDIO_MODEL", "gpt-4o-audio-preview")
+        )
+        self._client = None
+
+    def available(self) -> bool:
+        return bool(self.gemini_api_key or self.openai_api_key)
+
+    async def _get_client(self):
+        import httpx
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=60.0)
+        return self._client
+
+    async def understand(
+        self,
+        audio_base64: str,
+        *,
+        mime: str = "audio/webm",
+        prompt: str = "",
+    ) -> Dict[str, Any]:
+        """原生理解一段音频，返回 ``{success, text, engine, error?}``。"""
+        if not audio_base64:
+            return {"success": False, "error": "no_audio", "text": ""}
+        prompt = prompt or _DEFAULT_PROMPT
+
+        # 优先 Gemini（inline_data 原生音频），再 OpenAI input_audio
+        if self.gemini_api_key:
+            out = await self._call_gemini(audio_base64, mime, prompt)
+            if out is not None:
+                return {"success": True, "text": out, "engine": "gemini"}
+        if self.openai_api_key:
+            out = await self._call_openai(audio_base64, mime, prompt)
+            if out is not None:
+                return {"success": True, "text": out, "engine": "openai"}
+        return {"success": False, "error": "no_audio_capable_provider_configured", "text": ""}
+
+    async def _call_gemini(self, audio_base64: str, mime: str, prompt: str) -> Optional[str]:
+        try:
+            client = await self._get_client()
+            url = (
+                f"https://generativelanguage.googleapis.com/v1beta/models/"
+                f"{self.gemini_model}:generateContent?key={self.gemini_api_key}"
+            )
+            payload = build_gemini_payload(audio_base64, mime, prompt)
+            resp = await client.post(url, headers={"Content-Type": "application/json"}, json=payload, timeout=60.0)
+            resp.raise_for_status()
+            data = resp.json()
+            return data["candidates"][0]["content"]["parts"][0]["text"]
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Gemini 原生音频调用失败: %s", e)
+            return None
+
+    async def _call_openai(self, audio_base64: str, mime: str, prompt: str) -> Optional[str]:
+        try:
+            client = await self._get_client()
+            payload = build_openai_audio_payload(audio_base64, mime, prompt, self.openai_audio_model)
+            resp = await client.post(
+                f"{self.openai_api_base}/chat/completions",
+                headers={"Authorization": f"Bearer {self.openai_api_key}", "Content-Type": "application/json"},
+                json=payload,
+                timeout=60.0,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data["choices"][0]["message"]["content"]
+        except Exception as e:  # noqa: BLE001
+            logger.warning("OpenAI 原生音频调用失败: %s", e)
+            return None
+
+
+_pipeline: Optional[AudioPipeline] = None
+
+
+def get_audio_pipeline() -> AudioPipeline:
+    global _pipeline
+    if _pipeline is None:
+        _pipeline = AudioPipeline()
+    return _pipeline

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -3912,6 +3912,24 @@ class OpenClawd:
             "",
         )
 
+        # ── Desktop ambient perception injection ─────────────────────────────
+        # 电脑端 Electron 壳持续上传摄像头/屏幕/麦克风帧到 DesktopPerceptionStore。
+        # 若本次请求自身不带图像、且存储里有「新鲜」帧（TTL 内），则把它作为原生
+        # 多模态上下文注入——这样模型在普通对话时也能「看到」桌面摄像头/屏幕。
+        # 显式上传图像的请求不受影响；任何异常都静默跳过，绝不影响主流程。
+        try:
+            _has_req_images = bool(getattr(multimodal_context, "images", None)) if multimodal_context else False
+            if not _has_req_images:
+                from core.perception.desktop_perception_store import get_desktop_perception_store
+                _injected_ctx = get_desktop_perception_store().build_multimodal_context(
+                    existing=multimodal_context
+                )
+                if _injected_ctx is not None:
+                    multimodal_context = _injected_ctx
+                    logger.debug("Injected fresh desktop perception frame into request context")
+        except Exception as _dp_err:  # noqa: BLE001 — 注入失败不影响请求
+            logger.debug("desktop perception injection skipped: %s", _dp_err)
+
         # ── Multimodal Perception Bus (PR 1) ─────────────────────────────────
         # Run MultimodalBus.ingest() for every request (text-only requests
         # produce an empty fusion_summary and leave the message unchanged).

--- a/core/perception/desktop_perception_store.py
+++ b/core/perception/desktop_perception_store.py
@@ -1,0 +1,177 @@
+"""
+core/perception/desktop_perception_store.py
+============================================
+桌面端连续感知的「最新帧」存储（隐蔽上下文来源）。
+
+电脑端 Electron 壳通过 getUserMedia 持续采集摄像头/麦克风/屏幕，并以
+base64 帧 POST 到网关 /api/perception/desktop/*。本模块是这些帧的进程内
+最新值存储（单例），带 TTL 新鲜度判定：
+
+- 当一次正常请求进入 OpenClawd.process() 且本身不带图像时，若存在「新鲜」
+  的桌面帧，则把它作为原生多模态上下文注入——于是模型「真的看到了摄像头」。
+- 不新鲜（超过 TTL）的帧不会被注入，避免把过期画面喂给模型。
+
+设计原则：轻量、线程安全（简单锁）、永不抛出影响主流程；不持久化、不落盘。
+默认 TTL 10s；GALAXY_DESKTOP_PERCEPTION_TTL 可调。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Galaxy.DesktopPerceptionStore")
+
+
+def _default_ttl() -> float:
+    try:
+        return max(1.0, float(os.getenv("GALAXY_DESKTOP_PERCEPTION_TTL", "10")))
+    except (ValueError, TypeError):
+        return 10.0
+
+
+class DesktopPerceptionStore:
+    """进程内单例：保存桌面端最近一次的摄像头帧 / 屏幕帧 / 音频片段。"""
+
+    _instance: Optional["DesktopPerceptionStore"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.ttl_sec = _default_ttl()
+        # image (camera or screen)
+        self._image_b64: Optional[str] = None
+        self._image_mime: str = "image/jpeg"
+        self._image_source: str = "desktop_camera"
+        self._image_ts: float = 0.0
+        self._screen: Optional[Dict[str, Any]] = None
+        # audio (microphone)
+        self._audio_b64: Optional[str] = None
+        self._audio_mime: str = "audio/webm"
+        self._audio_ts: float = 0.0
+        # counters (diagnostics)
+        self._frames_received: int = 0
+        self._audio_received: int = 0
+
+    @classmethod
+    def get_instance(cls) -> "DesktopPerceptionStore":
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    # ── 写入（由 /api/perception/desktop/* 路由调用）────────────────────────
+
+    def update_frame(
+        self,
+        image_b64: str,
+        *,
+        mime: str = "image/jpeg",
+        source: str = "desktop_camera",
+        screen: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not image_b64:
+            return
+        with self._lock:
+            self._image_b64 = image_b64
+            self._image_mime = mime or "image/jpeg"
+            self._image_source = source or "desktop_camera"
+            self._screen = screen
+            self._image_ts = time.time()
+            self._frames_received += 1
+
+    def update_audio(self, audio_b64: str, *, mime: str = "audio/webm") -> None:
+        if not audio_b64:
+            return
+        with self._lock:
+            self._audio_b64 = audio_b64
+            self._audio_mime = mime or "audio/webm"
+            self._audio_ts = time.time()
+            self._audio_received += 1
+
+    # ── 读取 / 新鲜度 ───────────────────────────────────────────────────────
+
+    def _fresh(self, ts: float) -> bool:
+        return ts > 0.0 and (time.time() - ts) <= self.ttl_sec
+
+    def has_fresh_frame(self) -> bool:
+        with self._lock:
+            return bool(self._image_b64) and self._fresh(self._image_ts)
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            now = time.time()
+            return {
+                "ttl_sec": self.ttl_sec,
+                "frames_received": self._frames_received,
+                "audio_received": self._audio_received,
+                "image_fresh": self._fresh(self._image_ts),
+                "image_age_sec": round(now - self._image_ts, 2) if self._image_ts else None,
+                "image_source": self._image_source if self._image_b64 else None,
+                "audio_fresh": self._fresh(self._audio_ts),
+                "audio_age_sec": round(now - self._audio_ts, 2) if self._audio_ts else None,
+            }
+
+    def build_multimodal_context(self, existing: Optional[Any] = None) -> Optional[Any]:
+        """用最新「新鲜」帧/音频构建（或合并进）MultiModalContext。
+
+        - 仅当确有新鲜帧/音频时返回非 None。
+        - 若 ``existing`` 已带图像，则不覆盖（尊重显式请求），返回 None。
+        - 任何异常都返回 None（绝不影响主请求流程）。
+        """
+        try:
+            from core.schemas.multimodal import (
+                MultiModalContext, MultiModalImage, MultiModalAudio,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("multimodal schema unavailable: %s", exc)
+            return None
+
+        with self._lock:
+            has_img = bool(self._image_b64) and self._fresh(self._image_ts)
+            has_aud = bool(self._audio_b64) and self._fresh(self._audio_ts)
+            if not has_img and not has_aud:
+                return None
+            img_b64, img_mime, img_src, screen = (
+                self._image_b64, self._image_mime, self._image_source, self._screen,
+            )
+            aud_b64, aud_mime = self._audio_b64, self._audio_mime
+
+        # 若调用方已带图像，尊重之，不注入（避免覆盖显式上传）
+        existing_images = list(getattr(existing, "images", []) or []) if existing is not None else []
+        if existing_images:
+            return None
+
+        images = []
+        if has_img:
+            images.append(MultiModalImage(mime=img_mime, data=img_b64, source=img_src))
+        audio = []
+        if has_aud:
+            audio.append(MultiModalAudio(mime=aud_mime, data=aud_b64, source="desktop_microphone"))
+
+        metadata = {"injected_by": "desktop_perception_store", "ambient": True}
+        if existing is not None:
+            try:
+                existing_audio = list(getattr(existing, "audio", []) or [])
+                audio = existing_audio + audio
+                if getattr(existing, "metadata", None):
+                    metadata = {**existing.metadata, **metadata}
+                if screen is None:
+                    screen = getattr(existing, "screen", None)
+            except Exception:  # noqa: BLE001
+                pass
+
+        return MultiModalContext(
+            images=images,
+            audio=audio,
+            screen=screen,
+            metadata=metadata,
+        )
+
+
+def get_desktop_perception_store() -> DesktopPerceptionStore:
+    return DesktopPerceptionStore.get_instance()

--- a/core/routes/perception.py
+++ b/core/routes/perception.py
@@ -45,6 +45,12 @@ class DesktopAnalyze(BaseModel):
     session_id: str = ""
 
 
+class DesktopListen(BaseModel):
+    audio_base64: str = ""
+    mime: str = "audio/webm"
+    prompt: str = ""
+
+
 def create_router(service_manager=None, config=None) -> APIRouter:
     """Create desktop perception ingest routes."""
     router = APIRouter(prefix="/api/perception/desktop", tags=["perception"])
@@ -136,6 +142,36 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             }
         except Exception as exc:  # noqa: BLE001
             logger.warning("desktop analyze failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    @router.post("/listen")
+    async def listen_now(req: DesktopListen):
+        """「现在听一下」：把当前音频（或存储里的最新音频）原生送音频能力模型理解。
+
+        复用 AudioPipeline 的原生音频通路（Gemini inline_data / OpenAI input_audio），
+        返回模型对这段音频的理解/转写文本。需配置 GEMINI/GOOGLE 或 OPENAI key。
+        """
+        audio_b64 = req.audio_base64
+        mime = req.mime or "audio/webm"
+        if not audio_b64:
+            try:
+                from core.perception.desktop_perception_store import get_desktop_perception_store
+                _store = get_desktop_perception_store()
+                with _store._lock:  # noqa: SLF001 — 读快照
+                    audio_b64 = _store._audio_b64 or ""
+                    mime = _store._audio_mime
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("store audio snapshot failed: %s", exc)
+        if not audio_b64:
+            return {"success": False, "error": "no_audio_available"}
+        try:
+            from core.audio_pipeline import get_audio_pipeline
+            result = await get_audio_pipeline().understand(
+                audio_b64, mime=mime, prompt=req.prompt or "",
+            )
+            return result
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("desktop listen failed: %s", exc)
             return {"success": False, "error": str(exc)}
 
     return router

--- a/core/routes/perception.py
+++ b/core/routes/perception.py
@@ -1,0 +1,141 @@
+"""
+core/routes/perception.py
+=========================
+桌面端连续感知接收路由（摄像头 / 麦克风 / 屏幕）。
+
+电脑端 Electron 壳用 getUserMedia 采集帧后 POST 到这里：
+- POST /api/perception/desktop/frame    —— 存最新摄像头/屏幕帧（隐蔽上下文）
+- POST /api/perception/desktop/audio    —— 存最新麦克风音频片段
+- POST /api/perception/desktop/analyze  —— 「现在看一下」：把帧原生送模型分析
+- GET  /api/perception/desktop/status   —— 存储/新鲜度诊断
+
+frame/audio 只更新进程内 DesktopPerceptionStore，由 OpenClawd.process() 在下一次
+真实请求时按 TTL 取用、作为原生多模态上下文注入（模型真正「看到」摄像头）。
+analyze 则复用 Android vision 已验证的 runtime-shell 多模态路径，立即出分析。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("Galaxy.Routes.Perception")
+
+
+class DesktopFrame(BaseModel):
+    image_base64: str = Field(description="Base64 编码的图像帧（建议 JPEG，≤1MB）")
+    mime: str = Field(default="image/jpeg")
+    source: str = Field(default="desktop_camera", description="desktop_camera / desktop_screen")
+    screen: Optional[Dict[str, Any]] = None
+
+
+class DesktopAudio(BaseModel):
+    audio_base64: str = Field(description="Base64 编码的音频片段")
+    mime: str = Field(default="audio/webm")
+
+
+class DesktopAnalyze(BaseModel):
+    image_base64: str = ""
+    mime: str = "image/jpeg"
+    prompt: str = ""
+    source: str = "desktop_camera"
+    session_id: str = ""
+
+
+def create_router(service_manager=None, config=None) -> APIRouter:
+    """Create desktop perception ingest routes."""
+    router = APIRouter(prefix="/api/perception/desktop", tags=["perception"])
+
+    @router.post("/frame")
+    async def ingest_frame(frame: DesktopFrame):
+        """接收最新摄像头/屏幕帧 → 存入 DesktopPerceptionStore（不立即调模型）。"""
+        try:
+            from core.perception.desktop_perception_store import get_desktop_perception_store
+            get_desktop_perception_store().update_frame(
+                frame.image_base64, mime=frame.mime, source=frame.source, screen=frame.screen,
+            )
+            return {"success": True, "stored": "frame"}
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("frame ingest failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    @router.post("/audio")
+    async def ingest_audio(audio: DesktopAudio):
+        """接收最新麦克风音频片段 → 存入 DesktopPerceptionStore。"""
+        try:
+            from core.perception.desktop_perception_store import get_desktop_perception_store
+            get_desktop_perception_store().update_audio(audio.audio_base64, mime=audio.mime)
+            return {"success": True, "stored": "audio"}
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("audio ingest failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    @router.get("/status")
+    async def perception_status():
+        """返回桌面感知存储的新鲜度/计数诊断。"""
+        try:
+            from core.perception.desktop_perception_store import get_desktop_perception_store
+            return {"success": True, "store": get_desktop_perception_store().status()}
+        except Exception as exc:  # noqa: BLE001
+            return {"success": False, "error": str(exc)}
+
+    @router.post("/analyze")
+    async def analyze_now(req: DesktopAnalyze):
+        """「现在看一下」：把当前帧（或存储里的最新帧）原生送模型分析。
+
+        复用 Android vision 已验证的 runtime-shell 多模态路径：构建
+        MultiModalContext → DesktopPresenceRuntime.handle_request → 原生送模型。
+        """
+        image_b64 = req.image_base64
+        mime = req.mime or "image/jpeg"
+        source = req.source or "desktop_camera"
+        # 未带图则取存储里的最新帧
+        if not image_b64:
+            try:
+                from core.perception.desktop_perception_store import get_desktop_perception_store
+                _store = get_desktop_perception_store()
+                with _store._lock:  # noqa: SLF001 — 读快照
+                    image_b64 = _store._image_b64 or ""
+                    mime = _store._image_mime
+                    source = _store._image_source
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("store snapshot failed: %s", exc)
+        if not image_b64:
+            return {"success": False, "error": "no_frame_available"}
+
+        try:
+            from core.desktop_presence_runtime import get_desktop_presence_runtime
+            from core.schemas.multimodal import MultiModalContext, MultiModalImage
+
+            mm_context = MultiModalContext(
+                images=[MultiModalImage(mime=mime, data=image_b64, source=source)],
+                screen={"source": "desktop"},
+                metadata={"source": "desktop_perception_analyze"},
+            )
+            runtime = get_desktop_presence_runtime()
+            prompt = req.prompt or "描述一下你现在通过桌面摄像头/屏幕看到的内容。"
+            session_id = req.session_id or "desktop_perception"
+            result = await runtime.handle_request(
+                message=prompt,
+                source="desktop_vision",
+                device_id=None,
+                session_id=session_id,
+                user_id="desktop",
+                multimodal_context=mm_context,
+                entry_mode="local",
+            )
+            return {
+                "success": bool(result.get("success", True)),
+                "runtime_session_id": result.get("runtime_session_id"),
+                "response": result.get("response", ""),
+                "multimodal_route": result.get("multimodal_route_decision", {}),
+                "source": "runtime_shell_multimodal",
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("desktop analyze failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    return router

--- a/electron/main.js
+++ b/electron/main.js
@@ -40,6 +40,13 @@ const GATEWAY_PORT = parseInt(process.env.GALAXY_GATEWAY_PORT || process.env.POR
 const GATEWAY_BASE = `http://localhost:${GATEWAY_PORT}`;
 let ipcHttpServer = null;
 
+// 桌面连续感知（摄像头/麦克风/屏幕）配置 —— 默认关闭（隐私优先）。
+// 仅当 GALAXY_DESKTOP_PERCEPTION=1 时才在渲染层启动采集。
+const PERCEPTION_ENABLED = ['1', 'true', 'yes', 'on'].includes(
+    String(process.env.GALAXY_DESKTOP_PERCEPTION || '').trim().toLowerCase()
+);
+const PERCEPTION_INTERVAL_MS = parseInt(process.env.GALAXY_DESKTOP_PERCEPTION_INTERVAL_MS || '2000', 10);
+
 // ── Two-window architecture ──
 // mainWindow  : Three-State Full-Screen AI (always on, never hidden)
 // panelWindow : AI Control Panel — Colorless Lens (toggled by F12)
@@ -98,6 +105,21 @@ app.whenReady().then(() => {
     // 未取得单实例锁的后来者：什么都不做，等待 app.quit() 收尾，
     // 避免它创建窗口或去争抢已被占用的 IPC 端口。
     if (!gotSingleInstanceLock) return;
+
+    // 媒体权限：Electron 默认拒绝 getUserMedia。仅当桌面感知启用时放行
+    // 摄像头/麦克风/屏幕权限；否则一律拒绝（隐私优先）。
+    try {
+        const { session } = require('electron');
+        session.defaultSession.setPermissionRequestHandler((wc, permission, callback) => {
+            const mediaPerms = ['media', 'audioCapture', 'videoCapture', 'display-capture'];
+            if (PERCEPTION_ENABLED && mediaPerms.includes(permission)) {
+                return callback(true);
+            }
+            return callback(false);
+        });
+    } catch (e) {
+        console.warn('[Main] 设置媒体权限处理器失败:', e && e.message);
+    }
 
     createWindow();
 
@@ -311,6 +333,48 @@ ipcMain.handle('get-window-size', () => {
 ipcMain.on('set-ignore-mouse', (event, ignore) => {
     if (mainWindow) {
         mainWindow.setIgnoreMouseEvents(ignore, { forward: true });
+    }
+});
+
+// ═══════════════════════════════════════════
+// Desktop Perception — 摄像头/麦克风/屏幕连续感知
+// ═══════════════════════════════════════════
+
+// 渲染层询问是否启用 + 采集参数
+ipcMain.handle('galaxy:perception-config', () => ({
+    enabled: PERCEPTION_ENABLED,
+    intervalMs: PERCEPTION_INTERVAL_MS,
+    video: true,
+    audio: true,
+}));
+
+// 渲染层采到的帧/音频 → 转发到网关的桌面感知接收端
+ipcMain.on('galaxy:desktop-perception', async (_event, payload) => {
+    if (!PERCEPTION_ENABLED || !payload) return;
+    try {
+        if (payload.type === 'frame' && payload.image_base64) {
+            await fetch(`${GATEWAY_BASE}/api/perception/desktop/frame`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    image_base64: payload.image_base64,
+                    mime: payload.mime || 'image/jpeg',
+                    source: payload.source || 'desktop_camera',
+                }),
+            });
+        } else if (payload.type === 'audio' && payload.audio_base64) {
+            await fetch(`${GATEWAY_BASE}/api/perception/desktop/audio`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    audio_base64: payload.audio_base64,
+                    mime: payload.mime || 'audio/webm',
+                }),
+            });
+        }
+    } catch (e) {
+        // 后端未就绪/网络抖动等非致命；丢弃本帧即可
+        console.debug('[Perception] forward failed:', e && e.message);
     }
 });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -22,6 +22,12 @@ contextBridge.exposeInMainWorld('galaxyAPI', {
   getWindowSize: () => ipcRenderer.invoke('get-window-size'),
   setIgnoreMouse: (ignore) => ipcRenderer.send('set-ignore-mouse', ignore),
 
+  // ── 桌面连续感知（摄像头/麦克风/屏幕）─
+  // 配置（默认关闭，隐私优先）由 main.js 经环境变量决定。
+  getPerceptionConfig: () => ipcRenderer.invoke('galaxy:perception-config'),
+  // 渲染层采到的帧/音频片段 → main.js → 转发到网关 /api/perception/desktop/*
+  sendDesktopPerception: (payload) => ipcRenderer.send('galaxy:desktop-perception', payload),
+
   // ── 工具 ─
   platform: process.platform,
 

--- a/electron/renderer/index.html
+++ b/electron/renderer/index.html
@@ -111,6 +111,7 @@ body {
 <script src="bridge/websocket.js"></script>
 <script src="ui/island.js"></script>
 <script src="app.js"></script>
+<script src="perception-capture.js"></script>
 
 </body>
 </html>

--- a/electron/renderer/perception-capture.js
+++ b/electron/renderer/perception-capture.js
@@ -1,0 +1,112 @@
+/**
+ * perception-capture.js
+ * 电脑端连续感知采集：摄像头 / 麦克风 / 屏幕 → 周期性发往后端。
+ *
+ * 默认关闭（隐私优先）。仅当 main.js 通过 GALAXY_DESKTOP_PERCEPTION=1 启用时才采集。
+ * - 摄像头：getUserMedia({video}) → 每 intervalMs 抓一帧 → JPEG base64 → 后端
+ * - 麦克风：getUserMedia({audio}) → MediaRecorder 周期切片 → base64 → 后端
+ * 这些帧只更新后端的「最新帧」存储；模型在下一次普通请求时按 TTL 取用（原生看到）。
+ *
+ * 全程容错：拿不到权限/设备就降级关闭对应模态，绝不影响主覆盖层渲染。
+ */
+(function () {
+  'use strict';
+
+  async function getConfig() {
+    try {
+      if (window.galaxyAPI && window.galaxyAPI.getPerceptionConfig) {
+        return await window.galaxyAPI.getPerceptionConfig();
+      }
+    } catch (e) { /* ignore */ }
+    return { enabled: false, intervalMs: 2000, audio: true, video: true };
+  }
+
+  function send(payload) {
+    try {
+      if (window.galaxyAPI && window.galaxyAPI.sendDesktopPerception) {
+        window.galaxyAPI.sendDesktopPerception(payload);
+      }
+    } catch (e) { /* non-fatal */ }
+  }
+
+  async function startVideo(intervalMs) {
+    let stream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    } catch (e) {
+      console.warn('[Perception] camera unavailable:', e && e.message);
+      return;
+    }
+    const video = document.createElement('video');
+    video.srcObject = stream;
+    video.muted = true;
+    await video.play().catch(() => {});
+    const canvas = document.createElement('canvas');
+
+    setInterval(() => {
+      try {
+        const w = video.videoWidth, h = video.videoHeight;
+        if (!w || !h) return;
+        canvas.width = w; canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(video, 0, 0, w, h);
+        // JPEG ~0.6 质量，控制体积
+        const dataUrl = canvas.toDataURL('image/jpeg', 0.6);
+        const b64 = dataUrl.split(',')[1] || '';
+        if (b64) send({ type: 'frame', image_base64: b64, mime: 'image/jpeg', source: 'desktop_camera' });
+      } catch (e) { /* skip this frame */ }
+    }, Math.max(500, intervalMs));
+    console.log('[Perception] camera capture started');
+  }
+
+  async function startAudio(intervalMs) {
+    let stream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e) {
+      console.warn('[Perception] microphone unavailable:', e && e.message);
+      return;
+    }
+    if (typeof MediaRecorder === 'undefined') {
+      console.warn('[Perception] MediaRecorder unavailable; audio capture skipped');
+      return;
+    }
+    try {
+      const rec = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+      rec.ondataavailable = (ev) => {
+        if (!ev.data || ev.data.size === 0) return;
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          const b64 = (reader.result || '').toString().split(',')[1] || '';
+          if (b64) send({ type: 'audio', audio_base64: b64, mime: 'audio/webm' });
+        };
+        reader.readAsDataURL(ev.data);
+      };
+      // 每 intervalMs 产出一个切片
+      rec.start();
+      setInterval(() => {
+        try { if (rec.state === 'recording') rec.requestData(); } catch (e) { /* ignore */ }
+      }, Math.max(1000, intervalMs * 2));
+      console.log('[Perception] microphone capture started');
+    } catch (e) {
+      console.warn('[Perception] audio recorder failed:', e && e.message);
+    }
+  }
+
+  async function init() {
+    const cfg = await getConfig();
+    if (!cfg || !cfg.enabled) {
+      console.log('[Perception] disabled (set GALAXY_DESKTOP_PERCEPTION=1 to enable)');
+      return;
+    }
+    const interval = cfg.intervalMs || 2000;
+    if (cfg.video !== false) startVideo(interval);
+    if (cfg.audio !== false) startAudio(interval);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## 背景（排查结论）

桌面 V2 有「摄像头+麦克风+系统融合成隐蔽上下文」的架构骨架,但在 PC 上是断的:
- Electron 壳**从不采集**(全量搜 `getUserMedia/RTCPeerConnection` 零命中);
- 连续感知 `enable_multimodal_ingest` **默认关闭**;摄像头走 WebRTC 且无生产者(stub 模式);
- 即便开,也只有**特征**(VAD/energy/motion)进 `canonical_perception_state`,**原始媒体从不到模型**。

本 PR 补上缺失的端到端采集链,让**模型真正「看到」桌面摄像头/屏幕**。

## 改动

**采集端（Electron,默认关闭 / 隐私优先,`GALAXY_DESKTOP_PERCEPTION=1` 启用）**
- `renderer/perception-capture.js`:`getUserMedia` 采摄像头(canvas 周期抓 JPEG 帧)+ 麦克风(MediaRecorder webm 切片);设备/权限缺失时优雅降级。
- `preload.js`:暴露 `getPerceptionConfig()` / `sendDesktopPerception()`。
- `main.js`:媒体权限处理器(仅启用时放行摄像头/麦克风/屏幕)、采集配置、把帧/音频转发到网关。

**后端**
- `core/perception/desktop_perception_store.py`:进程单例,保存最新帧/音频 + **TTL 新鲜度**;`build_multimodal_context()` 仅在新鲜、且请求本身不带图像时产出 `MultiModalContext`(**绝不覆盖显式上传**)。
- `core/routes/perception.py`:`POST /api/perception/desktop/{frame,audio}`、`GET /status`、`POST /analyze`(「现在看一下」——复用 Android vision 已验证的 `runtime.handle_request` 路径,把帧**原生送模型**)。已在 `core/api_routes.py` 注册。
- `OpenClawd.process()`:在 `MultimodalBus.ingest` 前,若请求不带图像则注入最新「新鲜」桌面帧——**普通对话时模型也能看到摄像头**。全程 guard,异常静默跳过。

**配置**(`.env.example`):`GALAXY_DESKTOP_PERCEPTION` / `_INTERVAL_MS` / `_TTL`。

## 安全 / 影响面
- **默认关闭**,不开不采集、不申请摄像头权限。
- 只在请求**无显式图像**时注入;TTL 过期帧不注入(不喂过期画面)。
- 不改变文本请求语义;注入/转发/存储任何异常都吞掉,不影响主流程。

## 验证（本地）
- JS 语法:`main.js` / `preload.js` / `perception-capture.js`。
- Python AST:store / routes / api_routes / openclawd。
- store 单测:空→None、新鲜帧、ambient 元数据、音频合并、**尊重已有图像不注入**、TTL 过期、status 计数。

> ⚠️ 注意:① 模型原生看图仍依赖配置了 vision-capable 的 provider;② 原始音频已存储/附带,但「原生音频 payload 送模型」留作后续;③ 本环境无法跑 GUI/真机,需你在桌面端实测(开 `GALAXY_DESKTOP_PERCEPTION=1`,看 `/api/perception/desktop/status` 与对话时模型是否描述到摄像头画面)。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_