### PR TITLE
fix(clone-to-use): Electron 崩溃可诊断+重启退避 + 节点离线日志聚合

### DIFF
--- a/core/node_discovery.py
+++ b/core/node_discovery.py
@@ -347,26 +347,47 @@ class NodeDiscoveryService:
                 await asyncio.sleep(HEARTBEAT_INTERVAL)
                 now = time.time()
 
+                newly_offline: list = []
+                newly_suspect: list = []
                 for node in list(self.nodes.values()):
                     if node.node_id == self.node_id:
                         continue
 
                     elapsed = now - node.last_heartbeat
-                    old_state = node.state
 
                     if elapsed > NODE_TIMEOUT:
                         if node.state != DiscoveryState.OFFLINE:
                             node.state = DiscoveryState.OFFLINE
-                            logger.warning(f"节点离线: {node.node_id} (超时 {elapsed:.0f}s)")
+                            newly_offline.append(node.node_id)
                             for cb in self._on_node_left:
                                 _safe_call(cb, node)
                     elif elapsed > HEARTBEAT_INTERVAL * 2:
                         if node.state != DiscoveryState.SUSPECT:
                             node.state = DiscoveryState.SUSPECT
-                            logger.info(f"节点可疑: {node.node_id} (心跳延迟 {elapsed:.0f}s)")
+                            newly_suspect.append(node.node_id)
                     else:
                         if node.state not in (DiscoveryState.HEALTHY, DiscoveryState.REGISTERED):
                             node.state = DiscoveryState.HEALTHY
+
+                # 聚合日志：避免一次刷出上百行红色「节点离线」。desktop-local 单机下，
+                # 从静态注册表 seed 的节点并不广播 UDP 心跳（其可用性以 HTTP 健康为准），
+                # 因此批量 UDP 超时属预期、非致命，不影响 API/网关。状态与回调逻辑不变。
+                if newly_offline:
+                    if len(newly_offline) > 8:
+                        logger.warning(
+                            "%d 个节点 UDP 心跳超时转为离线（单机下未广播心跳的节点属正常，"
+                            "以 HTTP 健康为准，不影响 API）。示例: %s …",
+                            len(newly_offline), ", ".join(newly_offline[:8]),
+                        )
+                        for _nid in newly_offline:
+                            logger.debug("节点离线明细: %s", _nid)
+                    else:
+                        logger.warning("节点离线: %s", ", ".join(newly_offline))
+                if newly_suspect:
+                    if len(newly_suspect) > 8:
+                        logger.debug("%d 个节点心跳延迟（可疑）", len(newly_suspect))
+                    else:
+                        logger.info("节点可疑(心跳延迟): %s", ", ".join(newly_suspect))
 
             except asyncio.CancelledError:
                 break

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -656,10 +656,21 @@ class GalaxyUnified:
             else:
                 npx = shutil.which("npx")
                 cmd = [npx, "electron", "."] if npx else [npm, "exec", "--", "electron", "."]
+            # Capture Electron stdout/stderr to logs/electron.log so crashes are
+            # diagnosable (previously DEVNULL-swallowed → impossible to debug the
+            # "exited, restarting" loop / why Ctrl+Space overlay never appears).
+            _log_dir = Path("logs")
+            _log_dir.mkdir(exist_ok=True)
+            _elog = open(_log_dir / "electron.log", "ab")
+            _elog.write(
+                f"\n===== electron start {__import__('datetime').datetime.now().isoformat()} "
+                f"cmd={cmd} =====\n".encode("utf-8", "replace")
+            )
+            _elog.flush()
             self.electron_proc = sp.Popen(
                 cmd,
                 cwd=str(electron_dir),
-                stdout=sp.DEVNULL, stderr=sp.DEVNULL,
+                stdout=_elog, stderr=sp.STDOUT,
                 env=env,
             )
             return True
@@ -668,15 +679,42 @@ class GalaxyUnified:
             return False
 
     async def watch_processes(self):
