### PR TITLE
feat(hitl): re-land decision registry + wire both triggers (agent ask_human tool + high-risk confirmation gate)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -277,6 +277,11 @@ GALAXY_DESKTOP_PERCEPTION_TTL=10             # 后端帧新鲜度 TTL(秒); 超�
 # 喂进统一/跨模态记忆，使手机感知可被桌面大脑召回。默认开;置 0 关闭。
 # 截图入跨模态记忆还需 GALAXY_MEMORY_MEDIA=1。
 GALAXY_ANDROID_PERCEPTION_INGEST=1
+# 人在回路(HITL)高风险动作确认门：开启后,破坏性/高风险设备命令(delete/format/
+# shutdown/sudo/payment 等)在执行前必须经人类确认(手表/手机决策通知→human_input)。
+# 默认关闭;开启则 fail-closed —— 超时/无设备/拒绝都不执行。确认超时见下。
+GALAXY_HITL_CONFIRM_GATE=0
+GALAXY_HITL_CONFIRM_TIMEOUT_S=60        # 高风险确认等待秒数(默认 60;到点按保守取消)
 # 普通对话自动「听见」麦克风：用音频模型原生听懂最新麦克风音频→转写注入 prompt。
 # 默认关闭(每次新音频会多一次音频模型调用); 需配置 GEMINI/GOOGLE 或 OPENAI key。
 GALAXY_DESKTOP_AUDIO_AUTOINJECT=0

--- a/core/command_router.py
+++ b/core/command_router.py
@@ -796,6 +796,43 @@ class CommandRouter:
         cmd_lower = command.lower()
         return any(kw in cmd_lower for kw in self._HIGH_RISK_COMMANDS)
 
