### PR TITLE
fix(gateway): accept Android uplink acks / operator-results / ping (P1)

### DIFF
--- a/galaxy_gateway/android_bridge.py
+++ b/galaxy_gateway/android_bridge.py
@@ -983,6 +983,10 @@ class AndroidBridge:
         self._message_handlers[MessageType.SESSION_MIGRATE] = _wrap(handle_session_migrate)
         self._message_handlers[MessageType.AGENT_PING] = _wrap(handle_agent_ping)
         self._message_handlers[MessageType.AGENT_STATUS] = _wrap(handle_agent_status)
+        # Device-side operator-action completion: forward so operator surfaces can
+        # observe the result instead of it silently hanging. (ACK/PING need no
+        # handler — they are accepted as graceful no-ops via the else branch.)
+        self._message_handlers[MessageType.OPERATOR_ACTION_RESULT] = _wrap(handle_generic_forward)
         # Bounded compat path: generic-forward is an explicit allowlist gate,
         # not an open fallback for unclassified message semantics.
         for _compat_message_type in get_generic_forward_compat_allowlist():

--- a/galaxy_gateway/protocol/aip_v3.py
+++ b/galaxy_gateway/protocol/aip_v3.py
@@ -392,6 +392,20 @@ class MessageType(str, Enum):
     # absorb it into the unified semantic/cross-modal memory layer (core.memory).
     DEVICE_PERCEPTION_EMISSION = "device_perception_emission"
 
+    # === V2_INTERNAL: Android transport acks / uplink reports previously dropped ===
+    # Emitted by Android (GalaxyConnectionService.sendAdvancedAck / handleOperatorAction)
+    # and WearOS.  Previously absent → MessageType(...) raised ValueError and the
+    # gateway returned UNKNOWN_MESSAGE_TYPE error to the device:
+    #  - ACK: delivery confirmation for advanced types (relay/wake/lock/takeover);
+    #    accepted as a graceful no-op (no handler needed; never error back).
+    #  - OPERATOR_ACTION_RESULT: device-side completion of an operator action;
+    #    routed to handle_generic_forward so operator surfaces can observe it
+    #    instead of the result silently hanging.
+    #  - PING: low-priority transport ping (backpressure fallback); accepted no-op.
+    ACK = "ack"
+    OPERATOR_ACTION_RESULT = "operator_action_result"
+    PING = "ping"
+
 
 class TaskStatus(str, Enum):
     """任务状态"""

--- a/galaxy_gateway/protocol/normalized_ingress_event.py
+++ b/galaxy_gateway/protocol/normalized_ingress_event.py
@@ -130,6 +130,12 @@ class IngressEventKind:
     # unified semantic/cross-modal memory by handle_device_perception_emission.
     DEVICE_PERCEPTION_EMISSION: str = "device_perception_emission"
 
+    # Android transport acks / operator-action results / ping — previously dropped
+    # (UNKNOWN → error response); now recognised and routed to graceful handling.
+    ACK: str = "ack"
+    OPERATOR_ACTION_RESULT: str = "operator_action_result"
+    PING: str = "ping"
+
     # Unknown / unrecognised
     UNKNOWN: str = "unknown"
 
@@ -144,6 +150,7 @@ class IngressEventKind:
         HANDOFF_ACK, HANDOFF_RESULT, HANDOFF_FAILURE, HANDOFF_ENVELOPE_V2_RESULT,
         DEVICE_STATE_SNAPSHOT, DEVICE_EXECUTION_EVENT,
         DEVICE_PERCEPTION_EMISSION,
+        ACK, OPERATOR_ACTION_RESULT, PING,
         UNKNOWN,
     }
 

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -180,6 +180,12 @@ _ANDROID_DOMAIN_KINDS: FrozenSet[str] = frozenset({
     # through to the catch-all, miss the store, and return no ACK.
     IngressEventKind.DEVICE_STATE_SNAPSHOT,
     IngressEventKind.DEVICE_EXECUTION_EVENT,
+    # Android transport acks / operator-action results / ping — delegate to
+    # android_bridge so they are accepted gracefully (generic-forward / no-op)
+    # instead of hitting the catch-all and returning an error response.
+    IngressEventKind.ACK,
+    IngressEventKind.OPERATOR_ACTION_RESULT,
+    IngressEventKind.PING,
 })
 
 


### PR DESCRIPTION
## 体检 P1：接住 Android 上行被丢的 3 种消息

Android↔v2 覆盖审计发现 3 种 Android 上行消息因 `MessageType` 枚举缺失，在 `android_bridge.py:1169` 解析时抛 ValueError → 回 `UNKNOWN_MESSAGE_TYPE` 错误给设备（与我们一路修的"一端发、另一端没接"同类）：

| 类型 | 严重度 | 影响 | 修复 |
|---|---|---|---|
| `operator_action_result` | **CRITICAL** | 设备端 operator 动作完成结果丢失，operator 面板永远看不到 → 动作看似挂起 | 注册 + 路由 `handle_generic_forward`（转发供 operator 面板观测）|
| `ack` | **HIGH** | 设备对 relay/wake/lock/takeover 的送达确认被拒，破坏确认语义 + 每个 ack 回一个错误 | 注册 → 优雅 no-op |
| `ping` | LOW | 低优先级传输 ping（背压回退），未实际发送 | 注册 → 优雅 no-op（future-proof）|

### 改动（与既有 `cancel_result`/`device_perception_emission` 同一模式）
- `aip_v3.py` `MessageType`：注册 `ACK` / `OPERATOR_ACTION_RESULT` / `PING`。
- `normalized_ingress_event.py` `IngressEventKind` + `_ALL`：加 3 个 kind，`normalise` 可识别。
- `websocket_handler._ANDROID_DOMAIN_KINDS`：3 个 kind 委托 `android_bridge`，优雅接受而非落 catch-all 回错（**手表的 ack 也走 websocket_handler，一并覆盖**）。
- `android_bridge`：`OPERATOR_ACTION_RESULT → handle_generic_forward`；`ACK`/`PING` 无需 handler，经 else 分支优雅 no-op（debug 日志、不回错）。

### 验证
3 种 wire 值被 `MessageType` 接受、`IngressEventKind.normalise` 命中、均在 `_ANDROID_DOMAIN_KINDS`；4 文件 `py_compile` 通过。

### 诚实说明 ⚠️
`operator_action_result` 当前无专门消费者/无 request 端 await 可关联（v2 无 operator_action_request 设备下发链路），故路由到 `handle_generic_forward` 做到**可观测、不丢弃**，而非伪造关联。未做真机验证。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_