### PR TITLE
feat(agent): native multimodal in the general chat path (image_url to model)

### DIFF
--- a/core/agent/kernel.py
+++ b/core/agent/kernel.py
@@ -351,6 +351,7 @@ class AgentKernel:
         device_id: str = "",
         context: Optional[List[Dict[str, str]]] = None,
         timeout: float = 90.0,
+        multimodal_context: Optional[Any] = None,
     ) -> KernelResponse:
         """
         统一消息处理入口。
@@ -383,6 +384,7 @@ class AgentKernel:
                     runtime_attachment_session_id,
                     device_id,
                     ctx,
+                    multimodal_context,
                 ),
                 timeout=timeout,
             )
@@ -424,6 +426,7 @@ class AgentKernel:
         runtime_attachment_session_id: str,
         device_id: str,
         context: List[Dict[str, str]],
+        multimodal_context: Optional[Any] = None,
     ) -> KernelResponse:
         t0 = time.monotonic()
         self._ensure_components()
@@ -508,6 +511,7 @@ class AgentKernel:
             result = await self._handle_chat(
                 message, session_id, context, user_policy,
                 task_hint=intent.task_hint,
+                multimodal_context=multimodal_context,
             )
             result.intent = intent
             result.latency_ms = (time.monotonic() - t0) * 1000
@@ -665,6 +669,7 @@ class AgentKernel:
         context: List[Dict[str, str]],
         user_policy: str,
         task_hint: str = "",
+        multimodal_context: Optional[Any] = None,
     ) -> KernelResponse:
         """纯聊天处理路径——完全不加载 SOUL。
 
@@ -679,7 +684,10 @@ class AgentKernel:
                 rather than defaulting to generic keyword classification.
         """
         # 直接调用 LLM Router 处理聊天（保持单向依赖，不回调 OpenClawd）
-        return await self._fallback_chat(message, session_id, context, user_policy, task_hint=task_hint)
+        return await self._fallback_chat(
+            message, session_id, context, user_policy,
+            task_hint=task_hint, multimodal_context=multimodal_context,
+        )
 
     async def _fallback_chat(
         self,
@@ -688,6 +696,7 @@ class AgentKernel:
         context: List[Dict[str, str]],
         user_policy: str,
         task_hint: str = "",
+        multimodal_context: Optional[Any] = None,
     ) -> KernelResponse:
         """直接通过 LLM Router 处理聊天（最终降级路径）。
 
@@ -715,7 +724,10 @@ class AgentKernel:
             ]
             for turn in context[-8:]:
                 messages.append(turn)
-            messages.append({"role": "user", "content": message})
+            # 原生多模态：有图像且 GALAXY_NATIVE_MM_CHAT=1 时，user content 用 OpenAI
+            # content 数组(text+image_url)，让图像原生送达模型；否则纯文本(默认)。
+            from core.agent.multimodal_messages import build_user_message_content
+            messages.append({"role": "user", "content": build_user_message_content(message, multimodal_context)})
 
             # PR-17: pass task_hint as task_type when available so the router
             # uses real task semantics instead of generic keyword fallback.

--- a/core/agent/multimodal_messages.py
+++ b/core/agent/multimodal_messages.py
@@ -1,0 +1,37 @@
+"""core/agent/multimodal_messages.py — 通用对话路径的原生多模态消息构造。
+
+把 MultiModalContext 里的图像构造成 **OpenAI 风格 content 数组**(text + image_url
+data URL),让图像在普通 chat 里也能**原生送达模型**(不再被文本摘要化)。
+
+⚠️ 仅对 **OpenAI 兼容 provider** 安全(它们原样转发 messages)。Gemini 等适配器会对
+``m["content"]`` 做字符串拼接,收到数组会崩——因此默认**关闭**,需 OpenAI 兼容主链
+且显式开启 ``GALAXY_NATIVE_MM_CHAT=1`` 才生效。关闭时返回纯文本,行为与原先一致。
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, List, Union
+
+
+def native_mm_enabled() -> bool:
+    return os.getenv("GALAXY_NATIVE_MM_CHAT", "0").strip().lower() in ("1", "true", "yes", "on")
+
+
+def build_user_message_content(text: str, multimodal_context: Any) -> Union[str, List[dict]]:
+    """有图像且启用时返回 OpenAI content 数组;否则返回纯文本 ``text``。"""
+    if not native_mm_enabled() or multimodal_context is None:
+        return text
+    images = getattr(multimodal_context, "images", None) or []
+    if not images:
+        return text
+    content: List[dict] = [{"type": "text", "text": text}]
+    for im in images[:4]:  # 最多 4 张,控成本
+        mime = getattr(im, "mime", "image/jpeg") or "image/jpeg"
+        data = getattr(im, "data", "") or ""
+        if data:
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{data}"},
+            })
+    return content if len(content) > 1 else text

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -4258,6 +4258,7 @@ class OpenClawd:
                         runtime_attachment_session_id=runtime_attachment_session_id or "",
                         device_id=device_id or "",
                         context=context or [],
+                        multimodal_context=multimodal_context,
                     )
                     api_dict = kernel_result.to_api_dict()
                     mode = kernel_result.mode


### PR DESCRIPTION
## ① 通用对话路径的原生多模态(最后一公里)

让模型在**普通聊天**里也能原生"看到"图像(之前只走文本摘要)。

- `core/agent/multimodal_messages.py`:`build_user_message_content()` 把 `MultiModalContext` 的图像构造成 **OpenAI 风格 content 数组**(text + image_url data URL),图像**原生送达模型**。multi_llm 的 OpenAI 兼容适配器原样转发 messages,故无需改 router。
- 把 `multimodal_context` 顺着 `AgentKernel.handle_message → _process → _handle_chat → _fallback_chat` 透传(全是可选附加参数);OpenClawd 把请求的 multimodal_context 传给 kernel。

**安全**:**默认关**(`GALAXY_NATIVE_MM_CHAT=1` 开)。content 数组会让非 OpenAI 适配器(如 Gemini 适配器对 content 做字符串拼接)崩,且本环境无法对真 provider 验证——故 opt-in、需 OpenAI 兼容主链。关闭时行为与改动前**逐字节一致**。

**实测**:off→纯文本;on+图→`[{type:text},{type:image_url,...}]`;无图/无上下文→优雅退回文本。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_