### PR TITLE
feat(perception): auto-inject native mic audio into ordinary conversations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,9 @@ WEB_UI_PORT=8085                        # Unified Dashboard port (Galaxy unified
 GALAXY_DESKTOP_PERCEPTION=0                  # 1/true 启用桌面摄像头+麦克风采集
 GALAXY_DESKTOP_PERCEPTION_INTERVAL_MS=2000   # 采集间隔(毫秒)
 GALAXY_DESKTOP_PERCEPTION_TTL=10             # 后端帧新鲜度 TTL(秒); 超时不注入
+# 普通对话自动「听见」麦克风：用音频模型原生听懂最新麦克风音频→转写注入 prompt。
+# 默认关闭(每次新音频会多一次音频模型调用); 需配置 GEMINI/GOOGLE 或 OPENAI key。
+GALAXY_DESKTOP_AUDIO_AUTOINJECT=0
 
 # CORS allowed origins (comma-separated)
 # Default: http://localhost:3000,http://localhost:8085,http://localhost:9000

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -3912,6 +3912,30 @@ class OpenClawd:
             "",
         )
 
+        # ── Desktop ambient AUDIO auto-injection（普通对话也能「听见」麦克风）──
+        # 统一 router 不携带原生媒体，普通 chat 路径会把媒体文本摘要化；故让音频
+        # 能力模型（Gemini/OpenAI）先原生听懂这段新鲜麦克风音频，再把其转写/理解
+        # 文本注入到本次对话 prompt。默认关闭（每次新音频会多一次音频模型调用）；
+        # GALAXY_DESKTOP_AUDIO_AUTOINJECT=1 开启。去重 + TTL + 失败即跳过。
+        try:
+            import os as _os_aa
+            if _os_aa.getenv("GALAXY_DESKTOP_AUDIO_AUTOINJECT", "0").strip().lower() in ("1", "true", "yes", "on"):
+                from core.perception.desktop_perception_store import get_desktop_perception_store
+                _aud_b64, _aud_mime = get_desktop_perception_store().take_fresh_audio_for_autoinject()
+                if _aud_b64:
+                    from core.audio_pipeline import get_audio_pipeline
+                    _aud_res = await get_audio_pipeline().understand(
+                        _aud_b64, mime=_aud_mime or "audio/webm",
+                        prompt="转写这段麦克风音频，只输出其中的话语内容。",
+                    )
+                    if _aud_res.get("success") and _aud_res.get("text"):
+                        _aud_text = str(_aud_res["text"]).strip()[:1000]
+                        if _aud_text:
+                            message = f"{message}\n\n[麦克风/语音] {_aud_text}"
+                            logger.debug("Injected desktop mic transcript into request message")
+        except Exception as _aa_err:  # noqa: BLE001 — 音频自动注入失败不影响请求
+            logger.debug("desktop audio auto-inject skipped: %s", _aa_err)
+
         # ── Desktop ambient perception injection ─────────────────────────────
         # 电脑端 Electron 壳持续上传摄像头/屏幕/麦克风帧到 DesktopPerceptionStore。
         # 若本次请求自身不带图像、且存储里有「新鲜」帧（TTL 内），则把它作为原生

--- a/core/perception/desktop_perception_store.py
+++ b/core/perception/desktop_perception_store.py
@@ -55,6 +55,8 @@ class DesktopPerceptionStore:
         # counters (diagnostics)
         self._frames_received: int = 0
         self._audio_received: int = 0
+        # 自动注入去重：已被对话自动注入消费过的音频时间戳，避免同一片段反复转写
+        self._audio_autoinject_consumed_ts: float = 0.0
 
     @classmethod
     def get_instance(cls) -> "DesktopPerceptionStore":
@@ -101,6 +103,22 @@ class DesktopPerceptionStore:
     def has_fresh_frame(self) -> bool:
         with self._lock:
             return bool(self._image_b64) and self._fresh(self._image_ts)
+
+    def take_fresh_audio_for_autoinject(self):
+        """取一段「新鲜且未被自动注入消费过」的音频，用于对话自动注入。
+
+        返回 ``(audio_b64, mime)``；没有可用音频则返回 ``(None, None)``。
+        通过记录已消费时间戳去重，避免同一片段在多轮对话里被反复转写。
+        """
+        with self._lock:
+            if (
+                self._audio_b64
+                and self._fresh(self._audio_ts)
+                and self._audio_ts > self._audio_autoinject_consumed_ts
+            ):
+                self._audio_autoinject_consumed_ts = self._audio_ts
+                return self._audio_b64, self._audio_mime
+        return None, None
 
     def status(self) -> Dict[str, Any]:
         with self._lock:


### PR DESCRIPTION
## 目标

#1344 里图像已能在普通对话**自动注入**(模型"看到"摄像头),但麦克风音频此前只能走显式 `/listen`。本 PR 让**普通对话也能自动"听见"麦克风**。

## 做法(架构现实约束下的最优)

统一 router 不携带原生媒体、普通 chat 路径会把媒体文本摘要化。所以正确做法是:让**音频能力模型**(Gemini `inline_data` / OpenAI `input_audio`,经 `AudioPipeline`)**原生听懂**最新麦克风音频,再把其转写/理解文本注入本轮 prompt。音频字节由真正的音频模型原生处理,对话模型收到的是其结果文本。

- `DesktopPerceptionStore.take_fresh_audio_for_autoinject()`:取「新鲜且未被消费过」的音频(TTL + 已消费时间戳去重),避免同一片段跨轮反复转写。
- `OpenClawd.process()`:当 `GALAXY_DESKTOP_AUDIO_AUTOINJECT=1` 且有新鲜未处理片段时,`AudioPipeline.understand()` 之,把 `[麦克风/语音] <文本>` 追加到本轮消息。

## 安全 / 影响
- **默认关闭**(每个新片段会多一次音频模型调用);开启需配 GEMINI/GOOGLE 或 OPENAI key。
- 每个新片段最多一次调用;去重避免重复;**任何异常都吞掉,绝不阻塞请求**;显式带音频的请求不受影响。

## 验证(本地)
- AST 通过;store 去重/TTL 单测:返回一次、新片段可再取、过期不取——全过。
- 未真机验证(无 key/GUI)。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_