### PR TITLE
feat(memory): multilingual embedder + clone-stage 模型预下载 & 国内镜像换源

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,14 @@ KB_VECTOR_BACKEND=auto
 # all-MiniLM 偏英文、跨语言仅 ~50% recall@1)。首次下 ~470MB(HF);下不动则自动
 # 回退 chroma 默认 all-MiniLM(不崩)。设 "" 或 "default" 直接用 all-MiniLM。
 GALAXY_EMBED_MODEL=paraphrase-multilingual-MiniLM-L12-v2
+# HuggingFace 国内镜像：模型(嵌入器/CLIP/CLAP)下载走 hf-mirror.com，国内可达。
+# install.sh 会在克隆/安装阶段预下载这些模型(scripts/predownload_models.py)，首次运行无需等。
+# 设 GALAXY_HF_MIRROR=0 用 HuggingFace 官方域名；GALAXY_HF_ENDPOINT 可指向自建镜像。
+GALAXY_HF_MIRROR=1
+GALAXY_HF_ENDPOINT=https://hf-mirror.com
+HF_ENDPOINT=https://hf-mirror.com
+# pip 安装换源(被 install.sh 读取)：默认清华镜像；设 "default" 用官方 PyPI。
+GALAXY_PIP_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
 GALAXY_OMNIMEM_DIR=./data/omni_simplemem  # Omni-SimpleMem 持久化目录
 # 跨模态记忆：用户开口时把桌面摄像头/麦克风快照也写进记忆(绑定到该轮对话)。
 # 默认关闭(媒体摄入较重，尤其 omni 后端)；需同时启用桌面感知(GALAXY_DESKTOP_PERCEPTION=1)。

--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,10 @@ GALAXY_SIMPLEMEM_BASE_URL=
 # 向量后端选择(被 "vector" 使用): auto | local | chroma | qdrant
 # auto = 优先 chroma 真语义(需 pip install chromadb)，未装则自动退化 local 关键词。
 KB_VECTOR_BACKEND=auto
+# 文本嵌入模型(chroma)。默认多语言模型,显著改善中英文跨语言召回(eval 实测默认
+# all-MiniLM 偏英文、跨语言仅 ~50% recall@1)。首次下 ~470MB(HF);下不动则自动
+# 回退 chroma 默认 all-MiniLM(不崩)。设 "" 或 "default" 直接用 all-MiniLM。
+GALAXY_EMBED_MODEL=paraphrase-multilingual-MiniLM-L12-v2
 GALAXY_OMNIMEM_DIR=./data/omni_simplemem  # Omni-SimpleMem 持久化目录
 # 跨模态记忆：用户开口时把桌面摄像头/麦克风快照也写进记忆(绑定到该轮对话)。
 # 默认关闭(媒体摄入较重，尤其 omni 后端)；需同时启用桌面感知(GALAXY_DESKTOP_PERCEPTION=1)。

