### PR TITLE
feat(gateway): 三仓打通 — route ALL WearOS command-channel messages into v2 (voice/human_input/phase/devices)

### DIFF
--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -717,6 +717,50 @@ async def handle_command(connection_id: str, aip_msg):
             }
             await connection_manager.send_message(connection_id, response)
             return
+        elif command_text == "voice_query":
+            # 三仓打通：WearOS/手表语音 (sendVoiceQuery → command="voice_query"
+            # {text:<转写>}) 是自然语言查询，应进 AI 母体走 agent 主链——而非被当成
+            # 设备命令路由(那样转写文本永远到不了大脑)。经 canonical 运行时入口
+            # DesktopPresenceRuntime.handle_request(source="wear_voice") 处理，顺带
+            # 推进三态(手表据此显示 SILENT/LIMINAL/MANIFEST)。
+            transcript = str(_payload.get("text") or _payload.get("transcript") or "").strip()
+            if not transcript:
+                result = {"success": False, "error": "empty voice transcript"}
+            else:
+                try:
+                    from core.desktop_presence_runtime import get_desktop_presence_runtime
+                    runtime = get_desktop_presence_runtime()
+                    rt = await runtime.handle_request(
+                        message=transcript,
+                        source="wear_voice",
+                        device_id=device_id,
+                        session_id=_payload.get("session_id") or None,
+                    )
+                    reply = str(rt.get("response") or "")
+                    result = {
+                        "success": bool(rt.get("success", True)),
+                        "response": reply,
+                        "text": reply,
+                        "intent": rt.get("intent", "chat"),
+                        "runtime_session_id": rt.get("runtime_session_id", ""),
+                    }
+                except Exception as _vq_err:
+                    logger.error("voice_query routing failed: %s", _vq_err)
+                    result = {"success": False, "error": "voice query routing failed"}
+            response = {
+                "version": "3.0",
+                "message_id": str(uuid.uuid4()),
+                "correlation_id": aip_msg.message_id,
+                "type": MessageType.COMMAND_RESULT.value,
+                "device_id": aip_msg.device_id,
+                "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+                "success": result.get("success", False),
+                # 手表 AIPClient 读 command_result 的 json["data"]；同时保留 payload 约定
+                "data": result,
+                "payload": result,
+            }
+            await connection_manager.send_message(connection_id, response)
+            return
 
         # PR-OPENCLAWD-ROUTING-AUTHORITY: route through OpenClawd instead of
         # directly calling device_router.route_task().

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -680,7 +680,8 @@ async def handle_command(connection_id: str, aip_msg):
         device_id = aip_msg.device_id
 
         # PR-DEVICE-LIST-QUERY: Short-circuit for device status queries
-        if command_text == "query_device_list":
+        # ("query_devices" is the WearOS AIPClient variant of the same query.)
+        if command_text in ("query_device_list", "query_devices"):
             try:
                 result = device_router.get_device_status()
             except Exception as _dev_err:
@@ -756,6 +757,94 @@ async def handle_command(connection_id: str, aip_msg):
                 "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
                 "success": result.get("success", False),
                 # 手表 AIPClient 读 command_result 的 json["data"]；同时保留 payload 约定