+    async def _await_high_risk_confirmation(
+        self, command: str, device_id: str, task_id: str, trace_id: str
+    ) -> Dict[str, Any]:
+        """PR-HITL: block for explicit human confirmation of a high-risk command.
+
+        Uses the real blocking decision loop (``request_human_decision`` → device
+        notification → ``human_input`` → registry resolve).  Fail-CLOSED: timeout,
+        no connected device, an explicit "deny", or any error ⇒ ``proceed=False``.
+        The gate is opt-in (``GALAXY_HITL_CONFIRM_GATE``), so a high-risk action is
+        never executed without an explicit human "approve".
+
+        Returns ``{"proceed": bool, "status": str}``.
+        """
+        try:
+            from core.interaction.pending_decision_registry import (
+                request_human_decision,
+                OnTimeout,
+                DecisionStatus,
+            )
+            outcome = await request_human_decision(
+                title="高风险操作确认",
+                summary=f"是否执行高风险命令 '{command}'?（目标设备 {device_id}）",
+                options=[{"id": "approve", "label": "批准"}, {"id": "deny", "label": "拒绝"}],
+                urgency="high",                 # high ⇒ timeout derives CANCEL (no auto-proceed)
+                on_timeout=OnTimeout.CANCEL,
+                timeout_s=float(os.getenv("GALAXY_HITL_CONFIRM_TIMEOUT_S", "60")),
+                session_id=trace_id,
+            )
+            proceed = (
+                outcome.status == DecisionStatus.RESOLVED
+                and outcome.selected_option == "approve"
+            )
+            return {"proceed": bool(proceed), "status": outcome.status.value}
+        except Exception as exc:  # noqa: BLE001 — fail-closed: do not execute on gate error
+            logger.warning("HITL confirm gate failed (fail-closed, not executing): %s", exc)
+            return {"proceed": False, "status": "gate_error"}
+
     def _emit_audit(
         self,
         event_type,
@@ -4117,6 +4154,38 @@ class CommandRouter:
                 _exec_params = dict(payload)
                 _exec_params.setdefault("_galaxy_task_id", task_id)
                 _exec_params.setdefault("_galaxy_trace_id", trace_id)
+
+                # PR-HITL: high-risk action confirmation gate (opt-in via
+                # GALAXY_HITL_CONFIRM_GATE).  Destructive/high-risk commands must be
+                # confirmed by a human (real blocking decision loop) before reaching
+                # the executor; without an explicit "approve" the action is aborted.
+                if (
+                    os.getenv("GALAXY_HITL_CONFIRM_GATE", "0").strip().lower()
+                    in ("1", "true", "yes", "on")
+                    and self._is_high_risk_command(command)
+                ):
+                    _gate = await self._await_high_risk_confirmation(
+                        command, device_id, task_id, trace_id
+                    )
+                    if not _gate.get("proceed", False):
+                        latency_ms = (time.monotonic() - t0) * 1000
+                        _timed_out = _gate.get("status") == "timeout_cancel"
+                        return {
+                            **trace_base,
+                            "success": False,
+                            "result": None,
+                            "error_code": (
+                                GatewayErrorCode.HITL_TIMEOUT.value if _timed_out
+                                else GatewayErrorCode.HITL_DENIED.value
+                            ),
+                            "error_message": (
+                                f"High-risk command '{command}' not confirmed by human "
+                                f"(status={_gate.get('status')})"
+                            ),
+                            "requires_hitl": True,
+                            "latency_ms": round(latency_ms, 1),
+                        }
+
                 raw_result = await asyncio.wait_for(
                     self._executor(device_id, command, _exec_params),
                     timeout=timeout,

--- a/core/interaction/pending_decision_registry.py
+++ b/core/interaction/pending_decision_registry.py
@@ -1,0 +1,453 @@
+"""
+core/interaction/pending_decision_registry.py
+==============================================
+PR-HITL: Human-in-the-Loop pending-decision registry (bounded blocking await).
+
+Why this exists
+---------------
+V2 could *emit* a ``decision_request`` to devices (``android_bridge.
+push_decision_to_wearos``) and WearOS could *reply* (``human_input`` command),
+but the two ends were never connected: the ``decision_id`` was generated and
+discarded, there was no registry keyed by it, and no agent suspend/resume
+primitive — so a human reply could not be correlated back to whatever was
+asking.  This module closes that loop.
+
+Model (Approach A — bounded blocking await)
+-------------------------------------------
+The cognitive loop asks a question via :func:`request_human_decision`, which:
+
+1. mints a ``decision_id`` and registers a :class:`PendingDecision` (holding an
+   :class:`asyncio.Future` + the original options/context/timeout policy),
+2. emits the ``decision_request`` to the target devices (caller-supplied emit
+   callback — keeps this module transport-agnostic),
+3. ``await``\\s the future with a bounded timeout (default 60 s).
+
+When the device replies, the gateway calls :meth:`PendingDecisionRegistry.resolve`
+(``decision_id`` → choice), which resolves the future; the asking coroutine
+resumes **in its original context**.  No new suspend/resume machinery is needed
+— this mirrors the existing :mod:`core.task_envelope_lifecycle_registry` pattern
+which already blocks a coroutine awaiting a device task result.
+
+Composite timeout fallback (依情况)
+-----------------------------------
+On timeout the outcome is resolved per the decision's :class:`OnTimeout` policy,
+which is **chosen per decision** (composite, not one-size-fits-all):
+
+* ``DEFAULT_OPTION`` — resolve to the pre-declared ``default_option``.
+* ``CANCEL``         — abort; the asker should not proceed.
+* ``PROCEED``        — continue without explicit confirmation.
+
+When the caller does not pin a policy, :func:`derive_default_on_timeout` picks
+one from ``urgency`` (high → CANCEL, normal → DEFAULT_OPTION if a default exists
+else PROCEED, low → PROCEED).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.HITL")
+
+_DEFAULT_TIMEOUT_S: float = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Outcome / policy types
+# ---------------------------------------------------------------------------
+class OnTimeout(str, Enum):
+    """What to do when no human replies before the timeout."""
+    DEFAULT_OPTION = "default_option"  # resolve to the declared default option
+    CANCEL = "cancel"                  # abort — asker must not proceed
+    PROCEED = "proceed"                # continue without confirmation
+
+    @classmethod
+    def from_string(cls, value: Optional[str]) -> Optional["OnTimeout"]:
+        if not value:
+            return None
+        try:
+            return cls(str(value).lower().strip())
+        except ValueError:
+            return None
+
+
+class DecisionStatus(str, Enum):
+    RESOLVED = "resolved"               # a human answered
+    TIMEOUT_DEFAULT = "timeout_default"  # timed out → default option applied
+    TIMEOUT_CANCEL = "timeout_cancel"    # timed out → cancelled
+    TIMEOUT_PROCEED = "timeout_proceed"  # timed out → proceed unconfirmed
+    CANCELLED = "cancelled"             # explicitly cancelled (e.g. shutdown)
+
+
+@dataclass
+class DecisionOutcome:
+    """Result handed back to the asking coroutine."""
+    decision_id: str
+    status: DecisionStatus
+    selected_option: Optional[str] = None
+    voice_input: str = ""
+    source: str = ""
+    elapsed_s: float = 0.0
+
+    @property
+    def timed_out(self) -> bool:
+        return self.status in (
+            DecisionStatus.TIMEOUT_DEFAULT,
+            DecisionStatus.TIMEOUT_CANCEL,
+            DecisionStatus.TIMEOUT_PROCEED,
+        )
+
+    @property
+    def should_proceed(self) -> bool:
+        """True iff the asker may proceed (a choice exists or PROCEED policy)."""
+        if self.status == DecisionStatus.RESOLVED:
+            return True
+        return self.status in (DecisionStatus.TIMEOUT_DEFAULT, DecisionStatus.TIMEOUT_PROCEED)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "status": self.status.value,
+            "selected_option": self.selected_option,
+            "voice_input": self.voice_input,
+            "source": self.source,
+            "elapsed_s": round(self.elapsed_s, 3),
+            "timed_out": self.timed_out,
+            "should_proceed": self.should_proceed,
+        }
+
+
+def derive_default_on_timeout(urgency: str, has_default: bool) -> OnTimeout:
+    """Composite fallback selection when the caller does not pin a policy."""
+    u = (urgency or "normal").lower().strip()
+    if u == "high":
+        # High-urgency / risky actions: never auto-proceed without a human.
+        return OnTimeout.CANCEL
+    if u == "low":
+        return OnTimeout.PROCEED
+    # normal: prefer a safe default option if one was declared, else proceed.
+    return OnTimeout.DEFAULT_OPTION if has_default else OnTimeout.PROCEED
+
+
+# ---------------------------------------------------------------------------
+# Pending record
+# ---------------------------------------------------------------------------
+@dataclass
+class PendingDecision:
+    decision_id: str
+    future: asyncio.Future
+    options: List[str]
+    default_option: Optional[str]
+    on_timeout: OnTimeout
+    urgency: str
+    timeout_s: float
+    session_id: str = ""
+    runtime_session_id: str = ""
+    devices: List[str] = field(default_factory=list)
+    context: Dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+
+    def elapsed(self) -> float:
+        return time.time() - self.created_at
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+class PendingDecisionRegistry:
+    """Singleton registry of in-flight human decisions, keyed by ``decision_id``."""
+
+    def __init__(self) -> None:
+        self._pending: Dict[str, PendingDecision] = {}
+        self._resolved: int = 0
+        self._timed_out: int = 0
+
+    # ── Registration ──────────────────────────────────────────────────────
+    def register(
+        self,
+        *,
+        options: Optional[List[str]] = None,
+        default_option: Optional[str] = None,
+        on_timeout: Optional[OnTimeout] = None,
+        urgency: str = "normal",
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        session_id: str = "",
+        runtime_session_id: str = "",
+        devices: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
+        decision_id: Optional[str] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> PendingDecision:
+        """Register a pending decision and return the record (holding a Future)."""
+        did = decision_id or uuid.uuid4().hex
+        _loop = loop or asyncio.get_event_loop()
+        future: asyncio.Future = _loop.create_future()
+        opts = list(options or [])
+        policy = on_timeout or derive_default_on_timeout(urgency, default_option is not None)
+        record = PendingDecision(
+            decision_id=did,
+            future=future,
+            options=opts,
+            default_option=default_option,
+            on_timeout=policy,
+            urgency=urgency,
+            timeout_s=float(timeout_s),
+            session_id=session_id,
+            runtime_session_id=runtime_session_id,
+            devices=list(devices or []),
+            context=dict(context or {}),
+        )
+        self._pending[did] = record
+        logger.info(
+            "HITL.register | decision_id=%s urgency=%s on_timeout=%s timeout=%.0fs devices=%s",
+            did, urgency, policy.value, timeout_s, record.devices,
+        )
+        return record
+
+    # ── Resolution (called by the gateway when a human replies) ───────────
+    def resolve(
+        self,
+        decision_id: str,
+        *,
+        selected_option: Optional[str] = None,
+        voice_input: str = "",
+        source: str = "",
+    ) -> bool:
+        """Resolve a pending decision with a human reply.
+
+        Returns ``True`` iff a matching pending decision was found and resolved.
+        First reply wins; later replies for the same id are no-ops (e.g. when
+        the same decision was fanned out to several devices).
+        """
+        record = self._pending.pop(decision_id, None)
+        if record is None:
+            logger.debug("HITL.resolve: no pending decision for id=%s", decision_id)
+            return False
+        self._resolved += 1
+        outcome = DecisionOutcome(
+            decision_id=decision_id,
+            status=DecisionStatus.RESOLVED,
+            selected_option=selected_option,
+            voice_input=voice_input,
+            source=source,
+            elapsed_s=record.elapsed(),
+        )
+        logger.info(
+            "HITL.resolve | decision_id=%s option=%r source=%s elapsed=%.2fs",
+            decision_id, selected_option, source, outcome.elapsed_s,
+        )
+        if not record.future.done():
+            record.future.set_result(outcome)
+        return True
+
+    def cancel(self, decision_id: str, reason: str = "cancelled") -> bool:
+        """Explicitly cancel a pending decision (e.g. task aborted / shutdown)."""
+        record = self._pending.pop(decision_id, None)
+        if record is None:
+            return False
+        outcome = DecisionOutcome(
+            decision_id=decision_id,
+            status=DecisionStatus.CANCELLED,
+            source=reason,
+            elapsed_s=record.elapsed(),
+        )
+        if not record.future.done():
+            record.future.set_result(outcome)
+        return True
+
+    # ── Bounded await with composite timeout fallback ─────────────────────
+    async def await_decision(self, record: PendingDecision) -> DecisionOutcome:
+        """Block (bounded) until the decision resolves, applying the timeout policy."""
+        try:
+            return await asyncio.wait_for(record.future, timeout=record.timeout_s)
+        except asyncio.TimeoutError:
+            # Remove if still pending and synthesise the policy-driven outcome.
+            self._pending.pop(record.decision_id, None)
+            self._timed_out += 1
+            outcome = self._timeout_outcome(record)
+            logger.info(
+                "HITL.timeout | decision_id=%s policy=%s → status=%s after %.0fs",
+                record.decision_id, record.on_timeout.value, outcome.status.value,
+                record.timeout_s,
+            )
+            return outcome
+        except asyncio.CancelledError:
+            self._pending.pop(record.decision_id, None)
+            return DecisionOutcome(
+                decision_id=record.decision_id,
+                status=DecisionStatus.CANCELLED,
+                elapsed_s=record.elapsed(),
+            )
+
+    def _timeout_outcome(self, record: PendingDecision) -> DecisionOutcome:
+        if record.on_timeout == OnTimeout.DEFAULT_OPTION:
+            return DecisionOutcome(
+                decision_id=record.decision_id,
+                status=DecisionStatus.TIMEOUT_DEFAULT,
+                selected_option=record.default_option,
+                source="timeout",
+                elapsed_s=record.elapsed(),
+            )
+        if record.on_timeout == OnTimeout.CANCEL:
+            return DecisionOutcome(
+                decision_id=record.decision_id,
+                status=DecisionStatus.TIMEOUT_CANCEL,
+                source="timeout",
+                elapsed_s=record.elapsed(),
+            )
+        return DecisionOutcome(
+            decision_id=record.decision_id,
+            status=DecisionStatus.TIMEOUT_PROCEED,
+            source="timeout",
+            elapsed_s=record.elapsed(),
+        )
+
+    # ── Introspection / maintenance ───────────────────────────────────────
+    def get(self, decision_id: str) -> Optional[PendingDecision]:
+        return self._pending.get(decision_id)
+
+    def pending_ids(self) -> List[str]:
+        return list(self._pending.keys())
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "pending": len(self._pending),
+            "resolved": self._resolved,
+            "timed_out": self._timed_out,
+        }
+
+    def sweep_expired(self) -> List[str]:
+        """Resolve any records whose wall-clock age exceeded their timeout.
+
+        Safety net for callers that registered but are not actively awaiting
+        (await_decision already handles its own timeout).  Returns swept ids.
+        """
+        now = time.time()
+        expired = [
+            did for did, rec in list(self._pending.items())
+            if now - rec.created_at > rec.timeout_s
+        ]
+        for did in expired:
+            rec = self._pending.pop(did, None)
+            if rec is None:
+                continue
+            self._timed_out += 1
+            if not rec.future.done():
+                rec.future.set_result(self._timeout_outcome(rec))
+        return expired
+
+
+_registry: Optional[PendingDecisionRegistry] = None
+
+
+def get_pending_decision_registry() -> PendingDecisionRegistry:
+    """Return the process-wide singleton registry."""
+    global _registry
+    if _registry is None:
+        _registry = PendingDecisionRegistry()
+    return _registry
+
+
+# ---------------------------------------------------------------------------
+# High-level gate — the single entry the cognitive loop calls to ask a human
+# ---------------------------------------------------------------------------
+# Emit callback: given (device_id, decision_request_message) deliver it.
+EmitCallback = Callable[[str, Dict[str, Any]], Awaitable[Any]]
+
+
+async def request_human_decision(
+    *,
+    title: str,
+    summary: str = "",
+    options: Optional[List[Dict[str, str]]] = None,
+    default_option: Optional[str] = None,
+    urgency: str = "normal",
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    on_timeout: Optional[OnTimeout] = None,
+    devices: Optional[List[str]] = None,
+    emit: Optional[EmitCallback] = None,
+    session_id: str = "",
+    runtime_session_id: str = "",
+) -> DecisionOutcome:
+    """Ask connected device(s) a question and block (bounded) for the answer.
+
+    This is the canonical HITL entry point.  ``emit`` is the transport hook —
+    if ``None``, the default gateway emitter (:func:`_default_emit`) is used,
+    which sends a ``decision_request`` to each device via the gateway
+    connection manager (works for WearOS and phones alike).
+
+    Trigger policy ("when to ask") is intentionally left to the caller — this
+    function is the mechanism, invoked 依实际情况 by whatever cognitive gate
+    decides a human is needed.
+    """
+    option_ids = [str(o.get("id")) for o in (options or []) if o.get("id") is not None]
+    registry = get_pending_decision_registry()
+    record = registry.register(
+        options=option_ids,
+        default_option=default_option,
+        on_timeout=on_timeout,
+        urgency=urgency,
+        timeout_s=timeout_s,
+        session_id=session_id,
+        runtime_session_id=runtime_session_id,
+        devices=devices or [],
+    )
+
+    decision_request = {
+        "type": "decision_request",
+        "payload": {
+            "decision_id": record.decision_id,
+            "title": title,
+            "summary": summary,
+            "options": options or [],
+            "urgency": urgency,
+            "timeout_ms": int(timeout_s * 1000),
+            "default_option": default_option,
+            "source": "openclawd",
+            "timestamp": time.time(),
+        },
+    }
+
+    _emit = emit or _default_emit
+    targets = devices if devices is not None else await _discover_target_devices()
+    if not targets:
+        logger.warning("HITL.request: no target devices for decision_id=%s", record.decision_id)
+    for did in targets:
+        try:
+            await _emit(did, decision_request)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("HITL.request: emit to %s failed: %s", did, exc)
+
+    return await registry.await_decision(record)
+
+
+async def _default_emit(device_id: str, message: Dict[str, Any]) -> None:
+    """Default transport: deliver via the gateway connection manager."""
+    from galaxy_gateway.websocket_handler import connection_manager  # noqa: PLC0415
+    await connection_manager.send_to_device(device_id, message)
+
+
+async def _discover_target_devices() -> List[str]:
+    """Auto-discover connected WearOS + phone device ids to ask."""
+    try:
+        from galaxy_gateway.websocket_handler import connection_manager  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return []
+    try:
+        from core.routes._shared import registered_devices  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        registered_devices = {}
+    try:
+        ids = await connection_manager.get_connected_devices()
+    except Exception:  # noqa: BLE001
+        return []
+    targets: List[str] = []
+    for did in ids:
+        dtype = str((registered_devices.get(did) or {}).get("device_type", "")).lower()
+        if dtype in ("wear_os", "wearos", "watch", "galaxy_watch") or "phone" in dtype:
+            targets.append(did)
+    return targets

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -602,6 +602,49 @@ _RESOURCE_BUILTIN_TOOLS: List[Dict] = [
 ]
 
 
+# PR-HITL: agent-callable "ask the human" tool.  Lets the LLM decide, during its
+# own reasoning, to ask a human a question and block for the answer via the real
+# decision loop (request_human_decision → device notification → human_input).
+_ASK_HUMAN_BUILTIN_TOOLS: List[Dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "ask_human__request",
+            "description": (
+                "Ask a human for a decision or input and wait (bounded) for the reply. "
+                "Use when you genuinely need human clarification, approval, or a choice "
+                "before continuing — e.g. ambiguous intent, or an irreversible/risky step. "
+                "Blocks up to timeout_s; on timeout the configured fallback applies. "
+                "Returns {status, selected_option, voice_input, should_proceed}."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Short question/title shown to the human."},
+                    "summary": {"type": "string", "description": "Optional fuller explanation of what is being asked."},
+                    "options": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "label": {"type": "string"},
+                            },
+                            "required": ["id", "label"],
+                        },
+                        "description": "Optional choice list; omit for free-form/voice reply.",
+                    },
+                    "default_option": {"type": "string", "description": "Option id to fall back to on timeout (optional)."},
+                    "urgency": {"type": "string", "enum": ["low", "normal", "high"], "description": "Affects notification priority and timeout fallback (default normal)."},
+                    "timeout_s": {"type": "integer", "description": "Seconds to wait (default 60, clamped 5–3600)."},
+                },
+                "required": ["title"],
+            },
+        },
+    },
+]
+
+
 # PR-515 / GAP-512-009: OpenClawd is the multimodal ingress authority.
 # CriticalPathHarness records are written from _select_multimodal_route()
 # so that routing decisions are canonical-runtime-inspectable, not only
@@ -6746,6 +6789,9 @@ class OpenClawd:
         # ── Governed system resource layer tools (始终收集, PR-7) ─────────
         tools.extend(_RESOURCE_BUILTIN_TOOLS)
 
+        # ── Agent-callable human-decision tool (PR-HITL) ─────────────────────
+        tools.extend(_ASK_HUMAN_BUILTIN_TOOLS)
+
         return tools
 
     async def _dispatch_tool_call(self, tool_name: str, arguments: dict) -> dict:
@@ -6982,6 +7028,11 @@ class OpenClawd:
                 # Governed system resource layer tools (PR-7): resource__list, __status, etc.
                 action = tool_name[10:]  # strip "resource__"
                 return await self._dispatch_resource_tool(action, arguments)
+
+            elif tool_name.startswith("ask_human__"):
+                # Agent-callable human-decision tool (PR-HITL): ask_human__request
+                action = tool_name[len("ask_human__"):]
+                return await self._dispatch_ask_human_tool(action, arguments)
 
             else:
                 return {"success": False, "error": f"未知工具前缀: {tool_name}"}
@@ -7452,6 +7503,41 @@ class OpenClawd:
                 }
         except Exception as exc:
             logger.warning("_dispatch_resource_tool '%s' failed: %s", action, exc)
+            return {"success": False, "error": str(exc)}
+
+    async def _dispatch_ask_human_tool(self, action: str, arguments: dict) -> dict:
+        """Dispatch ``ask_human__*`` — let the agent ask a human and block for the reply.
+
+        Canonical HITL entry from the cognitive loop: routes to
+        ``request_human_decision`` (→ device notification → ``human_input`` →
+        registry resolve), threading the current session for traceability.
+        """
+        if action != "request":
+            return {"success": False, "error": f"Unknown ask_human action: {action!r} (valid: request)"}
+        title = str(arguments.get("title") or "").strip()
+        if not title:
+            return {"success": False, "error": "ask_human__request requires 'title'"}
+        try:
+            from core.interaction.pending_decision_registry import request_human_decision
+            try:
+                timeout_s = float(arguments.get("timeout_s") or 60)
+            except (TypeError, ValueError):
+                timeout_s = 60.0
+            timeout_s = max(5.0, min(3600.0, timeout_s))
+            sid = getattr(self, "_current_session_id", "") or ""
+            outcome = await request_human_decision(
+                title=title,
+                summary=str(arguments.get("summary") or ""),
+                options=arguments.get("options") or None,
+                default_option=arguments.get("default_option"),
+                urgency=str(arguments.get("urgency") or "normal"),
+                timeout_s=timeout_s,
+                session_id=sid,
+                runtime_session_id=sid,
+            )
+            return {"success": True, **outcome.to_dict()}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ask_human tool failed: %s", exc)
             return {"success": False, "error": str(exc)}
 
     # ========================================================================

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -798,16 +798,37 @@ async def handle_command(connection_id: str, aip_msg):
         elif command_text == "human_input":
             # WearOS sendHumanInput → command="human_input"
             # {decision_id, selected_option?, voice_input?}. 人在回路(HITL)的决策回复。
-            # 注：v2 当前发决策(android_bridge decision_request)是 fire-and-forget——
-            # decision_id 未登记,没有 pending-decision 注册表可按 decision_id 关联解析
-            # (更深的架构缺口,见 PR 说明)。在补齐注册表之前,这里把人类回复(语音/所选项)
-            # 作为一条人类输入送进认知闭环 handle_request(source="wear_decision"),确保用户
-            # 意图抵达大脑、而非像此前那样被当设备命令丢弃。
+            # 两条路:
+            #  1) 该回复应答某个 pending decision(由 request_human_decision 登记)→
+            #     resolve 之,等待中的认知协程在原上下文恢复(PR-HITL 闭环)。
+            #  2) 未命中任何 pending(主动/无主语音)→ 回退把人类输入送进认知闭环
+            #     handle_request(source="wear_decision"),确保意图不丢、不被当设备命令。
             decision_id = str(_payload.get("decision_id") or "")
             voice_input = str(_payload.get("voice_input") or "").strip()
             selected = str(_payload.get("selected_option") or "").strip()
             human_msg = voice_input or selected
-            if not human_msg:
+
+            # PR-HITL: if this reply answers a pending decision (registered by
+            # request_human_decision), resolve it — the asking coroutine resumes
+            # in its original context. First reply wins; fan-out duplicates no-op.
+            resolved = False
+            if decision_id:
+                try:
+                    from core.interaction.pending_decision_registry import (
+                        get_pending_decision_registry,
+                    )
+                    resolved = get_pending_decision_registry().resolve(
+                        decision_id,
+                        selected_option=selected or None,
+                        voice_input=voice_input,
+                        source="wear",
+                    )
+                except Exception as _reg_err:
+                    logger.debug("human_input resolve skipped: %s", _reg_err)
+
+            if resolved:
+                result = {"success": True, "decision_id": decision_id, "resolved": True}
+            elif not human_msg:
                 result = {"success": False, "error": "empty human input", "decision_id": decision_id}
             else:
                 try:

--- a/tests/test_hitl_pending_decision_registry.py
+++ b/tests/test_hitl_pending_decision_registry.py
@@ -1,0 +1,128 @@
+"""PR-HITL: tests for the human-in-the-loop pending-decision registry."""
+import asyncio
+
+import pytest
+
+from core.interaction.pending_decision_registry import (
+    DecisionStatus,
+    OnTimeout,
+    PendingDecisionRegistry,
+    derive_default_on_timeout,
+    request_human_decision,
+)
+
+
+def _fresh() -> PendingDecisionRegistry:
+    return PendingDecisionRegistry()
+
+
+def test_derive_default_on_timeout_composite():
+    assert derive_default_on_timeout("high", has_default=True) == OnTimeout.CANCEL
+    assert derive_default_on_timeout("high", has_default=False) == OnTimeout.CANCEL
+    assert derive_default_on_timeout("normal", has_default=True) == OnTimeout.DEFAULT_OPTION
+    assert derive_default_on_timeout("normal", has_default=False) == OnTimeout.PROCEED
+    assert derive_default_on_timeout("low", has_default=True) == OnTimeout.PROCEED
+
+
+@pytest.mark.asyncio
+async def test_resolve_wins():
+    reg = _fresh()
+    rec = reg.register(options=["confirm", "cancel"], timeout_s=5, decision_id="d1")
+
+    async def replier():
+        await asyncio.sleep(0.01)
+        assert reg.resolve("d1", selected_option="confirm", source="wear") is True
+
+    asyncio.create_task(replier())
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.RESOLVED
+    assert outcome.selected_option == "confirm"
+    assert outcome.should_proceed is True
+    assert reg.stats()["resolved"] == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_default_option():
+    reg = _fresh()
+    rec = reg.register(
+        options=["a", "b"], default_option="a",
+        on_timeout=OnTimeout.DEFAULT_OPTION, timeout_s=0.05, decision_id="d2",
+    )
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.TIMEOUT_DEFAULT
+    assert outcome.selected_option == "a"
+    assert outcome.timed_out and outcome.should_proceed
+
+
+@pytest.mark.asyncio
+async def test_timeout_cancel_high_urgency():
+    reg = _fresh()
+    # high urgency with no pinned policy → derive CANCEL
+    rec = reg.register(options=["go"], urgency="high", timeout_s=0.05, decision_id="d3")
+    assert rec.on_timeout == OnTimeout.CANCEL
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.TIMEOUT_CANCEL
+    assert outcome.timed_out and not outcome.should_proceed
+
+
+@pytest.mark.asyncio
+async def test_timeout_proceed_low_urgency():
+    reg = _fresh()
+    rec = reg.register(options=["go"], urgency="low", timeout_s=0.05, decision_id="d4")
+    assert rec.on_timeout == OnTimeout.PROCEED
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.TIMEOUT_PROCEED
+    assert outcome.should_proceed
+
+
+@pytest.mark.asyncio
+async def test_fanout_first_reply_wins():
+    reg = _fresh()
+    rec = reg.register(options=["x"], timeout_s=5, decision_id="d5")
+    assert reg.resolve("d5", selected_option="x", source="watch") is True
+    # second reply (e.g. from phone) is a no-op
+    assert reg.resolve("d5", selected_option="x", source="phone") is False
+    outcome = await reg.await_decision(rec)
+    assert outcome.status == DecisionStatus.RESOLVED and outcome.source == "watch"
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_id_is_false():
+    reg = _fresh()
+    assert reg.resolve("nope", selected_option="x") is False
+
+
+@pytest.mark.asyncio
+async def test_request_human_decision_end_to_end(monkeypatch):
+    import core.interaction.pending_decision_registry as mod
+
+    emitted = []
+
+    async def fake_emit(device_id, message):
+        emitted.append((device_id, message["payload"]["decision_id"]))
+
+    # singleton registry is used by request_human_decision + resolve
+    reg = mod.get_pending_decision_registry()
+
+    async def driver():
+        # wait for the emit to happen, then resolve via the singleton
+        for _ in range(100):
+            if emitted:
+                break
+            await asyncio.sleep(0.005)
+        did = emitted[0][1]
+        assert reg.resolve(did, selected_option="confirm", source="wear") is True
+
+    asyncio.create_task(driver())
+    outcome = await request_human_decision(
+        title="Proceed?",
+        options=[{"id": "confirm", "label": "确认"}, {"id": "cancel", "label": "取消"}],
+        urgency="normal",
+        timeout_s=5,
+        devices=["watch-1", "phone-1"],
+        emit=fake_emit,
+    )
+    assert outcome.status == DecisionStatus.RESOLVED
+    assert outcome.selected_option == "confirm"
+    # fanned out to both devices
+    assert {d for d, _ in emitted} == {"watch-1", "phone-1"}


### PR DESCRIPTION
## HITL 触发器（两个都要）+ 重新落地孤儿化的决策注册表

> ⚠️ **重要修复**：#1359（HITL 注册表）是 stacked PR（base = `claude/v2-wear-voice-brain`），它 merge 进的是 **base 分支**而非 main；而 base 早已并入 main，导致 **#1359 的内容成了孤儿、从未真正落到 main**（`core/interaction/pending_decision_registry.py` 在 main 上不存在）。本 PR 把 HITL 核心重新落地到最新 main，并按你的要求接上**两个**触发器。本 PR **取代** #1359。

### 1) 重新落地 HITL 核心（取自孤儿分支，适配当前 main）
- `core/interaction/pending_decision_registry.py`：有界阻塞 Future 注册表 + `request_human_decision` + 复合超时兜底（`OnTimeout`，依 urgency 派生），默认 60s。
- `tests/test_hitl_pending_decision_registry.py`。
- `websocket_handler.py`：`human_input` **先 `resolve(decision_id)`** → 命中唤醒等待协程；未命中回退 `handle_request`（保留 #1357 行为）。

### 2) 触发器①——agent 可调用的「询问用户」工具（LLM 自决何时问人）
`core/openclawd.py`：注册 builtin 工具 **`ask_human__request`**（schema：title/summary/options/default_option/urgency/timeout_s）；`_dispatch_tool_call` 路由 `ask_human__` 前缀；新增异步 `_dispatch_ask_human_tool` → `request_human_decision`，回 outcome。LLM 在推理中可主动调用它向人发问并阻塞等待。

### 3) 触发器②——高风险动作前置确认门（最保守）
`core/command_router.py`：在唯一执行咽喉 `_dispatch_to_device`（执行器调用前），当 `GALAXY_HITL_CONFIRM_GATE` 开启且 `_is_high_risk_command`（delete/format/shutdown/sudo/payment 等）→ `_await_high_risk_confirmation` 阻塞等人确认。**仅 "approve" 放行**；deny / 超时 / 无设备 / 异常一律 **fail-closed 中止**（回 `HITL_DENIED`/`HITL_TIMEOUT`）。`.env.example` 加 `GALAXY_HITL_CONFIRM_GATE`（默认关）+ `GALAXY_HITL_CONFIRM_TIMEOUT_S`。

### 验证
- 5 文件 `py_compile` 通过；注册表单测全过（asyncio harness，无 pytest）。
- **触发器①**：`ask_human` 往返（emit→resolve→outcome）通过。
- **触发器②**：高风险 `approve`=放行、`deny`+`timeout`=中止 通过。
- **完整回路**：`request_human_decision`(协程阻塞) → emit → `handle_command` `human_input` → `resolve` → 提问协程在原上下文恢复 通过。

### 诚实说明 ⚠️
- 沙箱无 pytest（asyncio harness 跑等价断言）、无真机、无 LLM（工具 schema 正确但未经真实 function-calling 往返）。
- 触发器②默认关闭、opt-in、fail-closed；开启后高风险命令会阻塞至多 `timeout_s` 等确认。
- 未重新落地 #1359 里 `push_decision_to_wearos` 的 `decision_id` 形参（非关键——canonical emit 走 `connection_manager`）。
- 配套手表接收端为 galaxy-wearos PR #2。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_