--- a/core/memory/_hf_mirror.py
+++ b/core/memory/_hf_mirror.py
@@ -1,0 +1,67 @@
+"""
+core/memory/_hf_mirror.py
+=========================
+国内可达的 HuggingFace 镜像 / pip 源辅助。
+
+为什么需要它
+-----------
+记忆/跨模态用到的嵌入模型(paraphrase-multilingual-MiniLM-L12-v2、CLIP、CLAP 等)
+首次需要从 HuggingFace 下载。HuggingFace 官方域名在国内常常连不上，导致模型下不动、
+记忆语义检索退化到关键词。`huggingface_hub` / `sentence-transformers` 都从
+**os.environ["HF_ENDPOINT"]** 读取下载端点，所以只要在 import 这些库之前把它指到国内
+镜像(https://hf-mirror.com)，下载就能在国内正常完成。
+
+注意：本仓库运行时 **不会** 把 .env 自动注入 os.environ(unified_config 只读进自己的
+dict)，因此这里必须由代码主动 setdefault，而不能只靠 .env。
+
+行为
+----
+- 默认开启镜像(GALAXY_HF_MIRROR 不显式设为 0/false/no)。
+- 已经显式设过 HF_ENDPOINT 的，尊重用户设置、不覆盖(setdefault)。
+- 镜像地址可用 GALAXY_HF_ENDPOINT 覆盖,默认 https://hf-mirror.com。
+- 设 GALAXY_HF_MIRROR=0 可彻底关闭(回到 HuggingFace 官方域名)。
+
+这个函数是幂等的，可在任意模型加载点调用前安全多次调用。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger("Galaxy.Memory.HFMirror")
+
+_DEFAULT_MIRROR = "https://hf-mirror.com"
+_applied = False
+
+
+def ensure_hf_mirror() -> str | None:
+    """在加载任何 HF 模型前调用：把 HF_ENDPOINT 指向国内镜像。
+
+    Returns
+    -------
+    生效的镜像地址(str)，或 None 表示镜像被显式关闭/已被用户接管。
+    """
+    global _applied
+
+    flag = os.getenv("GALAXY_HF_MIRROR", "1").strip().lower()
+    if flag in ("0", "false", "no", "off", ""):
+        return None  # 用户显式关闭镜像
+
+    endpoint = os.getenv("GALAXY_HF_ENDPOINT", _DEFAULT_MIRROR).strip() or _DEFAULT_MIRROR
+
+    # 用户已显式设置 HF_ENDPOINT(例如指向自建镜像) → 尊重，不覆盖。
+    existing = os.environ.get("HF_ENDPOINT", "").strip()
+    if existing:
+        if not _applied:
+            logger.info("HF_ENDPOINT 已由环境设置: %s(沿用，不覆盖)", existing)
+            _applied = True
+        return existing
+
+    os.environ["HF_ENDPOINT"] = endpoint
+    # huggingface_hub 的部分旧版本读 HF_MIRROR；一并兜底。
+    os.environ.setdefault("HF_MIRROR", endpoint)
+    if not _applied:
+        logger.info("已启用 HuggingFace 国内镜像 HF_ENDPOINT=%s(设 GALAXY_HF_MIRROR=0 关闭)", endpoint)
+        _applied = True
+    return endpoint

--- a/core/vector_backend.py
+++ b/core/vector_backend.py
@@ -138,6 +138,13 @@ class _ChromaBackend:
             _model = os.getenv("GALAXY_EMBED_MODEL", "paraphrase-multilingual-MiniLM-L12-v2").strip()
             if _model and _model.lower() not in ("default", "all-minilm-l6-v2"):
                 try:
+                    # 国内可达：加载嵌入模型前把 HF_ENDPOINT 指向镜像(hf-mirror.com)，
+                    # 否则多语言模型在国内常常下不动。设 GALAXY_HF_MIRROR=0 可关闭。
+                    try:
+                        from core.memory._hf_mirror import ensure_hf_mirror
+                        ensure_hf_mirror()
+                    except Exception:
+                        pass
                     from chromadb.utils import embedding_functions
                     _kwargs["embedding_function"] = embedding_functions.SentenceTransformerEmbeddingFunction(
                         model_name=_model

--- a/core/vector_backend.py
+++ b/core/vector_backend.py
@@ -130,10 +130,22 @@ class _ChromaBackend:
 
             os.makedirs(self._persist_dir, exist_ok=True)
             self._client = chromadb.PersistentClient(path=self._persist_dir)
-            self._collection = self._client.get_or_create_collection(
-                name=self._collection_name,
-                metadata={"hnsw:space": "cosine"},
-            )
+            # 多语言嵌入器(默认 paraphrase-multilingual-MiniLM-L12-v2)显著改善中英文
+            # 跨语言召回(eval 实测默认 all-MiniLM 偏英文、跨语言仅 ~50% recall@1)。
+            # GALAXY_EMBED_MODEL="" 或 "default" → 用 chroma 默认 all-MiniLM。
+            # 优雅降级链：多语言模型加载失败(如 HF 不可达) → chroma 默认 all-MiniLM。
+            _kwargs = {"name": self._collection_name, "metadata": {"hnsw:space": "cosine"}}
+            _model = os.getenv("GALAXY_EMBED_MODEL", "paraphrase-multilingual-MiniLM-L12-v2").strip()
+            if _model and _model.lower() not in ("default", "all-minilm-l6-v2"):
+                try:
+                    from chromadb.utils import embedding_functions
+                    _kwargs["embedding_function"] = embedding_functions.SentenceTransformerEmbeddingFunction(
+                        model_name=_model
+                    )
+                    logger.info("ChromaDB 使用多语言嵌入器: %s", _model)
+                except Exception as _ef_err:
+                    logger.warning("多语言嵌入器 %s 加载失败(%s)，回退 chroma 默认 all-MiniLM", _model, _ef_err)
+            self._collection = self._client.get_or_create_collection(**_kwargs)
             self._ready = True
             logger.info(f"ChromaDB 已连接，集合: {self._collection_name}，目录: {self._persist_dir}")
             return True

--- a/install.sh
+++ b/install.sh
@@ -102,20 +102,48 @@ install_deps() {
 
     source .venv/bin/activate
 
+    # ── pip 换源（国内可达）──
+    # 默认走清华镜像；境外/自建可用 GALAXY_PIP_INDEX 覆盖，或设为 "default"/"" 用官方 PyPI。
+    PIP_INDEX="${GALAXY_PIP_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}"
+    PIP_ARGS=()
+    if [[ -n "$PIP_INDEX" && "$PIP_INDEX" != "default" ]]; then
+        PIP_HOST="$(echo "$PIP_INDEX" | sed -E 's#^https?://([^/]+)/.*#\1#')"
+        PIP_ARGS=(-i "$PIP_INDEX" --trusted-host "$PIP_HOST")
+        info "pip 使用镜像: $PIP_INDEX  (设 GALAXY_PIP_INDEX=default 用官方 PyPI)"
+    fi
+
     info "Upgrading pip"
-    pip install --quiet --upgrade pip
+    pip install --quiet "${PIP_ARGS[@]}" --upgrade pip
 
     info "Installing core dependencies (this may take a few minutes)"
-    pip install --quiet -r requirements.txt
+    pip install --quiet "${PIP_ARGS[@]}" -r requirements.txt
 
     ok "Python dependencies installed"
 
     # Voice dependencies (required)
     info "Installing voice dependencies (required)"
-    pip install --quiet pvporcupine webrtcvad faster-whisper pyaudio 2>/dev/null && \
+    pip install --quiet "${PIP_ARGS[@]}" pvporcupine webrtcvad faster-whisper pyaudio 2>/dev/null && \
         ok "Voice dependencies installed" || \
         warn "Voice dependencies failed — microphone support may be limited"
 
+    echo ""
+}
+
+# ── Phase 2b: Pre-download Models (clone-stage) ──
+# 把记忆/跨模态用到的 HF 嵌入模型在安装阶段就拉到本地缓存，首次运行无需等下载。
+# 走国内 HF 镜像(hf-mirror.com)；下载失败只告警，不中断安装。
+predownload_models() {
+    info "Phase 2b: Pre-downloading models (HF mirror, clone-stage)"
+    source .venv/bin/activate
+    # HF 镜像默认开启(由 core.memory._hf_mirror / predownload 脚本读取)
+    export GALAXY_HF_MIRROR="${GALAXY_HF_MIRROR:-1}"
+    export GALAXY_HF_ENDPOINT="${GALAXY_HF_ENDPOINT:-https://hf-mirror.com}"
+    # 让预下载读取已生成的 .env 里的 GALAXY_EMBED_MODEL（若 Phase 3 先于此运行则尊重）
+    if [[ -f ".env" ]]; then
+        EMBED_FROM_ENV="$(grep -E '^GALAXY_EMBED_MODEL=' .env | head -1 | cut -d= -f2-)"
+        [[ -n "$EMBED_FROM_ENV" ]] && export GALAXY_EMBED_MODEL="$EMBED_FROM_ENV"
+    fi
+    python3 scripts/predownload_models.py || warn "模型预下载有项目失败(运行时会自动回退，不影响启动)"
     echo ""
 }
 
@@ -180,6 +208,14 @@ OLLAMA_PRIORITY=1
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
+# ── Memory / Embeddings ──
+# 多语言文本嵌入器：显著改善中英文跨语言召回(默认 all-MiniLM 偏英文)。
+GALAXY_EMBED_MODEL=paraphrase-multilingual-MiniLM-L12-v2
+# HuggingFace 国内镜像：模型下载走 hf-mirror.com(设 GALAXY_HF_MIRROR=0 用官方域名)。
+GALAXY_HF_MIRROR=1
+GALAXY_HF_ENDPOINT=https://hf-mirror.com
+HF_ENDPOINT=https://hf-mirror.com
+
 # ── Electron ──
 ELECTRON_START=true
 
@@ -242,6 +278,7 @@ main() {
     check_env
     install_deps
     setup_env
+    predownload_models
     setup_data_dir
     verify
 }

--- a/scripts/predownload_models.py
+++ b/scripts/predownload_models.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+scripts/predownload_models.py
+=============================
+克隆/安装阶段预下载模型 —— 把记忆/跨模态用到的 HuggingFace 嵌入模型在安装时就拉到本地
+缓存(~/.cache/huggingface)，这样首次运行不必等下载、断网也能用真语义检索。
+
+设计原则
+--------
+1. **国内可达**：下载前先把 HF_ENDPOINT 指向镜像(默认 https://hf-mirror.com)，
+   走 core.memory._hf_mirror.ensure_hf_mirror()。可用 GALAXY_HF_MIRROR=0 关闭。
+2. **优雅**：任何模型下载失败(无网络/依赖缺失)都只 WARN，**绝不让安装中断**
+   (退出码恒为 0)；运行时仍可懒加载或回退。
+3. **按需**：只下当前配置真正会用到的模型——
+     - 文本嵌入：GALAXY_EMBED_MODEL(默认 paraphrase-multilingual-MiniLM-L12-v2)
+     - 跨模态(若该 provider 存在且 GALAXY_MEMORY_MEDIA 开)：CLIP / CLAP
+
+用法
+----
+    python scripts/predownload_models.py            # 跟随 .env / 默认值
+    GALAXY_EMBED_MODEL="" python scripts/...         # 跳过多语言、用 chroma 默认
+    GALAXY_HF_MIRROR=0 python scripts/...            # 用 HuggingFace 官方域名
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# 让 `python scripts/predownload_models.py` 能 import core.*
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _log(level: str, msg: str) -> None:
+    colors = {"INFO": "\033[0;34m", "OK": "\033[0;32m", "WARN": "\033[1;33m", "ERR": "\033[0;31m"}
+    nc = "\033[0m"
+    print(f"{colors.get(level, '')}[{level}]{nc} {msg}", flush=True)
+
+
+def _apply_mirror() -> None:
+    try:
+        from core.memory._hf_mirror import ensure_hf_mirror
+        ep = ensure_hf_mirror()
+        if ep:
+            _log("INFO", f"HuggingFace 端点: {ep}")
+        else:
+            _log("INFO", "HF 镜像已关闭(GALAXY_HF_MIRROR=0)，使用官方域名")
+    except Exception as exc:  # pragma: no cover - 极端环境
+        _log("WARN", f"镜像设置跳过: {exc}")
+
+
+def _predownload_embed() -> bool:
+    """预下载文本嵌入模型(sentence-transformers)。返回是否成功。"""
+    model = os.getenv("GALAXY_EMBED_MODEL", "paraphrase-multilingual-MiniLM-L12-v2").strip()
+    if not model or model.lower() in ("default", "all-minilm-l6-v2"):
+        _log("INFO", "GALAXY_EMBED_MODEL 为默认/空，跳过多语言嵌入器预下载(将用 chroma 内置 all-MiniLM)")
+        return True
+    try:
+        from sentence_transformers import SentenceTransformer  # type: ignore
+    except Exception as exc:
+        _log("WARN", f"sentence-transformers 未安装({exc})，跳过嵌入器预下载；运行时缺则自动回退关键词后端")
+        return False
+    try:
+        _log("INFO", f"预下载文本嵌入模型: {model}(首次约 ~470MB)…")
+        SentenceTransformer(model)  # 触发下载并落到 HF 缓存
+        _log("OK", f"嵌入模型已就绪: {model}")
+        return True
+    except Exception as exc:
+        _log("WARN", f"嵌入模型 {model} 下载失败({exc})；运行时会自动回退 chroma 默认 all-MiniLM，不影响启动")
+        return False
+
+
+def _predownload_crossmodal() -> None:
+    """若跨模态 provider 存在且启用，预下载 CLIP/CLAP。全程 best-effort。"""
+    if os.getenv("GALAXY_MEMORY_MEDIA", "0").strip().lower() in ("0", "false", "no", ""):
+        return  # 跨模态记忆未开，无需预下载
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    # CLIP(图像↔文本)
+    if os.path.exists(os.path.join(here, "core", "memory", "clip_provider.py")):
+        model = os.getenv("GALAXY_CLIP_MODEL", "clip-ViT-B-32").strip()
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+            _log("INFO", f"预下载 CLIP 模型: {model}…")
+            SentenceTransformer(model)
+            _log("OK", f"CLIP 模型已就绪: {model}")
+        except Exception as exc:
+            _log("WARN", f"CLIP 模型下载失败({exc})；运行时懒加载，跨模态图像检索缺失时降级")
+    # CLAP(音频↔文本)
+    if os.path.exists(os.path.join(here, "core", "memory", "clap_provider.py")):
+        model = os.getenv("GALAXY_CLAP_MODEL", "laion/clap-htsat-unfused").strip()
+        try:
+            from transformers import ClapModel, ClapProcessor  # type: ignore
+            _log("INFO", f"预下载 CLAP 模型: {model}…")
+            ClapModel.from_pretrained(model)
+            ClapProcessor.from_pretrained(model)
+            _log("OK", f"CLAP 模型已就绪: {model}")
+        except Exception as exc:
+            _log("WARN", f"CLAP 模型下载失败({exc})；运行时懒加载，跨模态音频检索缺失时降级")
+
+
+def main() -> int:
+    _log("INFO", "模型预下载开始(失败只告警，不会中断安装)")
+    _apply_mirror()
+    _predownload_embed()
+    _predownload_crossmodal()
+    _log("OK", "模型预下载阶段结束")
+    return 0  # 永远成功 —— 安装不应因模型下载失败而中断
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -34,5 +34,12 @@ if [[ ! -f ".env" ]]; then
     exit 0
 fi
 
+# Export HF mirror vars from .env so model downloads honor the user's setting.
+# (Runtime reads HF_ENDPOINT from os.environ; .env is otherwise not auto-exported.)
+for _k in HF_ENDPOINT GALAXY_HF_MIRROR GALAXY_HF_ENDPOINT GALAXY_EMBED_MODEL GALAXY_PIP_INDEX; do
+    _v="$(grep -E "^${_k}=" .env 2>/dev/null | head -1 | cut -d= -f2-)"
+    [[ -n "$_v" ]] && export "${_k}=${_v}"
+done
+
 # Delegate to main.py (unified entrypoint)
 python main.py "$@"


### PR DESCRIPTION
## 背景

Memory recall eval 实测：ChromaDB 默认嵌入器 `all-MiniLM-L6-v2` 偏英文，**中英文跨语言召回仅 ~50% recall@1**。换多语言模型可直击这个短板——但多语言模型/CLIP/CLAP 首次都要从 HuggingFace 下载，官方域名在国内常连不上。本 PR 一并解决「换更好的嵌入器」+「让它在国内的克隆/安装阶段就能正常下好」。

## 改动

### 1. 多语言嵌入器
- `core/vector_backend.py`：`GALAXY_EMBED_MODEL`(默认 `paraphrase-multilingual-MiniLM-L12-v2`)经 chroma `SentenceTransformerEmbeddingFunction` 接入。设 `""`/`"default"` 回到 all-MiniLM。

### 2. 克隆/安装阶段预下载模型（不拖到运行时）
- `scripts/predownload_models.py`：装完依赖后立即把嵌入器(+ 跨模态开启时的 CLIP/CLAP)拉到本地 HF 缓存。任何下载失败只 WARN、**退出码恒 0**，绝不中断安装。
- `install.sh` 新增 **Phase 2b** 调用它。

### 3. 全面换国内源
- **pip**：`install.sh` 默认清华镜像，`GALAXY_PIP_INDEX` 可覆盖、设 `default` 用官方 PyPI。
- **HuggingFace**：新增 `core/memory/_hf_mirror.ensure_hf_mirror()`，加载任何模型前把 `HF_ENDPOINT` 指向 `hf-mirror.com`；`vector_backend` 加载嵌入器前调用。`GALAXY_HF_MIRROR=0` 用官方域名；已显式设 `HF_ENDPOINT` 则尊重不覆盖。
- `start.sh`：把 `.env` 里 HF/EMBED 变量 export 进进程环境（运行时从 `os.environ` 读，`.env` 否则不自动注入），让 `.env` 开关真正生效。
- `.env.example` + `install.sh` 生成的 `.env` 同步补充 `GALAXY_HF_MIRROR` / `GALAXY_HF_ENDPOINT` / `HF_ENDPOINT` / `GALAXY_PIP_INDEX`。

## 优雅降级链（已验证不崩）
```
多语言模型下载失败 → chroma 默认 all-MiniLM → 关键词后端
镜像三态：默认生效 / GALAXY_HF_MIRROR=0 关闭 / 显式 HF_ENDPOINT 被尊重
```

## 验证
- 镜像三态单测通过（默认→hf-mirror.com、关闭→官方域名、显式→尊重）。
- 预下载脚本在沙箱无网络下：走 hf-mirror.com → 优雅 WARN → 退出 0（安装不中断）。
- bash/py 语法全过。

## 诚实说明 ⚠️
当前沙箱访问不了 HuggingFace（连 hf-mirror.com 也被网络策略挡），所以本地只验证了「走镜像 + 失败优雅回退」这条路径。**真实的模型下载与跨语言召回提升需在能联网的国内环境（你本机克隆/安装阶段）首次执行 `install.sh` 时生效**，下完缓存到本地后断网照常用。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b