### PR TITLE
feat(hitl): close the human-in-the-loop decision loop (Approach A, bounded blocking await)

### DIFF
--- a/core/interaction/pending_decision_registry.py
+++ b/core/interaction/pending_decision_registry.py
@@ -1,0 +1,453 @@
+"""
+core/interaction/pending_decision_registry.py
+==============================================
+PR-HITL: Human-in-the-Loop pending-decision registry (bounded blocking await).
+
+Why this exists
+---------------
+V2 could *emit* a ``decision_request`` to devices (``android_bridge.
+push_decision_to_wearos``) and WearOS could *reply* (``human_input`` command),
+but the two ends were never connected: the ``decision_id`` was generated and
+discarded, there was no registry keyed by it, and no agent suspend/resume
+primitive — so a human reply could not be correlated back to whatever was
+asking.  This module closes that loop.
+
+Model (Approach A — bounded blocking await)
+-------------------------------------------
+The cognitive loop asks a question via :func:`request_human_decision`, which:
+
+1. mints a ``decision_id`` and registers a :class:`PendingDecision` (holding an
+   :class:`asyncio.Future` + the original options/context/timeout policy),
+2. emits the ``decision_request`` to the target devices (caller-supplied emit
+   callback — keeps this module transport-agnostic),
+3. ``await``\\s the future with a bounded timeout (default 60 s).
+
+When the device replies, the gateway calls :meth:`PendingDecisionRegistry.resolve`
+(``decision_id`` → choice), which resolves the future; the asking coroutine
+resumes **in its original context**.  No new suspend/resume machinery is needed
+— this mirrors the existing :mod:`core.task_envelope_lifecycle_registry` pattern
+which already blocks a coroutine awaiting a device task result.
+
+Composite timeout fallback (依情况)
+-----------------------------------
+On timeout the outcome is resolved per the decision's :class:`OnTimeout` policy,
+which is **chosen per decision** (composite, not one-size-fits-all):
+
+* ``DEFAULT_OPTION`` — resolve to the pre-declared ``default_option``.
+* ``CANCEL``         — abort; the asker should not proceed.
+* ``PROCEED``        — continue without explicit confirmation.
+
+When the caller does not pin a policy, :func:`derive_default_on_timeout` picks
+one from ``urgency`` (high → CANCEL, normal → DEFAULT_OPTION if a default exists
+else PROCEED, low → PROCEED).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.HITL")
+
+_DEFAULT_TIMEOUT_S: float = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Outcome / policy types
+# ---------------------------------------------------------------------------
+class OnTimeout(str, Enum):
+    """What to do when no human replies before the timeout."""
+    DEFAULT_OPTION = "default_option"  # resolve to the declared default option
+    CANCEL = "cancel"                  # abort — asker must not proceed
+    PROCEED = "proceed"                # continue without confirmation
+
+    @classmethod
+    def from_string(cls, value: Optional[str]) -> Optional["OnTimeout"]:
+        if not value:
+            return None
+        try:
+            return cls(str(value).lower().strip())
+        except ValueError:
+            return None
+
+
+class DecisionStatus(str, Enum):
+    RESOLVED = "resolved"               # a human answered
+    TIMEOUT_DEFAULT = "timeout_default"  # timed out → default option applied
+    TIMEOUT_CANCEL = "timeout_cancel"    # timed out → cancelled
+    TIMEOUT_PROCEED = "timeout_proceed"  # timed out → proceed unconfirmed
+    CANCELLED = "cancelled"             # explicitly cancelled (e.g. shutdown)
+
+
+@dataclass
+class DecisionOutcome:
+    """Result handed back to the asking coroutine."""
+    decision_id: str
+    status: DecisionStatus
+    selected_option: Optional[str] = None
+    voice_input: str = ""
+    source: str = ""
+    elapsed_s: float = 0.0
+
+    @property
+    def timed_out(self) -> bool:
+        return self.status in (
+            DecisionStatus.TIMEOUT_DEFAULT,
+            DecisionStatus.TIMEOUT_CANCEL,
+            DecisionStatus.TIMEOUT_PROCEED,
+        )
+
+    @property
+    def should_proceed(self) -> bool:
+        """True iff the asker may proceed (a choice exists or PROCEED policy)."""
+        if self.status == DecisionStatus.RESOLVED:
+            return True
+        return self.status in (DecisionStatus.TIMEOUT_DEFAULT, DecisionStatus.TIMEOUT_PROCEED)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "status": self.status.value,
+            "selected_option": self.selected_option,
+            "voice_input": self.voice_input,
+            "source": self.source,
+            "elapsed_s": round(self.elapsed_s, 3),
+            "timed_out": self.timed_out,
+            "should_proceed": self.should_proceed,
+        }
+
+
+def derive_default_on_timeout(urgency: str, has_default: bool) -> OnTimeout:
+    """Composite fallback selection when the caller does not pin a policy."""
+    u = (urgency or "normal").lower().strip()
+    if u == "high":
+        # High-urgency / risky actions: never auto-proceed without a human.
+        return OnTimeout.CANCEL
+    if u == "low":
+        return OnTimeout.PROCEED
+    # normal: prefer a safe default option if one was declared, else proceed.
+    return OnTimeout.DEFAULT_OPTION if has_default else OnTimeout.PROCEED
+
+
+# ---------------------------------------------------------------------------
+# Pending record
+# ---------------------------------------------------------------------------
+@dataclass
+class PendingDecision:
+    decision_id: str
+    future: asyncio.Future
+    options: List[str]
+    default_option: Optional[str]
+    on_timeout: OnTimeout
+    urgency: str
+    timeout_s: float
+    session_id: str = ""
+    runtime_session_id: str = ""
+    devices: List[str] = field(default_factory=list)
+    context: Dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+
+    def elapsed(self) -> float:
+        return time.time() - self.created_at
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+class PendingDecisionRegistry:
+    """Singleton registry of in-flight human decisions, keyed by ``decision_id``."""
+
+    def __init__(self) -> None:
+        self._pending: Dict[str, PendingDecision] = {}
+        self._resolved: int = 0
+        self._timed_out: int = 0
+
+    # ── Registration ──────────────────────────────────────────────────────
+    def register(
+        self,
+        *,
+        options: Optional[List[str]] = None,
+        default_option: Optional[str] = None,
+        on_timeout: Optional[OnTimeout] = None,
+        urgency: str = "normal",
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        session_id: str = "",
+        runtime_session_id: str = "",
+        devices: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
+        decision_id: Optional[str] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> PendingDecision:
+        """Register a pending decision and return the record (holding a Future)."""
+        did = decision_id or uuid.uuid4().hex
+        _loop = loop or asyncio.get_event_loop()
+        future: asyncio.Future = _loop.create_future()
+        opts = list(options or [])
+        policy = on_timeout or derive_default_on_timeout(urgency, default_option is not None)
+        record = PendingDecision(
+            decision_id=did,
+            future=future,
+            options=opts,
+            default_option=default_option,
+            on_timeout=policy,
+            urgency=urgency,
+            timeout_s=float(timeout_s),
+            session_id=session_id,
+            runtime_session_id=runtime_session_id,
+            devices=list(devices or []),
+            context=dict(context or {}),
+        )
+        self._pending[did] = record
+        logger.info(
+            "HITL.register | decision_id=%s urgency=%s on_timeout=%s timeout=%.0fs devices=%s",
+            did, urgency, policy.value, timeout_s, record.devices,
+        )
+        return record
+
+    # ── Resolution (called by the gateway when a human replies) ───────────
+    def resolve(
+        self,
+        decision_id: str,
+        *,
+        selected_option: Optional[str] = None,
+        voice_input: str = "",
+        source: str = "",
+    ) -> bool:
+        """Resolve a pending decision with a human reply.
+
+        Returns ``True`` iff a matching pending decision was found and resolved.
+        First reply wins; later replies for the same id are no-ops (e.g. when
+        the same decision was fanned out to several devices).
+        """
+        record = self._pending.pop(decision_id, None)
+        if record is None:
+            logger.debug("HITL.resolve: no pending decision for id=%s", decision_id)
+            return False
+        self._resolved += 1
+        outcome = DecisionOutcome(
+            decision_id=decision_id,
+            status=DecisionStatus.RESOLVED,
+            selected_option=selected_option,
+            voice_input=voice_input,
+            source=source,
+            elapsed_s=record.elapsed(),
+        )
+        logger.info(
+            "HITL.resolve | decision_id=%s option=%r source=%s elapsed=%.2fs",
+            decision_id, selected_option, source, outcome.elapsed_s,
+        )
+        if not record.future.done():
+            record.future.set_result(outcome)
+        return True
+
+    def cancel(self, decision_id: str, reason: str = "cancelled") -> bool:
+        """Explicitly cancel a pending decision (e.g. task aborted / shutdown)."""
+        record = self._pending.pop(decision_id, None)
+        if record is None:
+            return False
+        outcome = DecisionOutcome(
+            decision_id=decision_id,
+            status=DecisionStatus.CANCELLED,
+            source=reason,
+            elapsed_s=record.elapsed(),
+        )
+        if not record.future.done():
+            record.future.set_result(outcome)
+        return True
+
+    # ── Bounded await with composite timeout fallback ─────────────────────
+    async def await_decision(self, record: PendingDecision) -> DecisionOutcome:
+        """Block (bounded) until the decision resolves, applying the timeout policy."""
+        try:
+            return await asyncio.wait_for(record.future, timeout=record.timeout_s)
+        except asyncio.TimeoutError:
+            # Remove if still pending and synthesise the policy-driven outcome.
+            self._pending.pop(record.decision_id, None)
+            self._timed_out += 1
+            outcome = self._timeout_outcome(record)
+            logger.info(
+                "HITL.timeout | decision_id=%s policy=%s → status=%s after %.0fs",
+                record.decision_id, record.on_timeout.value, outcome.status.value,
+                record.timeout_s,
+            )
+            return outcome
+        except asyncio.CancelledError:
+            self._pending.pop(record.decision_id, None)
+            return DecisionOutcome(
+                decision_id=record.decision_id,
+                status=DecisionStatus.CANCELLED,
+                elapsed_s=record.elapsed(),
+            )
+
+    def _timeout_outcome(self, record: PendingDecision) -> DecisionOutcome:
+        if record.on_timeout == OnTimeout.DEFAULT_OPTION:
+            return DecisionOutcome(
+                decision_id=record.decision_id,
+                status=DecisionStatus.TIMEOUT_DEFAULT,
+                selected_option=record.default_option,
+                source="timeout",
+                elapsed_s=record.elapsed(),
+            )
+        if record.on_timeout == OnTimeout.CANCEL:
+            return DecisionOutcome(
+                decision_id=record.decision_id,
+                status=DecisionStatus.TIMEOUT_CANCEL,
+                source="timeout",
+                elapsed_s=record.elapsed(),
+            )
+        return DecisionOutcome(
+            decision_id=record.decision_id,
+            status=DecisionStatus.TIMEOUT_PROCEED,
+            source="timeout",
+            elapsed_s=record.elapsed(),
+        )
+
+    # ── Introspection / maintenance ───────────────────────────────────────
+    def get(self, decision_id: str) -> Optional[PendingDecision]:
+        return self._pending.get(decision_id)
+
+    def pending_ids(self) -> List[str]:
+        return list(self._pending.keys())
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "pending": len(self._pending),
+            "resolved": self._resolved,
+            "timed_out": self._timed_out,
+        }
+
+    def sweep_expired(self) -> List[str]:
+        """Resolve any records whose wall-clock age exceeded their timeout.
+
+        Safety net for callers that registered but are not actively awaiting
+        (await_decision already handles its own timeout).  Returns swept ids.
+        """
+        now = time.time()
+        expired = [
+            did for did, rec in list(self._pending.items())
+            if now - rec.created_at > rec.timeout_s
+        ]
+        for did in expired:
+            rec = self._pending.pop(did, None)
+            if rec is None:
+                continue
+            self._timed_out += 1
+            if not rec.future.done():
+                rec.future.set_result(self._timeout_outcome(rec))
+        return expired
+
+
+_registry: Optional[PendingDecisionRegistry] = None
+
+
+def get_pending_decision_registry() -> PendingDecisionRegistry:
+    """Return the process-wide singleton registry."""
+    global _registry
+    if _registry is None:
+        _registry = PendingDecisionRegistry()
+    return _registry
+
+
+# ---------------------------------------------------------------------------
+# High-level gate — the single entry the cognitive loop calls to ask a human
+# ---------------------------------------------------------------------------
+# Emit callback: given (device_id, decision_request_message) deliver it.
+EmitCallback = Callable[[str, Dict[str, Any]], Awaitable[Any]]
+
+
+async def request_human_decision(
+    *,
+    title: str,
+    summary: str = "",
+    options: Optional[List[Dict[str, str]]] = None,
+    default_option: Optional[str] = None,
+    urgency: str = "normal",
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    on_timeout: Optional[OnTimeout] = None,
+    devices: Optional[List[str]] = None,
+    emit: Optional[EmitCallback] = None,
+    session_id: str = "",
+    runtime_session_id: str = "",
+) -> DecisionOutcome:
+    """Ask connected device(s) a question and block (bounded) for the answer.
+
+    This is the canonical HITL entry point.  ``emit`` is the transport hook —
+    if ``None``, the default gateway emitter (:func:`_default_emit`) is used,
+    which sends a ``decision_request`` to each device via the gateway
+    connection manager (works for WearOS and phones alike).
+
+    Trigger policy ("when to ask") is intentionally left to the caller — this
+    function is the mechanism, invoked 依实际情况 by whatever cognitive gate
+    decides a human is needed.
+    """
+    option_ids = [str(o.get("id")) for o in (options or []) if o.get("id") is not None]
+    registry = get_pending_decision_registry()
+    record = registry.register(
+        options=option_ids,
+        default_option=default_option,
+        on_timeout=on_timeout,
+        urgency=urgency,
+        timeout_s=timeout_s,
+        session_id=session_id,
+        runtime_session_id=runtime_session_id,
+        devices=devices or [],
+    )
+
+    decision_request = {
+        "type": "decision_request",
+        "payload": {
+            "decision_id": record.decision_id,
+            "title": title,
+            "summary": summary,
+            "options": options or [],
+            "urgency": urgency,
+            "timeout_ms": int(timeout_s * 1000),
+            "default_option": default_option,
+            "source": "openclawd",
+            "timestamp": time.time(),
+        },
+    }
+
+    _emit = emit or _default_emit
+    targets = devices if devices is not None else await _discover_target_devices()
+    if not targets:
+        logger.warning("HITL.request: no target devices for decision_id=%s", record.decision_id)
+    for did in targets:
+        try:
+            await _emit(did, decision_request)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("HITL.request: emit to %s failed: %s", did, exc)
+
+    return await registry.await_decision(record)
+
+
+async def _default_emit(device_id: str, message: Dict[str, Any]) -> None:
+    """Default transport: deliver via the gateway connection manager."""
+    from galaxy_gateway.websocket_handler import connection_manager  # noqa: PLC0415
+    await connection_manager.send_to_device(device_id, message)
+
+
+async def _discover_target_devices() -> List[str]:
+    """Auto-discover connected WearOS + phone device ids to ask."""
+    try:
+        from galaxy_gateway.websocket_handler import connection_manager  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return []
+    try:
+        from core.routes._shared import registered_devices  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        registered_devices = {}
+    try:
+        ids = await connection_manager.get_connected_devices()
+    except Exception:  # noqa: BLE001
+        return []
+    targets: List[str] = []
+    for did in ids:
+        dtype = str((registered_devices.get(did) or {}).get("device_type", "")).lower()
+        if dtype in ("wear_os", "wearos", "watch", "galaxy_watch") or "phone" in dtype:
+            targets.append(did)
+    return targets

--- a/galaxy_gateway/android_bridge.py
+++ b/galaxy_gateway/android_bridge.py
@@ -1074,20 +1074,24 @@ class AndroidBridge:
             if msg_type not in self._message_handlers:
                 self._message_handlers[msg_type] = _wrap(handle_unregistered)
 
-    async def push_decision_to_wearos(self, device_id: str, decision_context: Dict[str, Any]) -> bool:
-        """向 WearOS 设备推送决策通知。
+    async def push_decision_to_wearos(
+        self,
+        device_id: str,
+        decision_context: Dict[str, Any],
+        decision_id: Optional[str] = None,
+    ) -> bool:
+        """向 WearOS 设备推送决策通知（低层 emit 原语）。
 
-        当 OpenClawd 需要人类确认时，通过此方法向已注册的 WearOS 设备
-        推送决策上下文，手表显示通知并等待用户操作。
+        PR-HITL: 规范的人在回路入口是
+        :func:`core.interaction.pending_decision_registry.request_human_decision`,
+        它登记 pending decision 并阻塞等待回复。本方法只是一个底层 emit 原语:
+        ``decision_id`` 由调用方(注册表)传入,**不再**内联 mint-and-discard,否则手表
+        回传的 ``human_input`` 无法按 id 关联回 pending decision。未传时回退随机 id。
 
         Args:
             device_id: 目标 WearOS 设备 ID
-            decision_context: 决策上下文，包含:
-                - title: 决策标题
-                - summary: 一句话摘要
-                - options: 预设选项列表 [{"id": "confirm", "label": "确认"}, ...]
-                - urgency: 紧急程度 ("low" | "normal" | "high")
-                - timeout_ms: 超时时间（毫秒）
+            decision_context: 决策上下文(title/summary/options/urgency/timeout_ms)
+            decision_id: 关联用决策 ID(应由 PendingDecisionRegistry 提供)
 
         Returns:
             bool: 是否成功推送
@@ -1105,7 +1109,7 @@ class AndroidBridge:
                 "type": "decision_request",
                 "payload": {
                     **decision_context,
-                    "decision_id": str(uuid.uuid4()),
+                    "decision_id": decision_id or str(uuid.uuid4()),
                     "timestamp": time.time(),
                     "source": "openclawd",
                 }

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -795,16 +795,37 @@ async def handle_command(connection_id: str, aip_msg):
         elif command_text == "human_input":
             # WearOS sendHumanInput → command="human_input"
             # {decision_id, selected_option?, voice_input?}. 人在回路(HITL)的决策回复。
-            # 注：v2 当前发决策(android_bridge decision_request)是 fire-and-forget——
-            # decision_id 未登记,没有 pending-decision 注册表可按 decision_id 关联解析
-            # (更深的架构缺口,见 PR 说明)。在补齐注册表之前,这里把人类回复(语音/所选项)
-            # 作为一条人类输入送进认知闭环 handle_request(source="wear_decision"),确保用户
-            # 意图抵达大脑、而非像此前那样被当设备命令丢弃。
+            # 两条路:
+            #  1) 该回复应答某个 pending decision(由 request_human_decision 登记)→
+            #     resolve 之,等待中的认知协程在原上下文恢复(PR-HITL 闭环)。
+            #  2) 未命中任何 pending(主动/无主语音)→ 回退把人类输入送进认知闭环
+            #     handle_request(source="wear_decision"),确保意图不丢、不被当设备命令。
             decision_id = str(_payload.get("decision_id") or "")
             voice_input = str(_payload.get("voice_input") or "").strip()
             selected = str(_payload.get("selected_option") or "").strip()
             human_msg = voice_input or selected
-            if not human_msg:
+
+            # PR-HITL: if this reply answers a pending decision (registered by
+            # request_human_decision), resolve it — the asking coroutine resumes
+            # in its original context. First reply wins; fan-out duplicates no-op.
+            resolved = False
+            if decision_id:
+                try:
+                    from core.interaction.pending_decision_registry import (
+                        get_pending_decision_registry,
+                    )
+                    resolved = get_pending_decision_registry().resolve(
+                        decision_id,
+                        selected_option=selected or None,
+                        voice_input=voice_input,
+                        source="wear",
+                    )
+                except Exception as _reg_err:
+                    logger.debug("human_input resolve skipped: %s", _reg_err)
+
+            if resolved:
+                result = {"success": True, "decision_id": decision_id, "resolved": True}
+            elif not human_msg:
                 result = {"success": False, "error": "empty human input", "decision_id": decision_id}
             else:
                 try:

--- a/tests/test_hitl_pending_decision_registry.py
+++ b/tests/test_hitl_pending_decision_registry.py
@@ -1,0 +1,128 @@
+"""PR-HITL: tests for the human-in-the-loop pending-decision registry."""
+import asyncio
+
+import pytest
+
+from core.interaction.pending_decision_registry import (
+    DecisionStatus,
+    OnTimeout,
+    PendingDecisionRegistry,
+    derive_default_on_timeout,
+    request_human_decision,
+)
+
+
+def _fresh() -> PendingDecisionRegistry:
+    return PendingDecisionRegistry()
+
+
+def test_derive_default_on_timeout_composite():
+    assert derive_default_on_timeout("high", has_default=True) == OnTimeout.CANCEL
+    assert derive_default_on_timeout("high", has_default=False) == OnTimeout.CANCEL
+    assert derive_default_on_timeout("normal", has_default=True) == OnTimeout.DEFAULT_OPTION
+    assert derive_default_on_timeout("normal", has_default=False) == OnTimeout.PROCEED
+    assert derive_default_on_timeout("low", has_default=True) == OnTimeout.PROCEED
+
+
+@pytest.mark.asyncio
+async def test_resolve_wins():
+    reg = _fresh()
+    rec = reg.register(options=["confirm", "cancel"], timeout_s=5, decision_id="d1")
+
+    async def replier():
+        await asyncio.sleep(0.01)
+        assert reg.resolve("d1", selected_option="confirm", source="wear") is True
+
+    asyncio.create_task(replier())
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.RESOLVED
+    assert outcome.selected_option == "confirm"
+    assert outcome.should_proceed is True
+    assert reg.stats()["resolved"] == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_default_option():
+    reg = _fresh()
+    rec = reg.register(
+        options=["a", "b"], default_option="a",
+        on_timeout=OnTimeout.DEFAULT_OPTION, timeout_s=0.05, decision_id="d2",
+    )
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.TIMEOUT_DEFAULT
+    assert outcome.selected_option == "a"
+    assert outcome.timed_out and outcome.should_proceed
+
+
+@pytest.mark.asyncio
+async def test_timeout_cancel_high_urgency():
+    reg = _fresh()
+    # high urgency with no pinned policy → derive CANCEL
+    rec = reg.register(options=["go"], urgency="high", timeout_s=0.05, decision_id="d3")
+    assert rec.on_timeout == OnTimeout.CANCEL
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.TIMEOUT_CANCEL
+    assert outcome.timed_out and not outcome.should_proceed
+
+
+@pytest.mark.asyncio
+async def test_timeout_proceed_low_urgency():
+    reg = _fresh()
+    rec = reg.register(options=["go"], urgency="low", timeout_s=0.05, decision_id="d4")
+    assert rec.on_timeout == OnTimeout.PROCEED
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.TIMEOUT_PROCEED
+    assert outcome.should_proceed
+
+
+@pytest.mark.asyncio
+async def test_fanout_first_reply_wins():
+    reg = _fresh()
+    rec = reg.register(options=["x"], timeout_s=5, decision_id="d5")
+    assert reg.resolve("d5", selected_option="x", source="watch") is True
+    # second reply (e.g. from phone) is a no-op
+    assert reg.resolve("d5", selected_option="x", source="phone") is False
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.RESOLVED and outcome.source == "watch"
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_id_is_false():
+    reg = _fresh()
+    assert reg.resolve("nope", selected_option="x") is False
+
+
+@pytest.mark.asyncio
+async def test_request_human_decision_end_to_end(monkeypatch):
+    import core.interaction.pending_decision_registry as mod
+
+    emitted = []
+
+    async def fake_emit(device_id, message):
+        emitted.append((device_id, message["payload"]["decision_id"]))
+
+    # singleton registry is used by request_human_decision + resolve
+    reg = mod.get_pending_decision_registry()
+
+    async def driver():
+        # wait for the emit to happen, then resolve via the singleton
+        for _ in range(100):
+            if emitted:
+                break
+            await asyncio.sleep(0.005)
+        did = emitted[0][1]
+        assert reg.resolve(did, selected_option="confirm", source="wear") is True
+
+    asyncio.create_task(driver())
+    outcome = await request_human_decision(
+        title="Proceed?",
+        options=[{"id": "confirm", "label": "确认"}, {"id": "cancel", "label": "取消"}],
+        urgency="normal",
+        timeout_s=5,
+        devices=["watch-1", "phone-1"],
+        emit=fake_emit,
+    )
+    assert outcome.status == DecisionStatus.RESOLVED
+    assert outcome.selected_option == "confirm"
+    # fanned out to both devices
+    assert {d for d, _ in emitted} == {"watch-1", "phone-1"}


### PR DESCRIPTION
## HITL 决策闭环（方案 A · 有界阻塞等待）

> 🔗 **Stacked PR**：base 是 `claude/v2-wear-voice-brain`（#1357），因为它在 #1357 的 `human_input` 分支上加 resolve 接线。请**先合 #1357**，本 PR base 会自动转为 main。

### 背景
讨论确认：此前整条 HITL 链在 v2 侧是断的——`push_decision_to_wearos` **零调用**、`decision_id` 即生即弃、**无注册表**、**无 agent 挂起/恢复原语**，手表回传的 `human_input` 无法关联回任何提问者。

### 方案 A（你拍板）：有界阻塞等待
复用 v2 已有的 `task_envelope_lifecycle_registry` 的 **Future-注册表**模式（它本就阻塞协程等设备任务结果）——等人只是 timeout 更长，**无需新建挂起/恢复机制**，提问协程在原上下文 `await` 一个 Future 即可。

### 改动
**新增 `core/interaction/pending_decision_registry.py`**
- `PendingDecisionRegistry`：`register(→Future)` / `resolve(decision_id→choice)` / `await_decision(有界 wait_for)` / `cancel` / `sweep_expired` / 单例。
- `request_human_decision(...)`：**canonical HITL 入口** — mint `decision_id` → 登记 → 经 `emit` 回调（默认走网关 `connection_manager`，**手表/手机通吃**）fan-out `decision_request` → 阻塞等回复。**首个回复胜出**，其余 no-op。
- **复合型超时兜底（依情况）**：`OnTimeout.{DEFAULT_OPTION, CANCEL, PROCEED}`；未指定时按 `urgency` 派生（**high→CANCEL** 保守、**normal→**有默认则默认否则 PROCEED、**low→PROCEED**）。默认 **timeout 60s**。

**接线**
- `handle_command` 的 `human_input`：**先 `resolve(decision_id)`** → 命中则等待中的认知协程在原上下文恢复；未命中（主动语音）回退 `handle_request(source="wear_decision")`（#1357 的行为保留）。
- `android_bridge.push_decision_to_wearos`：改为**接收** `decision_id`（由注册表提供），不再 mint-and-discard；降为底层 emit 原语。

**触发策略（"何时问人"）** 按你说的"按实际情况而定" —— 本 PR 提供**机制**（可调用的 gate），不硬塞触发点。任何认知 gate 在判定需要人类时调用 `request_human_decision(...)` 即可。

### 验证
- 8 项单测（`tests/test_hitl_pending_decision_registry.py`）：复合策略派生 / resolve-wins / 三种超时兜底（default/cancel/proceed）/ fan-out 首胜 / 未知 id / `request_human_decision` 端到端 —— **全过**（无 pytest，经等价 asyncio harness 运行）。
- **完整回路**：`request_human_decision`(asker 协程阻塞) → 经 `connection_manager` emit 到手表 → 手表 `human_input` 经 `handle_command` → 注册表 resolve → **asker 在原上下文恢复并拿到 outcome**，`command_result` ack `resolved=True` —— 通过。
- 4 文件 `py_compile` 通过。

### 跨仓
手表**无需改**：它已回传 `decision_id`，而 `decision_id` 由 v2 生成、v2 持有映射，单凭它即可关联。

### 诚实说明 ⚠️
- 沙箱无 pytest（用 asyncio harness 跑了等价断言）、无真机。
- 有界阻塞会占住该请求协程至多 `timeout` 秒（默认 60s）；WS 长连可接受，复合兜底保证不会无限挂起。
- "何时问人"的具体认知触发点是后续按场景接入的事——本 PR 只交付可被随处调用的机制。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_