### PR TITLE
feat(eval): agent trajectory evaluation framework (the L4 measuring stick)

### DIFF
--- a/core/eval/__init__.py
+++ b/core/eval/__init__.py
@@ -1,0 +1,26 @@
+"""
+core/eval/ — Agent 轨迹评估框架（L4 的"标尺"）
+================================================
+
+在改动记忆/规划/反思等"会影响智能"的东西之前，先有一把可量化的尺子：
+给定一组任务用例，跑 agent、对其**输出与轨迹**打分，产出可对比的报告
+（通过率/平均分/逐例明细 + 与基线对比的回归项）。
+
+刻意与具体 agent 解耦：``EvalRunner`` 接收一个 ``agent_fn(prompt)->result``，
+因此既能跑真实 OpenClawd，也能用 fake agent 做单测（无需模型/key）。
+
+result 约定（与 agent_factory 的输出兼容）::
+
+    {"output": str, "success": bool,
+     "tool_calls": [{"tool"/"tool_name": str, ...}], ...}
+"""
+
+from core.eval.cases import EvalCase, builtin_cases, load_cases
+from core.eval.scorer import CaseScore, score_case
+from core.eval.runner import EvalReport, EvalRunner, run_eval
+
+__all__ = [
+    "EvalCase", "builtin_cases", "load_cases",
+    "CaseScore", "score_case",
+    "EvalReport", "EvalRunner", "run_eval",
+]

--- a/core/eval/cases.py
+++ b/core/eval/cases.py
@@ -1,0 +1,80 @@
+"""core/eval/cases.py — 评估用例 schema + 内置用例集 + JSONL 加载。"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class EvalCase:
+    """一个评估用例：给 agent 的 prompt + 对其结果的判定标准。"""
+
+    id: str
+    prompt: str
+    must_contain: List[str] = field(default_factory=list)       # 输出须含全部(大小写不敏感)
+    must_not_contain: List[str] = field(default_factory=list)   # 输出不得含任一
+    expect_tools: List[str] = field(default_factory=list)       # 轨迹中应出现的工具名
+    expect_success: Optional[bool] = None                       # 期望 result.success
+    weight: float = 1.0
+    tags: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "EvalCase":
+        return cls(
+            id=str(d["id"]),
+            prompt=str(d.get("prompt", "")),
+            must_contain=list(d.get("must_contain", [])),
+            must_not_contain=list(d.get("must_not_contain", [])),
+            expect_tools=list(d.get("expect_tools", [])),
+            expect_success=d.get("expect_success"),
+            weight=float(d.get("weight", 1.0)),
+            tags=list(d.get("tags", [])),
+        )
+
+
+def builtin_cases() -> List[EvalCase]:
+    """一组最小的内置用例（冒烟级；真实评估请用更大的 JSONL 数据集）。"""
+    return [
+        EvalCase(
+            id="smoke_chat_greeting",
+            prompt="用一句话礼貌地打个招呼。",
+            must_contain=[],
+            expect_success=True,
+            tags=["chat", "smoke"],
+        ),
+        EvalCase(
+            id="tool_list_files",
+            prompt="列出当前目录下的文件。",
+            expect_tools=["filesystem", "shell", "list"],   # 任一类文件/列目录工具
+            expect_success=True,
+            tags=["tool", "smoke"],
+        ),
+        EvalCase(
+            id="reasoning_capital",
+            prompt="法国的首都是哪座城市？只回答城市名。",
+            must_contain=["巴黎"],
+            must_not_contain=["伦敦", "柏林"],
+            expect_success=True,
+            tags=["reasoning"],
+        ),
+    ]
+
+
+def load_cases(path: str) -> List[EvalCase]:
+    """从 JSONL(每行一个用例 dict) 加载用例集；文件不存在/为空则返回内置用例。"""
+    if not path or not os.path.exists(path):
+        return builtin_cases()
+    cases: List[EvalCase] = []
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                cases.append(EvalCase.from_dict(json.loads(line)))
+            except (json.JSONDecodeError, KeyError, ValueError):
+                continue
+    return cases or builtin_cases()

--- a/core/eval/runner.py
+++ b/core/eval/runner.py
@@ -1,0 +1,78 @@
+"""core/eval/runner.py — 评估执行器 + 报告 + 基线回归对比。"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+
+from core.eval.cases import EvalCase, builtin_cases
+from core.eval.scorer import CaseScore, score_case
+
+# agent_fn: 接收 prompt(str)，返回 result dict（可同步或异步）。
+AgentFn = Callable[[str], Union[Dict[str, Any], Awaitable[Dict[str, Any]]]]
+
+
+@dataclass
+class EvalReport:
+    total: int
+    passed: int
+    avg_score: float
+    pass_rate: float
+    scores: List[CaseScore] = field(default_factory=list)
+    duration_ms: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total": self.total,
+            "passed": self.passed,
+            "pass_rate": round(self.pass_rate, 4),
+            "avg_score": round(self.avg_score, 4),
+            "duration_ms": round(self.duration_ms, 1),
+            "cases": [
+                {"id": s.case_id, "score": s.score, "passed": s.passed, "detail": s.detail}
+                for s in self.scores
+            ],
+        }
+
+    def regressions_vs(self, baseline: "EvalReport") -> List[str]:
+        """返回相对基线分数下降的用例 id 列表（回归项）。"""
+        base = {s.case_id: s.score for s in baseline.scores}
+        return [s.case_id for s in self.scores if s.case_id in base and s.score < base[s.case_id]]
+
+
+class EvalRunner:
+    def __init__(self, cases: Optional[List[EvalCase]] = None) -> None:
+        self.cases = cases or builtin_cases()
+
+    async def _invoke(self, agent_fn: AgentFn, prompt: str) -> Dict[str, Any]:
+        try:
+            out = agent_fn(prompt)
+            if inspect.isawaitable(out):
+                out = await out
+            return out if isinstance(out, dict) else {"output": str(out), "success": True}
+        except Exception as exc:  # noqa: BLE001 — agent 异常记为失败用例，不中断整轮
+            return {"output": "", "success": False, "error": str(exc)}
+
+    async def run(self, agent_fn: AgentFn) -> EvalReport:
+        t0 = time.monotonic()
+        scores: List[CaseScore] = []
+        for case in self.cases:
+            result = await self._invoke(agent_fn, case.prompt)
+            scores.append(score_case(case, result))
+        dur = (time.monotonic() - t0) * 1000
+        n = len(scores) or 1
+        passed = sum(1 for s in scores if s.passed)
+        avg = sum(s.score for s in scores) / n
+        return EvalReport(
+            total=len(scores), passed=passed,
+            avg_score=avg, pass_rate=passed / n,
+            scores=scores, duration_ms=dur,
+        )
+
+
+def run_eval(agent_fn: AgentFn, cases: Optional[List[EvalCase]] = None) -> EvalReport:
+    """同步便捷入口。"""
+    return asyncio.run(EvalRunner(cases).run(agent_fn))