+                "data": result,
+                "payload": result,
+            }
+            await connection_manager.send_message(connection_id, response)
+            return
+        elif command_text == "phase_report":
+            # WearOS sendPhaseReport → command="phase_report" {phase, device}.
+            # 手表上报自身三态相位。v2 暂无 canonical 设备相位库,故记入
+            # registered_devices 镜像条目(供 operator 面板观测)并 ack;关键是不再被
+            # 误当设备命令路由(那样会进 send_gateway_command 当作设备动作失败)。
+            reported_phase = str(_payload.get("phase") or "").strip()
+            try:
+                from core.routes._shared import registered_devices as _reg
+                if device_id in _reg and reported_phase:
+                    _reg[device_id]["reported_phase"] = reported_phase  # COMPAT_MIRROR_WRITE
+                    _reg[device_id]["reported_phase_at"] = (
+                        datetime.now(timezone.utc).isoformat()
+                    )
+            except Exception as _pr_err:
+                logger.debug("phase_report record skipped: %s", _pr_err)
+            logger.info("📲 设备相位上报: device=%s phase=%s", device_id, reported_phase)
+            result = {"success": bool(reported_phase), "phase": reported_phase}
+            response = {
+                "version": "3.0",
+                "message_id": str(uuid.uuid4()),
+                "correlation_id": aip_msg.message_id,
+                "type": MessageType.COMMAND_RESULT.value,
+                "device_id": aip_msg.device_id,
+                "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+                "success": result["success"],
+                "data": result,
+                "payload": result,
+            }
+            await connection_manager.send_message(connection_id, response)
+            return
+        elif command_text == "human_input":
+            # WearOS sendHumanInput → command="human_input"
+            # {decision_id, selected_option?, voice_input?}. 人在回路(HITL)的决策回复。
+            # 注：v2 当前发决策(android_bridge decision_request)是 fire-and-forget——
+            # decision_id 未登记,没有 pending-decision 注册表可按 decision_id 关联解析
+            # (更深的架构缺口,见 PR 说明)。在补齐注册表之前,这里把人类回复(语音/所选项)
+            # 作为一条人类输入送进认知闭环 handle_request(source="wear_decision"),确保用户
+            # 意图抵达大脑、而非像此前那样被当设备命令丢弃。
+            decision_id = str(_payload.get("decision_id") or "")
+            voice_input = str(_payload.get("voice_input") or "").strip()
+            selected = str(_payload.get("selected_option") or "").strip()
+            human_msg = voice_input or selected
+            if not human_msg:
+                result = {"success": False, "error": "empty human input", "decision_id": decision_id}
+            else:
+                try:
+                    from core.desktop_presence_runtime import get_desktop_presence_runtime
+                    runtime = get_desktop_presence_runtime()
+                    rt = await runtime.handle_request(
+                        message=human_msg,
+                        source="wear_decision",
+                        device_id=device_id,
+                        session_id=_payload.get("session_id") or None,
+                        context=(
+                            [{
+                                "role": "system",
+                                "content": (
+                                    f"human_decision_reply decision_id={decision_id} "
+                                    f"selected_option={selected}"
+                                ),
+                            }]
+                            if decision_id else None
+                        ),
+                    )
+                    reply = str(rt.get("response") or "")
+                    result = {
+                        "success": bool(rt.get("success", True)),
+                        "response": reply,
+                        "text": reply,
+                        "decision_id": decision_id,
+                        "runtime_session_id": rt.get("runtime_session_id", ""),
+                    }
+                except Exception as _hi_err:
+                    logger.error("human_input routing failed: %s", _hi_err)
+                    result = {"success": False, "error": "human input routing failed", "decision_id": decision_id}
+            response = {
+                "version": "3.0",
+                "message_id": str(uuid.uuid4()),
+                "correlation_id": aip_msg.message_id,
+                "type": MessageType.COMMAND_RESULT.value,
+                "device_id": aip_msg.device_id,
+                "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+                "success": result.get("success", False),
                 "data": result,
                 "payload": result,
             }


### PR DESCRIPTION
## 三仓打通：手表 command 通道全部接对（voice_query / human_input / phase_report / query_devices）

### 问题（深挖手表 `sendCommand` 全量发现）
WearOS 经 `AIPClient.sendCommand(...)` 上行 **4** 种命令，全部落到 v2 `handle_command` 的**通用分支** → `openclawd.send_gateway_command()`，被当作**设备命令**构造 TaskEnvelope 路由给设备（命令名是字面量、设备根本不认）→ 功能集体失效。v2 此前只显式处理 `query_device_list`/`query_device_status`。

逐一补齐（按价值与可正确性）：

| 命令 | 含义 | 修复 |
|---|---|---|
| `voice_query` | 口语转写（自然语言查询） | 经 canonical `DesktopPresenceRuntime.handle_request(source="wear_voice")` 进 AI 主链，顺带驱动三态；回复回填 `data`/`payload` |
| `human_input` | 人在回路决策回复 `{decision_id, selected_option?, voice_input?}` | 把人类回复（语音/所选项）送进认知闭环 `handle_request(source="wear_decision")`，确保意图抵达大脑 |
| `phase_report` | 手表上报自身三态相位 | 记入 `registered_devices` 镜像（供 operator 面板观测）并 ack；不再被误路由 |
| `query_devices` | 手表版设备列表查询 | 与既有 `query_device_list` 等价 → 合并到同一短路分支（命名漂移修复） |

好处：手表语音真正进大脑并*驱动*三态（与 #1358 的三态*回传*合起来双向闭环）；HITL 回复与设备查询不再石沉大海。

### 已知更深缺口（诚实标注，非本次造轮子范围）
v2 发决策（`android_bridge` 的 `decision_request`）是 **fire-and-forget**——`decision_id = uuid4()` 内联生成、**从不登记**（`android_bridge.py:1104-1112`），没有 pending-decision 注册表可按 `decision_id` 精确关联解析。因此 `human_input` 目前**无法**精确续接原决策；在补齐注册表（含超时/续接语义，属较大特性）之前，把人类回复作为一条人类输入送进认知闭环，是确保意图不丢失的**最佳可用解**。这点已在代码注释与此处明确标注。

### 验证
四路命令端到端（mock 运行时 / 设备路由 / `registered_devices`）：`query_devices` 返回设备列表、`phase_report` 记录相位并 ack、`voice_query`/`human_input`（含空输入）正确进 `handle_request` 并回填 `data`——**全过**；`py_compile` 通过。

### 诚实说明 ⚠️
未做真机端到端（无手表 + 常驻网关，沙箱缺 fastapi；handler 经 stub 注入跑真实逻辑）。回复信封沿用 `command_result` 约定并补 `data` 字段对齐手表 `json["data"]` 读取。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b