### PR TITLE
fix(clone-to-use): 全链路检修 — 网关/守护/健康检查/端口/图标/字体 共 12 项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ electron/package-lock.json
 
 # Panel runtime state written by unified_panel_aggregation during tests
 runtime/panel_last_operator_action.json
+
+# Client-discovery entrypoint written by unified_launcher on every launch
+runtime/entrypoint.json

--- a/core/node_lifecycle_governor.py
+++ b/core/node_lifecycle_governor.py
@@ -721,9 +721,9 @@ class NodeLifecycleGovernor:
         # Identify wild-growth nodes in NodeFabricRegistry not governed here
         wild_growth: List[str] = []
         try:
-            from core.nodes.node_fabric_registry import NodeFabricRegistry
+            from core.nodes.node_fabric_registry import get_node_fabric_registry
 
-            registry = NodeFabricRegistry.get_instance()
+            registry = get_node_fabric_registry()
             governed_names = {r.node_name for r in records}
             for node in registry.get_all_nodes():
                 if node.node_id not in governed_names and node.node_name not in governed_names:

--- a/core/projection/runtime_truth_compiler.py
+++ b/core/projection/runtime_truth_compiler.py
@@ -335,9 +335,9 @@ def _compile_continuum() -> Optional[Dict[str, Any]]:
     """Source #1: ContinuumState."""
     # Try cognitive field engine (Block-3 integration)
     try:
-        from core.cognitive.cognitive_field_engine import CognitiveFieldEngine
+        from core.cognitive.cognitive_field_engine import get_cognitive_field_engine
 
-        engine = CognitiveFieldEngine.get_instance()
+        engine = get_cognitive_field_engine()
         if engine is not None and hasattr(engine, "get_continuum_state"):
             state = engine.get_continuum_state()
             if state is not None:
@@ -465,7 +465,7 @@ def _compile_oneapi() -> Dict[str, Any]:
             build_oneapi_integration_summary,
         )
 
-        summary = build_oneapi_integration_summary()
+        summary = build_oneapi_integration_summary().to_dict()
         summary.setdefault("system_layer", ONEAPI_SYSTEM_LAYER)
         return summary
     except Exception as exc:

--- a/core/routes/projection.py
+++ b/core/routes/projection.py
@@ -4617,9 +4617,9 @@ def _get_continuum_state_with_source() -> Tuple[Optional["ContinuumState"], str,
     """
     try:
         # Try the cognitive field engine first (Block-3 integration).
-        from core.cognitive.cognitive_field_engine import CognitiveFieldEngine
+        from core.cognitive.cognitive_field_engine import get_cognitive_field_engine
 
-        engine = CognitiveFieldEngine.get_instance()
+        engine = get_cognitive_field_engine()
         if engine is not None and hasattr(engine, "get_continuum_state"):
             state = engine.get_continuum_state()
             if state is not None:

--- a/core/system_orchestrator.py
+++ b/core/system_orchestrator.py
@@ -627,8 +627,9 @@ class SystemOrchestrator:
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
-                # Detached so Electron survives if Python parent exits
-                start_new_task=True if sys.platform != "win32" else False,
+                # Detached so Electron survives if Python parent exits.
+                # (POSIX: setsid via start_new_session; ignored on Windows.)
+                start_new_session=True if sys.platform != "win32" else False,
             )
 
             # Start a background thread to drain stdout (prevents pipe buffer fill)

--- a/main.py
+++ b/main.py
@@ -665,6 +665,11 @@ def _run_setup_wizard() -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Galaxy V2 Unified Entry")
     parser.add_argument("--setup", action="store_true", help="Run interactive setup wizard")
+    # Accept --host/--port so the documented start command
+    # (`python main.py --host 127.0.0.1 --port 8299`) works instead of crashing
+    # with "unrecognized arguments".  Default None ⇒ keep the config default.
+    parser.add_argument("--host", type=str, default=None, help="API 服务监听地址 (默认取配置)")
+    parser.add_argument("--port", "-p", type=int, default=None, help="API 服务端口 (默认 9000)")
     args = parser.parse_args()
 
     if args.setup:
@@ -708,6 +713,11 @@ def main() -> int:
     from unified_launcher import GalaxyUnified
 
     lumiv = GalaxyUnified()
+    # Apply optional CLI overrides for the API gateway bind address/port.
+    if args.host:
+        lumiv.config.host = args.host
+    if args.port:
+        lumiv.config.web_ui_port = args.port
 
     async def _run() -> None:
         # ── Galaxy WebSocket Bridge — 桌面覆盖层事件推送 ──

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -438,12 +438,27 @@ class UnifiedWebUI:
                 self.config.host, self.config.web_ui_port
             )
             logger.info("API 文档: http://localhost:%d/docs", self.config.web_ui_port)
-            # Bind socket and run ASGI startup before probing HTTP — otherwise
-            # run_startup_health_check hits connection refused (WinError 10061).
-            await server.startup()
+            # Run uvicorn via the public serve() entrypoint in a background task.
+            # serve() correctly loads the config AND initialises self.lifespan;
+            # manually calling server.startup() breaks on uvicorn ≥0.30 with
+            # "'Server' object has no attribute 'lifespan'" (the gateway then never
+            # binds — /api/v1/chat is unreachable even though the banner says ready).
+            # We wait on the public ``server.started`` flag so the socket is bound
+            # before probing, then let serve()'s main_loop keep running in the
+            # background so the launcher proceeds to later phases (Electron / ready
+            # banner) instead of blocking here.
+            self._server = server
+            self._serve_task = asyncio.create_task(server.serve())
+            for _ in range(300):  # up to ~30s for bind + ASGI startup
+                if server.started or self._serve_task.done():
+                    break
+                await asyncio.sleep(0.1)
+            if self._serve_task.done():
+                # serve() exited during startup — re-raise the real error so the
+                # caller logs an accurate "API 网关启动失败" cause.
+                self._serve_task.result()
             print_section("启动后健康检查")
             await run_startup_health_check(self.config.web_ui_port)
-            await server.main_loop()
 
         except ImportError as e:
             logger.error("API 服务依赖未安装: %s", e)


### PR DESCRIPTION
## clone-to-use 全链路排查与检修

按 `docs/CLONE_TO_USE_REALITY.md` 的 canonical 路径**实际逐阶段运行** `python main.py` + 审计安装/脚本/入口，系统性修掉从"起不来 / 点不开"到"图标怪 / curl 失败"的全部真实问题。

### 🔴 P0 — 让系统根本起不来 / 不可用
1. **主 API 网关从不绑定**（`unified_launcher` 误用 uvicorn 私有 `server.startup()` → `'Server' object has no attribute 'lifespan'`）→ :9000 不监听、`/api/v1/chat` 不可达，却照打"系统就绪"。改用公共 `serve()` 后台任务 + `started` 标志。**整套起不来的根因。**
2. **启动健康检查冻结事件循环**（`run_startup_health_check` 用同步 `urllib` 探测，阻塞了网关所在的 loop）→ `Launcher /health: timed out`（看起来全挂）。改为 `asyncio.to_thread` 卸载所有阻塞探测。**实测 `/health: HTTP 200`。**
3. **守护进程点不开**：`galaxy_daemon.py` 缺 `if __name__=="__main__"`，`python galaxy_daemon.py` 跑了等于没跑。补入口。
4. **Electron 三态 GUI 起不来**：预检 `Popen(start_new_task=)` 非法参数抛 TypeError（preflight DEGRADED）。改 `start_new_session`，预检恢复 READY。

### 🟠 P1 — 坏/困惑但可恢复
5. **端口文档与实际不符（你踩到的）**：运行时实际绑 **9000**，但文档/状态板/健康检查/引导回退/测试全写旧值 **8299** → `curl :8299` 必然失败、状态板默认连不上。统一对齐到实际的 9000（不动运行绑定与 compose 拓扑）。
6. **Electron 启动**：无 `npx` 时退化成非法命令 `npm electron .` + 首次 `npm install` 静默吞错 → 改用本地 `electron` 二进制 + 可见错误 + 600s。
7. **文档启动命令崩溃**：`python main.py --host ... --port ...` 之前 `unrecognized arguments` → 已补 `--host/--port`。
8. **投影真相静默降级**：3 处访问器写错（`get_instance()` 不存在）→ 改用真实 `get_*()`。
9. **本地模型误加载**：Ollama 标签 `gemma4:12b` 喂给 HF transformers 报错刷屏 → 加守卫静默跳过。

### 🎨 桌面观感（你要求）
10. **全新桌面图标**（替换默认 Electron 原子 logo）：深空圆角 + 发光青色存在感内核 + 三态点（Pillow 生成）；托盘图标同款重画（去掉旧"圈中 G"）。
11. **Windows 任务栏图标**：多尺寸 `icon.ico` + `app.setAppUserModelId` + 快捷方式 `IconLocation`。
12. **现代字体**：Inter 优先栈 + CJK 回退 + 抗锯齿（覆盖层/面板/构建产物）。

### 验证
- `validate_runtime.py` **PASS（148/1/0）**，readiness=READY 6/6，`[DESKTOP_SURFACE] OK — Electron GUI launched`。
- 真实 uvicorn 后台任务下 `Launcher /health: HTTP 200`（修复前 timed out）；网关 lifespan 隔离复现+修复验证。
- `unified_launcher` 端口解析仍=9000；用户可见 8299 引用已清零；触动的 .py 全部编译通过；图标已渲染预览。

### ⚠️ 诚实边界
沙箱**无显示器、且会杀监听 socket 的进程（exit 144）**：无法在此活体 `curl :9000` 或截图 Windows 任务栏图标。但网关/健康检查均以真实 uvicorn 隔离验证，图标 PNG 已预览，端口对齐有 `get_service_port` 实证。**请在本机拉分支跑一次确认**。CI 全红是仓库级 runner 故障（与本 PR 无关）。

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b