### PR TITLE
fix(local-brain): correct MiniCPM-o Ollama tag + loud cloud-fallback warning

### DIFF
--- a/core/hardware_aware_multimodal_router.py
+++ b/core/hardware_aware_multimodal_router.py
@@ -379,7 +379,7 @@ class HardwareAwareMultimodalRouter:
             elif profile.max_model_size_mb > 4000:
                 # 中等显存 (4-8GB) → Gemma 4 4B 或 MiniCPM-o 4.5
                 if task_type == "multimodal":
-                    return "minicpm-o4.5:9b"
+                    return "openbmb/minicpm-o4.5"  # Ollama 真实 tag（带命名空间）
                 return "gemma4:e4b"
             elif profile.max_model_size_mb > 2000:
                 # 较小显存 (2-4GB) → Gemma 4 2B

--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -87,24 +87,21 @@ class LocalBrainManager:
         "fast": "gemma4:e4b",             # 4B 快速响应
         "creative": "gemma4:12b",         # 创意任务
         "reasoning": "gemma4:12b",        # 推理任务
-        "multimodal": "minicpm-o4.5:9b",  # MiniCPM-o 4.5 全模态(看+听+说)
+        # MiniCPM-o 4.5 全模态(看+听+说) — Ollama 真实 tag 带 openbmb/ 命名空间，
+        # 此前误写为 "minicpm-o4.5:9b" 会 pull 失败 → 本地多模态静默不可用。
+        "multimodal": "openbmb/minicpm-o4.5",
     }
 
     # 模型大小估算（MB，用于 VRAM 评估）
     MODEL_SIZE_ESTIMATE_MB = {
-        # Gemma 4 系列
+        # Gemma 4 系列（Ollama 官方 library 真实 tag）
         "gemma4:12b": 8000,
         "gemma4:26b": 16000,
         "gemma4:31b": 20000,
         "gemma4:e2b": 1800,
         "gemma4:e4b": 3000,
-        "gemma4:27b": 18000,
-        # MiniCPM-o 4.5 全模态
-        "minicpm-o4.5:9b": 6000,
-        "minicpm-o4.5:3.5b": 2500,
-        "minicpm-o4.5:2.5b": 1800,
-        "minicpm-o4.5:8b": 5500,
-        "minicpm-o4.5:7.6b": 5000,
+        # MiniCPM-o 4.5 全模态（9B）
+        "openbmb/minicpm-o4.5": 6000,
         # 旧模型（兼容保留）
         "qwen2:7b": 4500,
         "qwen2:1.5b": 1000,

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -1487,6 +1487,20 @@ class MultiLLMRouter:
                 )
 
         # 4. 本地主脑不可用 → 升级到云端
+        # 明确告警（而非静默回落）：本地主脑预期可用却未就绪时，提示用户检查
+        # Ollama / 模型 tag（最常见是模型未 pull 或 tag 名不对），便于排查
+        # "看着配了本地原生多模态、实际一直走云端" 的情况。
+        _local_present = any(
+            p in self.providers and self.providers[p].status != ProviderStatus.DOWN
+            for p in ("ollama", "hf_local")
+        )
+        if not _local_present:
+            logger.warning(
+                "LOCAL-BRAIN-FIRST: 本地主脑不可用(ollama/hf_local 未就绪)，本次回落云端。"
+                "请检查 `ollama list` 是否含所需模型(如 gemma4:12b / openbmb/minicpm-o4.5)、"
+                "Ollama 是否在 %s 运行。",
+                getattr(self, "ollama_url", "localhost:11434"),
+            )
         # 如果有多模态输入，先尝试多模态路由
         if has_multimodal:
             decision = self.route_multimodal_first(
@@ -1805,6 +1819,20 @@ class MultiLLMRouter:
                 )
 
         # 4. 本地主脑不可用 → 升级到云端
+        # 明确告警（而非静默回落）：本地主脑预期可用却未就绪时，提示用户检查
+        # Ollama / 模型 tag（最常见是模型未 pull 或 tag 名不对），便于排查
+        # "看着配了本地原生多模态、实际一直走云端" 的情况。
+        _local_present = any(
+            p in self.providers and self.providers[p].status != ProviderStatus.DOWN
+            for p in ("ollama", "hf_local")
+        )
+        if not _local_present:
+            logger.warning(
+                "LOCAL-BRAIN-FIRST: 本地主脑不可用(ollama/hf_local 未就绪)，本次回落云端。"
+                "请检查 `ollama list` 是否含所需模型(如 gemma4:12b / openbmb/minicpm-o4.5)、"
+                "Ollama 是否在 %s 运行。",
+                getattr(self, "ollama_url", "localhost:11434"),
+            )
         # 如果有多模态输入，先尝试多模态路由
         if has_multimodal:
             decision = self.route_multimodal_first(

--- a/launch_desktop.py
+++ b/launch_desktop.py
@@ -42,7 +42,7 @@ UFO Galaxy — 系统化完整启动器 (Systematic Launcher)
 用法：
     python launch_desktop.py                    # 完整启动（推荐）
     python launch_desktop.py --model gemma4:12b # 指定模型
-    python launch_desktop.py --model minicpm-o4.5:9b
+    python launch_desktop.py --model openbmb/minicpm-o4.5
     python launch_desktop.py --skip-model-download  # 跳过模型下载
     python launch_desktop.py --check            # 只检查环境
     python launch_desktop.py --backend          # 只启动 Gateway
@@ -99,7 +99,7 @@ AVAILABLE_MODELS = {
         "vram": "8GB+",
         "recommended": True,
     },
-    "minicpm-o4.5:9b": {
+    "openbmb/minicpm-o4.5": {
         "name": "MiniCPM-o 4.5 9B",
         "desc": "全模态(看+听+说)，全双工实时交互",
         "size": "~6GB",


### PR DESCRIPTION
## 问题(已查证)

本地原生多模态"配了却没真用"的根因:模型 tag 名对不上 Ollama 真实 registry,`LocalBrainManager` 拉不到 → 进 DEGRADED/UNAVAILABLE → **静默回落云端**。

实测对照真实 registry:
- **Gemma 4** tag(`gemma4:e2b/e4b/12b/26b/31b`)**是 Ollama 官方真实 tag,保留**。
- **MiniCPM-o 4.5** 在 Ollama 上是 **`openbmb/minicpm-o4.5`(带命名空间)**,仓库写的 `minicpm-o4.5:9b` **pull 不到** → 多模态本地主脑永远加载不了。

## 改动

| 文件 | 改动 |
|------|------|
| `core/local_brain_manager.py` | `RECOMMENDED_MODELS["multimodal"]` 与 VRAM 估算表改用 `openbmb/minicpm-o4.5`;清掉伪造的 size 变体和不存在的 `gemma4:27b` |
| `core/hardware_aware_multimodal_router.py` | 多模态任务返回 `openbmb/minicpm-o4.5` |
| `launch_desktop.py` | 模型项 + `--model` 帮助改为 `openbmb/minicpm-o4.5` |
| `core/multi_llm_router.py` | `route_local_brain_first`(两个 router 类):本地主脑不可用回落云端时**明确 WARNING**,提示查 `ollama list` / tag,而不是静默降级 |

## 验证
- 实测核对 Ollama registry:`ollama.com/openbmb/minicpm-o4.5`、`ollama.com/library/gemma4`。
- AST 通过;全仓库已无残留 `minicpm-o4.5:9b`(除解释性注释)。
- 用户侧确认:`ollama pull openbmb/minicpm-o4.5` 应成功;之前的 `minicpm-o4.5:9b` 会 not found。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_