### PR TITLE
fix(desktop): 系统托盘改由 Python 启动器常驻（与 Electron 解耦，修复托盘消失）

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -215,21 +215,9 @@ app.whenReady().then(() => {
         console.warn('[IPC] Failed to start HTTP receiver:', err);
     }
 
-    // PR-D5: Start system tray alongside Electron GUI
-    // P22 修复：根据平台选择 python/python3，避免硬编码
-    try {
-        const { spawn } = require('child_process');
-        const pythonCmd = process.platform === 'win32' ? 'python' : 'python3';
-        const trayProcess = spawn(pythonCmd, ['-m', 'windows_service.tray_icon'], {
-            cwd: path.join(__dirname, '..'),
-            detached: true,
-            stdio: 'ignore'
-        });
-        trayProcess.unref();
-        console.log('System tray started');
-    } catch (err) {
-        console.warn('Failed to start system tray:', err);
-    }
+    // 系统托盘已改由 Python 启动器 (unified_launcher.start_system_tray) 在其自身进程
+    // 内常驻启动，与 Electron 解耦 —— 避免 Electron 崩溃/重启把右下角托盘图标带没，
+    // 也避免与 Python 侧重复启动出现两个托盘图标。此处不再 spawn。
 
     // Toggle AI Control Panel (Colorless Lens)
     // F12 在很多环境会被开发者工具/输入法/其他应用占用，因此注册一组候选

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -683,6 +683,25 @@ class GalaxyUnified:
             logger.error(f"Electron start failed: {exc}")
             return False
 
+    async def start_system_tray(self) -> bool:
+        """启动系统托盘（右下角），与 Electron 解耦、常驻于本启动器进程。
+
+        以前托盘由 Electron `spawn('python -m windows_service.tray_icon')` 拉起，
+        Electron 崩溃/重启就把托盘也带没了。现在在 Python 启动器自身进程的后台线程里
+        启动（start_tray_in_thread 内部 run_detached），后端存活期间托盘一直在。
+        缺 pystray/Pillow 时优雅降级（非致命）。
+        """
+        try:
+            from windows_service.tray_icon import start_tray_in_thread
+            tray = await asyncio.to_thread(start_tray_in_thread)
+            if tray is not None:
+                self._tray = tray
+                return True
+            return False
+        except Exception as exc:
+            logger.warning("系统托盘启动失败(非致命): %s", exc)
+            return False
+
     async def watch_processes(self):
         """进程保活 + GPU 自适应：监控 Electron，崩溃时自动重启。
 
@@ -887,6 +906,16 @@ class GalaxyUnified:
                 "如需桌面覆盖层：安装 Node.js≥18 后在 electron/ 执行 `npm install`。",
                 self.config.web_ui_port,
             )
+
+        # ── 系统托盘（独立于 Electron，常驻）──
+        # 托盘原先仅由 Electron 进程 spawn；Electron 在部分机器上崩溃/重启会让右下角
+        # 托盘图标随之消失。改由 Python 启动器在自身进程的后台线程启动，与 Electron
+        # 解耦 —— 后端在，托盘就在。
+        tray_ok = await self.start_system_tray()
+        if tray_ok:
+            print_status_row("系统托盘 — 右下角常驻", True)
+        else:
+            print_status_row("系统托盘 — 不可用 (pip install pystray Pillow)", False)
 
         # ── Ready ──
         print()


### PR DESCRIPTION
## 右下角系统托盘图标消失 — 改由 Python 启动器常驻

### 根因
不是图标绘制问题（已实测 `create_icon_image` 四种状态均正常渲染）。真因是托盘**原先仅由 Electron 进程 `spawn('python -m windows_service.tray_icon')`** 拉起 —— 而 Electron 在你机器上 GPU 崩溃→重启循环→最终放弃，把它 spawn 的（detached）托盘子进程也一并带没/不再重启 → 右下角图标消失。

### 修复（与 Electron 解耦）
- `unified_launcher` 新增 `start_system_tray()`：经 `asyncio.to_thread` 调 `windows_service.tray_icon.start_tray_in_thread`（内部 `run_detached` 后台线程跑 pystray），在 Phase 9 后启动。**后端存活期间托盘常驻**，不受 Electron 崩溃影响。缺 pystray/Pillow 时优雅降级。
- `electron/main.js` 移除原 tray spawn，避免与 Python 侧**重复出现两个托盘**。

### 验证
`py_compile` + `node --check` 通过；`create_icon_image` 四态渲染正常。

### ⚠️ 诚实边界 + 关于那个 "system" 报错
沙箱无 pystray/显示器，托盘真实显示需 Windows 实测。你提到的 "system 什么的" 报错信息太模糊我没能定位——**麻烦你下次启动时把那条报错的完整文字发我**（或 `logs\lumiv.log` / `logs\electron.log` 里相关行），我再对症处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_