### PR TITLE
feat(gateway): 三仓打通 — ingest Android DEVICE_PERCEPTION_EMISSION into unified memory (conflict-free redo of #1356)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,6 +273,10 @@ WEB_UI_PORT=8085                        # Unified Dashboard port (Galaxy unified
 GALAXY_DESKTOP_PERCEPTION=0                  # 1/true 启用桌面摄像头+麦克风采集
 GALAXY_DESKTOP_PERCEPTION_INTERVAL_MS=2000   # 采集间隔(毫秒)
 GALAXY_DESKTOP_PERCEPTION_TTL=10             # 后端帧新鲜度 TTL(秒); 超时不注入
+# 三仓打通：把 Android 经 WS 上行的 DEVICE_PERCEPTION_EMISSION(视觉/grounding/截图)
+# 喂进统一/跨模态记忆，使手机感知可被桌面大脑召回。默认开;置 0 关闭。
+# 截图入跨模态记忆还需 GALAXY_MEMORY_MEDIA=1。
+GALAXY_ANDROID_PERCEPTION_INGEST=1
 # 普通对话自动「听见」麦克风：用音频模型原生听懂最新麦克风音频→转写注入 prompt。
 # 默认关闭(每次新音频会多一次音频模型调用); 需配置 GEMINI/GOOGLE 或 OPENAI key。
 GALAXY_DESKTOP_AUDIO_AUTOINJECT=0

--- a/galaxy_gateway/protocol/aip_v3.py
+++ b/galaxy_gateway/protocol/aip_v3.py
@@ -382,6 +382,16 @@ class MessageType(str, Enum):
     DEVICE_STATE_SNAPSHOT = "device_state_snapshot"
     DEVICE_EXECUTION_EVENT = "device_execution_event"
 
+    # === V2_INTERNAL: Android Multimodal Perception Uplink (三仓打通) ===
+    # Emitted by GalaxyWebSocketClient.kt::sendDevicePerceptionEmission on the
+    # Android side (MsgType.DEVICE_PERCEPTION_EMISSION).  Carries continuous
+    # perception emissions — screenshot / vision / grounding / local-perception —
+    # for V2 multimodal ingestion.  Previously absent from this enum, which made
+    # MessageType('device_perception_emission') raise ValueError and the gateway
+    # drop the message.  Now registered so handle_device_perception_emission can
+    # absorb it into the unified semantic/cross-modal memory layer (core.memory).
+    DEVICE_PERCEPTION_EMISSION = "device_perception_emission"
+
 
 class TaskStatus(str, Enum):
     """任务状态"""

--- a/galaxy_gateway/protocol/normalized_ingress_event.py
+++ b/galaxy_gateway/protocol/normalized_ingress_event.py
@@ -126,6 +126,10 @@ class IngressEventKind:
     DEVICE_STATE_SNAPSHOT: str = "device_state_snapshot"
     DEVICE_EXECUTION_EVENT: str = "device_execution_event"
 
+    # Android multimodal perception uplink (三仓打通) — absorbed into core.memory
+    # unified semantic/cross-modal memory by handle_device_perception_emission.
+    DEVICE_PERCEPTION_EMISSION: str = "device_perception_emission"
+
     # Unknown / unrecognised
     UNKNOWN: str = "unknown"
 
@@ -139,6 +143,7 @@ class IngressEventKind:
         GOAL_EXECUTION_RESULT, GOAL_RESULT,
         HANDOFF_ACK, HANDOFF_RESULT, HANDOFF_FAILURE, HANDOFF_ENVELOPE_V2_RESULT,
         DEVICE_STATE_SNAPSHOT, DEVICE_EXECUTION_EVENT,
+        DEVICE_PERCEPTION_EMISSION,
         UNKNOWN,
     }
 

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -113,6 +113,7 @@ OPENCLAWD_ROUTING_AUTHORITY = (
 import asyncio
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Dict, FrozenSet, Set
 import uuid
@@ -475,6 +476,8 @@ async def handle_message(connection_id: str, message: Dict, websocket: WebSocket
             await handle_status(connection_id, aip_msg)
         elif event.kind == IngressEventKind.WAKE_EVENT:
             await handle_wake_event(connection_id, aip_msg)
+        elif event.kind == IngressEventKind.DEVICE_PERCEPTION_EMISSION:
+            await handle_device_perception_emission(connection_id, aip_msg)
         else:
             # SESSION_MIGRATE and any future transport-class kinds are handled here
             # by falling through to per-type checks using MessageType for backward
@@ -965,6 +968,96 @@ async def handle_wake_event(connection_id: str, aip_msg):
 
     except Exception as e:
         logger.error(f"❌ 处理唤醒事件失败: {e}")
+
+
+async def handle_device_perception_emission(connection_id: str, aip_msg):
+    """处理 Android 多模态感知上行 (三仓打通 / 最小可用桥)。
+
+    Android 端 sendDevicePerceptionEmission 持续把 DEVICE_PERCEPTION_EMISSION
+    上行给 V2（含 vision / grounding / local-perception / screenshot）。本处理器把
+    其中的文本语义与（可选）截图喂进 core.memory 统一/跨模态长程记忆，使手机端的
+    视觉/本地感知能被桌面大脑一句话召回——V2 始终是多模态权威。
+
+    默认开启（GALAXY_ANDROID_PERCEPTION_INGEST=1）；置 0 关闭。任何异常都吞掉，
+    绝不影响 WS 主流程。截图入记忆需另外打开 GALAXY_MEMORY_MEDIA=1。
+    """
+    try:
+        if os.getenv("GALAXY_ANDROID_PERCEPTION_INGEST", "1").strip().lower() in ("0", "false", "no", "off"):
+            return
+
+        device_id = aip_msg.device_id
+        payload = aip_msg.payload or {}
+
+        def _g(d, *keys):
+            for k in keys:
+                v = (d or {}).get(k)
+                if v not in (None, "", []):
+                    return v
+            return None
+
+        vision = payload.get("vision_payload") or {}
+        grounding = payload.get("grounding_payload") or {}
+        local = payload.get("local_perception_payload") or {}
+
+        # 组装可读文本语义（只取有信息量的字段）
+        parts = []
+        kind = _g(payload, "emission_kind")
+        stage = _g(payload, "perception_stage")
+        head = "[Android感知]"
+        if kind:
+            head += f" {kind}"
+        if stage:
+            head += f"@{stage}"
+        parts.append(head)
+        for txt in (
+            _g(vision, "prompt_text"),
+            _g(vision, "request_reason"),
+            _g(grounding, "intent"),
+            _g(grounding, "element_description"),
+            _g(grounding, "error"),
+        ):
+            if txt:
+                parts.append(str(txt))
+        content = "  ".join(p for p in parts if p).strip()
+
+        task_id = _g(payload, "task_id")
+        meta = {
+            "source": "android_perception_emission",
+            "device_id": device_id,
+            "task_id": task_id,
+            "emission_kind": kind,
+            "perception_stage": stage,
+        }
+
+        from core.memory import get_unified_memory
+        um = get_unified_memory()
+        # 文本语义入记忆（仅当确有内容时；纯头部无信息量则跳过文本，仍可走截图）
+        if content and len(content) > len(head) + 2:
+            await asyncio.to_thread(um.remember, content, metadata=meta)
+
+        # 可选：截图入跨模态记忆（CLIP），仅当 GALAXY_MEMORY_MEDIA 开启且有 base64 图像
+        screenshot = payload.get("screenshot") or {}
+        img_b64 = _g(screenshot, "data")
+        if img_b64 and os.getenv("GALAXY_MEMORY_MEDIA", "0").strip().lower() in ("1", "true", "yes", "on"):
+            try:
+                await asyncio.to_thread(
+                    lambda: um.remember_media(
+                        img_b64,
+                        modality="image",
+                        mime="image/jpeg",
+                        caption=content or head,
+                        metadata=meta,
+                    )
+                )
+            except Exception as _media_err:  # noqa: BLE001
+                logger.debug("android perception screenshot ingest skipped: %s", _media_err)
+
+        logger.info(
+            "✅ Android 感知已入记忆: device=%s kind=%s stage=%s text=%s img=%s",
+            device_id, kind, stage, bool(content), bool(img_b64),
+        )
+    except Exception as e:  # noqa: BLE001 — 感知入记忆失败绝不影响 WS 主流程
+        logger.debug("handle_device_perception_emission skipped: %s", e)
 
 
 async def handle_session_migrate(connection_id: str, aip_msg):


### PR DESCRIPTION
## 三仓打通②（重做）：Android 视觉/感知 → 统一·跨模态记忆

> 这是原 #1356 的**无冲突重做**，基于已合并全部 PR（#1354/55/57/58/59 + wearos#1）后的最新 main 重新落地。原 #1356 因 `websocket_handler.py` 被多个已合 PR 改动而产生冲突，未合并。本 PR 干净重建、与当前 main 零冲突。

### 问题
Android `GalaxyWebSocketClient.sendDevicePerceptionEmission()` 持续把 `DEVICE_PERCEPTION_EMISSION`（vision / grounding / local-perception / screenshot）经 WS 上行给 V2。但 V2：协议枚举不含该类型 → `parse_message_strict` 抛 ValueError；WS 派发也没有分支 → 消息被丢弃。**手机视觉/感知完全没进桌面统一记忆。**

### 改动（最小可用桥）
1. `galaxy_gateway/protocol/aip_v3.py`：`MessageType` 注册 `DEVICE_PERCEPTION_EMISSION`（与既有 `cancel_result`/`device_state_snapshot` 等 Android 上行类型同一模式）。
2. `normalized_ingress_event.py`：`IngressEventKind` + `_ALL` 加该 kind，`normalise()` 可识别。
3. `galaxy_gateway/websocket_handler.py`：派发分支 + `handle_device_perception_emission` —— 抽取 `vision.prompt_text` / `grounding.intent` / `element_description` 等文本喂进 `core.memory` 统一记忆；截图在 `GALAXY_MEMORY_MEDIA=1` 时入跨模态（CLIP）。线程池执行不阻塞事件循环；默认开（`GALAXY_ANDROID_PERCEPTION_INGEST=1`），异常全吞不影响 WS 主流程。
4. `.env.example`：文档化 `GALAXY_ANDROID_PERCEPTION_INGEST`。

### 验证
`MessageType('device_perception_emission')` 不再抛错；`IngressEventKind.normalise` 命中；handler 端到端（文本抽取 / metadata / 媒体门控 / 禁用开关）全过；3 文件 `py_compile` 通过。

### 诚实说明 ⚠️
未做真机端到端（无 Android 设备 + 常驻网关；沙箱缺 fastapi，handler 经 stub 注入跑真实逻辑；协议枚举/normalise 在真实模块上验证）。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_