### PR TITLE
fix(presence): 三态回传打通 — push tri-state phase to WearOS connections

### DIFF
--- a/core/cross_device_sync.py
+++ b/core/cross_device_sync.py
@@ -199,6 +199,16 @@ async def _async_push_phase_to_all_devices(
         "phase": new_phase,
     }
 
+    # PR-WEAR-PHASE-SYNC: also push to WearOS gateway connections.
+    # WearOS registers via websocket_handler.handle_register → connection_manager
+    # (NOT android_bridge._devices), so the android-only loop below misses it.
+    # The same state_event msg is reused; the watch parses payload.to_phase.
+    # Done first so it runs even when there are zero android_bridge devices.
+    try:
+        await _push_phase_to_wearos_devices(msg)
+    except Exception as _wear_err:  # noqa: BLE001
+        logger.debug("CrossDeviceSync: wearos phase push failed: %s", _wear_err)
+
     # Collect connected devices
     connected: List[Tuple[str, Any]] = []
     for device_id, device in _bridge._devices.items():
@@ -238,6 +248,44 @@ async def _async_push_phase_to_all_devices(
         "CrossDeviceSync: phase %s→%s pushed to %d/%d device(s) "
         "in %.1fms (adaptive concurrent)",
         old_phase, new_phase, sent, len(connected), total_ms,
+    )
+
+
+async def _push_phase_to_wearos_devices(msg: Dict[str, Any]) -> None:
+    """PR-WEAR-PHASE-SYNC: push the phase state_event to connected WearOS watches.
+
+    WearOS connections live in the gateway ``connection_manager`` (registered via
+    ``handle_register``), not in ``android_bridge._devices``.  We identify watches
+    by their raw registered device_type (``wear_os``/``wearos``/``watch``/...) and
+    deliver via ``connection_manager.send_to_device`` (which has its own UCM
+    fallback).  Reuses the same ``state_event`` message Android receives.
+    """
+    from galaxy_gateway.websocket_handler import connection_manager  # noqa: PLC0415
+    from galaxy_gateway.android.handlers.wearos_sync import is_wearos_device  # noqa: PLC0415
+
+    try:
+        from core.routes._shared import registered_devices  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        registered_devices = {}
+
+    device_ids = await connection_manager.get_connected_devices()
+    wear_ids = [
+        did for did in device_ids
+        if is_wearos_device(str((registered_devices.get(did) or {}).get("device_type", "")))
+    ]
+    if not wear_ids:
+        return
+
+    sent = 0
+    for did in wear_ids:
+        try:
+            await connection_manager.send_to_device(did, msg)
+            sent += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("CrossDeviceSync: wear push to %s failed: %s", did, exc)
+    logger.info(
+        "CrossDeviceSync: phase %s pushed to %d/%d WearOS device(s)",
+        msg.get("event_action", ""), sent, len(wear_ids),
     )
 
 


### PR DESCRIPTION
## 三态回传打通（双仓修复 · v2 侧 1/2）

### 问题（Explore agent 确认的目标定向缺口）
桌面三态推进（silent→liminal→manifest）时，`emit_cross_device_phase_sync` → `_async_push_phase_to_all_devices` **只遍历 `android_bridge._devices`**（`cross_device_sync.py:204`）。而 WearOS 经 `websocket_handler.handle_register` → `connection_manager`/UCM 注册，**从不进入 `android_bridge._devices`** → 手表永远收不到三态推送。专用的 `handle_wearos_state_sync` 存在但**零调用点**（死代码），且它发的是手表读不懂的压缩格式 `{t,cat,act}`。

结果：手表的三态环形同虚设——配套 PR（WearOS 语音 #1357）让语音去*驱动* v2 三态，但手表*看不到*它回来。

### 改动（v2 侧）
新增 `_push_phase_to_wearos_devices`：按 `registered_devices` 里的**原始** device_type（`wear_os`/`wearos`/`watch`/...，经 `is_wearos_device` 判定）识别手表，经 `connection_manager.send_to_device`（自带 UCM fallback）投递**与 Android 相同的 `state_event` 消息**。在 android 收集之前调用，确保零 android 设备时也能推给手表。失败降级、不阻塞。

不发明新格式——配套手表侧 PR 让 `handleStateEvent` 兼容这个 `state_event`（读 `payload.to_phase`）。

### 配套
galaxy-wearos PR（分支 `claude/v2-ai-wakeup-debug-i2csu7`）：手表解析 V2 `state_event` 格式。两个 PR 需一起合。

### 验证
mock `connection_manager` + `registered_devices`：仅 WearOS 设备（`wear_os`/`watch`）被定向、`android_phone` 被排除、phase 透传正确；`py_compile` 通过。

### 诚实说明 ⚠️
未做真机端到端（无手表+常驻网关，沙箱缺 fastapi，逻辑经 stub 注入验证）。device_type 识别依赖 `registered_devices` 的原始类型镜像；若某些手表注册时 device_type 不在 `is_wearos_device` 集合内，需相应扩充该集合。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_