### PR TITLE
fix(desktop): 透明覆盖层 GPU 崩溃→闪退循环（默认禁用硬件加速）+ 崩溃诊断

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -12,6 +12,32 @@ if (process.platform === 'win32') {
     app.setAppUserModelId('ai.galaxy.desktop');
 }
 
+// ── 透明全屏覆盖层稳定性 ──
+// mainWindow 是 transparent + fullscreen + alwaysOnTop + WebGL(three.js) 覆盖层。
+// 在不少 Windows GPU/驱动组合上，透明窗口 + GPU 合成会让 GPU 进程崩溃 → 窗口关闭
+// → window-all-closed → app.quit() → 进程退出，外层 watch_processes 再拉起又崩，
+// 形成「exited, restarting」循环（Ctrl+Space 永远点不出来）。默认禁用硬件加速以
+// 保证覆盖层稳定显示（WebGL 退化为软件渲染，覆盖层够用）；如确认 GPU 正常可设
+// GALAXY_ELECTRON_GPU=1 恢复硬件加速。
+if (!['1', 'true', 'yes', 'on'].includes(
+        String(process.env.GALAXY_ELECTRON_GPU || '').trim().toLowerCase())) {
+    try {
+        app.disableHardwareAcceleration();
+    } catch (_e) { /* older electron may not support; non-fatal */ }
+}
+
+// ── GPU / 渲染进程崩溃诊断 ──
+// 把崩溃原因打到 stdout（→ logs/electron.log），便于定位「闪退循环」根因。
+app.on('gpu-process-gone', (_e, details) => {
+    console.error('[Main] gpu-process-gone:', JSON.stringify(details));
+});
+app.on('child-process-gone', (_e, details) => {
+    console.error('[Main] child-process-gone:', JSON.stringify(details));
+});
+app.on('render-process-gone', (_e, _wc, details) => {
+    console.error('[Main] render-process-gone:', JSON.stringify(details));
+});
+
 // ── 单实例锁 ──
 // 端口 EADDRINUSE 崩溃最常见的根因就是"已有一个实例在跑"。单实例锁从源头
 // 杜绝第二个进程争抢 IPC 端口；后来者直接退出，并唤起已存在的窗口。


### PR DESCRIPTION
## Electron 桌面覆盖层闪退循环（Ctrl+Space 点不出来）

真机日志确认：后端/9000 API/健康检查全部正常，唯一卡点是 Electron 覆盖层每 5s `exited, restarting` 循环（之前的 PR 已把它从无限刷屏收敛为崩 5 次停止 + 写 `logs/electron.log`）。

### 根因
`mainWindow` 是 **transparent + fullscreen + alwaysOnTop + WebGL(three.js)** 覆盖层。在不少 Windows GPU/驱动组合上，透明窗口 + GPU 合成会导致 **GPU 进程崩溃** → 窗口关闭 → `window-all-closed` → `app.quit()` → 整个进程退出 → 外层重启又崩 → 循环。这是 Electron 透明覆盖层在 Windows 上的经典症状。

### 修复
1. **默认 `app.disableHardwareAcceleration()`** —— 透明覆盖层 Windows 崩溃的标准修复（WebGL 退化为软件渲染，作为存在感覆盖层够用）。如确认 GPU 正常，设 `GALAXY_ELECTRON_GPU=1` 可恢复硬件加速。
2. **崩溃诊断日志** —— 新增 `gpu-process-gone` / `child-process-gone` / `render-process-gone` 监听，原因打到 `logs/electron.log`。即便根因不是 GPU，下次也能看到确切 reason。

### 验证
`node --check electron/main.js` 语法通过。

### ⚠️ 诚实边界
沙箱无显示器/GPU，无法在此复现透明窗口崩溃。`disableHardwareAcceleration` 是此症状最高概率、低风险的修复（最坏只是软件渲染慢一点，对当前"完全打不开"是净改善）。若禁用 HW 加速后**仍**崩溃，新的 `*-process-gone` 日志会在 `logs/electron.log` 写明确切原因，据此再精修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_