-        """进程保活：监控 Gateway 和 Electron，崩溃时自动重启。"""
+        """进程保活：监控 Electron，崩溃时自动重启（带退避与上限，避免无限刷屏）。
+
+        Electron 的 stdout/stderr 现写入 logs/electron.log；若它反复快速崩溃，
+        在 60s 窗口内重启达到上限后停止自动重启并给出明确指引（后端/API 不受影响）。
+        """
         import asyncio
+        import time
+        restarts: list = []          # 最近一次窗口内的重启时间戳
+        MAX_RAPID = 5                 # 60s 内连续崩溃上限
+        gave_up = False
         while True:
-            await asyncio.sleep(10)
-            # Check Electron
-            if hasattr(self, 'electron_proc') and self.electron_proc:
-                if self.electron_proc.poll() is not None:
-                    logger.warning("Electron exited, restarting...")
-                    await self.start_electron()
+            await asyncio.sleep(5)
+            proc = getattr(self, 'electron_proc', None)
+            if not proc:
+                continue
+            if proc.poll() is None:
+                continue              # 仍在运行
+            if gave_up:
+                continue
+            now = time.time()
+            restarts = [t for t in restarts if now - t < 60]
+            if len(restarts) >= MAX_RAPID:
+                gave_up = True
+                logger.error(
+                    "Electron 桌面覆盖层在 60s 内反复崩溃 %d 次，已停止自动重启。"
+                    "崩溃详情见 logs/electron.log；后端与 API 仍在 "
+                    "http://localhost:%d 正常运行（Ctrl+Space 覆盖层暂不可用）。",
+                    len(restarts), self.config.web_ui_port,
+                )
+                continue
+            restarts.append(now)
+            logger.warning(
+                "Electron 已退出，重启中（60s 内第 %d/%d 次；详情见 logs/electron.log）…",
+                len(restarts), MAX_RAPID,
+            )
+            await self.start_electron()
 
     async def setup(self):
         """加载配置并初始化服务管理器。"""


### PR DESCRIPTION
## 承接真机启动日志的两处剩余问题

真机日志确认：✅ 网关 `/health: HTTP 200`、9000 API、33/33 子系统、NATS 监听都正常（之前的修复已生效）。剩两处影响"整套系统可用感"的问题：

### 1. 🔴 Electron 桌面覆盖层反复 `exited, restarting`（Ctrl+Space 没用）
- **致命点**：`start_electron` 把 Electron 的 `stdout/stderr` 全 `DEVNULL` 吞掉 → 根本看不到它为什么崩，无法诊断。**改为写入 `logs/electron.log`**（每次启动带时间戳+命令头）。
- `watch_processes` 原来每 10s 无脑重启、无上限 → 无限刷屏。**改为 60s 窗口内最多重启 5 次**，超限即停止并明确提示"详情见 `logs/electron.log`；后端/API 仍在 :9000 正常"。
- ⇒ 下次真机运行即可从 `logs/electron.log` 看到**真正的崩溃原因**，再对症修复。

### 2. 🟠 上百行"节点离线 (超时 35s)"红字刷屏
- **根因**：`node_discovery` 从静态注册表 seed ~125 个节点进 **UDP 心跳**监控，但这些节点的可用性其实走 **HTTP**（节点进程不广播 UDP 心跳）→ 单机 desktop-local 下必然全部 35s 超时→误报离线刷屏。**非致命**（API/网关正常、节点经 HTTP 可达）。
- `_health_check_loop` 改为**聚合日志**：>8 个超时只打 1 行汇总（+debug 明细），**状态机与 `_on_node_left` 回调逻辑完全不变**。

### 验证
两文件 `py_compile` 通过。Electron 的**真实崩溃原因**需下次真机 `logs/electron.log` 才能定位——这正是本 PR 的目的（让它可见、并止住刷屏）。

### ⚠️ 诚实边界
沙箱无显示器/杀 socket 进程，无法在此重现 Electron 崩溃或截图。请你拉这个分支再跑一次，把 **`logs/electron.log`** 的内容发我——我据此修掉覆盖层崩溃的根因。节点离线已降为非刷屏汇总（属单机正常现象，不影响 API）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_