--- a/core/eval/scorer.py
+++ b/core/eval/scorer.py
@@ -1,0 +1,59 @@
+"""core/eval/scorer.py — 基于规则的轨迹打分（确定性、无需 LLM/key）。
+
+把一个 agent result 与 EvalCase 的判定标准比对，给出 0~1 的分 + 通过与否 + 明细。
+每个被设置的判据是一个等权检查项；分 = 通过项 / 总项。无判据的用例只看 success。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from core.eval.cases import EvalCase
+
+
+@dataclass
+class CaseScore:
+    case_id: str
+    score: float                       # 0.0~1.0
+    passed: bool                       # score == 1.0(全部判据通过)
+    checks: Dict[str, bool] = field(default_factory=dict)
+    detail: str = ""
+
+
+def _tool_names(result: Dict[str, Any]) -> List[str]:
+    names: List[str] = []
+    for tc in (result.get("tool_calls") or []):
+        if isinstance(tc, dict):
+            n = tc.get("tool") or tc.get("tool_name") or ""
+            if n:
+                names.append(str(n).lower())
+    return names
+
+
+def score_case(case: EvalCase, result: Dict[str, Any]) -> CaseScore:
+    output = str(result.get("output") or result.get("reply") or "").lower()
+    tools = _tool_names(result)
+    checks: Dict[str, bool] = {}
+
+    for kw in case.must_contain:
+        checks[f"contains:{kw}"] = kw.lower() in output
+    for kw in case.must_not_contain:
+        checks[f"absent:{kw}"] = kw.lower() not in output
+    if case.expect_tools:
+        # 命中任一期望工具(名称子串匹配)即算通过该项
+        checks["tool_used"] = any(
+            any(exp.lower() in t for t in tools) for exp in case.expect_tools
+        )
+    if case.expect_success is not None:
+        checks["success"] = bool(result.get("success", True)) == case.expect_success
+
+    if not checks:
+        # 无显式判据 → 退化为 success 检查
+        ok = bool(result.get("success", True))
+        return CaseScore(case.id, 1.0 if ok else 0.0, ok, {"success": ok})
+
+    passed_n = sum(1 for v in checks.values() if v)
+    score = passed_n / len(checks)
+    detail = ", ".join(f"{k}={'✓' if v else '✗'}" for k, v in checks.items())
+    return CaseScore(case.id, round(score, 4), score >= 1.0, checks, detail)

--- a/scripts/run_agent_eval.py
+++ b/scripts/run_agent_eval.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""scripts/run_agent_eval.py — 跑一轮 agent 轨迹评估并打印/保存报告。
+
+用法:
+    python -m scripts.run_agent_eval                      # 内置用例 + 真实 agent
+    python -m scripts.run_agent_eval --cases cases.jsonl  # 自定义用例集
+    python -m scripts.run_agent_eval --baseline base.json # 与基线对比, 报告回归
+    python -m scripts.run_agent_eval --out report.json    # 保存报告
+
+真实 agent 需要配置好 LLM key / 本地模型；未就绪时每个用例记为失败(报告仍可产出)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any, Dict
+
+
+async def galaxy_agent_fn(prompt: str) -> Dict[str, Any]:
+    """把一条 prompt 跑过真实 OpenClawd，归一化成评估 result。"""
+    from core.openclawd import get_openclawd
+
+    clawd = get_openclawd()
+    res = await clawd.process(message=prompt, device_id="eval", session_id="eval_session")
+    if not isinstance(res, dict):
+        return {"output": str(res), "success": True, "tool_calls": []}
+    # 归一化：OpenClawd/agent_factory 的输出 → 评估约定字段
+    tool_calls = res.get("tool_calls") or (res.get("task_result") or {}).get("tool_calls") or []
+    return {
+        "output": res.get("response") or res.get("reply") or res.get("output") or "",
+        "success": bool(res.get("success", True)),
+        "tool_calls": tool_calls,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="run_agent_eval")
+    ap.add_argument("--cases", default="", help="JSONL 用例集路径(默认内置)")
+    ap.add_argument("--baseline", default="", help="基线报告 JSON 路径(用于回归对比)")
+    ap.add_argument("--out", default="", help="保存报告 JSON 路径")
+    args = ap.parse_args()
+
+    sys.path.insert(0, os.getcwd())
+    from core.eval import EvalRunner, load_cases
+    from core.eval.runner import EvalReport
+
+    cases = load_cases(args.cases)
+    report = asyncio.run(EvalRunner(cases).run(galaxy_agent_fn))
+    d = report.to_dict()
+
+    print(json.dumps(d, ensure_ascii=False, indent=2))
+    print(f"\n通过率 {report.pass_rate:.0%} | 平均分 {report.avg_score:.3f} | "
+          f"{report.passed}/{report.total} 通过")
+
+    if args.baseline and os.path.exists(args.baseline):
+        try:
+            base_d = json.load(open(args.baseline, encoding="utf-8"))
+            base = EvalReport(
+                total=base_d["total"], passed=base_d["passed"],
+                avg_score=base_d["avg_score"], pass_rate=base_d["pass_rate"],
+            )
+            from core.eval.scorer import CaseScore
+            base.scores = [CaseScore(c["id"], c["score"], c["passed"]) for c in base_d.get("cases", [])]
+            regs = report.regressions_vs(base)
+            print(f"回归项({len(regs)}): {regs}" if regs else "无回归 ✅")
+        except Exception as exc:  # noqa: BLE001
+            print(f"基线对比跳过: {exc}")
+
+    if args.out:
+        json.dump(d, open(args.out, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
+        print(f"报告已保存: {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 目标(A — L4 的"标尺")

改记忆/规划/反思这种"会影响智能"的东西之前,必须有一把可量化的尺子,否则改完不知道是变好还是变坏。本 PR 提供 agent 轨迹评估框架。

- `core/eval/cases.py`:`EvalCase`(must_contain / must_not_contain / expect_tools / expect_success / weight / tags)+ 内置冒烟用例 + JSONL 加载。
- `core/eval/scorer.py`:**确定性规则打分**(无需 LLM/key)——每个判据等权,分=通过/总,全过才 pass。
- `core/eval/runner.py`:`EvalRunner(agent_fn)` 跑全部用例 → `EvalReport`(通过率/平均分/逐例)+ `regressions_vs(baseline)` 抓回归。**与 agent 解耦**(`agent_fn: prompt->result`,同步/异步皆可),既能跑真实 OpenClawd,也能 fake agent 单测。
- `scripts/run_agent_eval.py`:CLI,把**真实 OpenClawd** 接成 agent_fn(无模型/key 时优雅降级),支持 `--cases / --baseline / --out`。

## 验证(本地,fake agent)
- scorer 逐项正确;
- 整轮:good agent 100% vs 回归 agent 50%;
- **回归检测**:与基线对比,正确标出回归用例。

## 用法
```bash
python -m scripts.run_agent_eval                       # 内置用例 + 真实 agent
python -m scripts.run_agent_eval --baseline base.json  # 抓回归
```

> 这是 L4 三支柱之一(标尺)。配合统一记忆(#1348)的经验复用,后续可量化"加了经验学习到底有没有用"。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_