### PR TITLE
fix(desktop): Electron 用绝对路径启动（修复 system-cannot-find-path 闪退根因）

### DIFF
--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -654,13 +654,19 @@ class GalaxyUnified:
                 env["GALAXY_ELECTRON_GPU"] = "0"
             # Prefer the locally-installed electron binary — robust and avoids the
             # `npm electron .` bug (invalid command) that hit when npx was absent.
+            # CRITICAL: use ABSOLUTE paths for both the binary and the app dir.
+            # 之前用相对路径 electron\node_modules\.bin\electron.cmd，而 Popen 的 cwd=electron，
+            # 系统会按 electron\electron\... 解析 → "The system cannot find the path specified."
+            # → Electron 根本起不来、闪退循环。绝对路径彻底消除该 cwd 相对解析歧义。
+            app_dir = electron_dir.resolve()
             bin_name = "electron.cmd" if os.name == "nt" else "electron"
-            local_electron = electron_dir / "node_modules" / ".bin" / bin_name
+            local_electron = (app_dir / "node_modules" / ".bin" / bin_name)
             if local_electron.exists():
-                cmd = [str(local_electron), "."]
+                cmd = [str(local_electron), str(app_dir)]
             else:
                 npx = shutil.which("npx")
-                cmd = [npx, "electron", "."] if npx else [npm, "exec", "--", "electron", "."]
+                cmd = ([npx, "electron", str(app_dir)] if npx
+                       else [npm, "exec", "--", "electron", str(app_dir)])
             # Capture Electron stdout/stderr to logs/electron.log so crashes are
             # diagnosable (previously DEVNULL-swallowed → impossible to debug the
             # "exited, restarting" loop / why Ctrl+Space overlay never appears).
@@ -674,7 +680,7 @@ class GalaxyUnified:
             _elog.flush()
             self.electron_proc = sp.Popen(
                 cmd,
-                cwd=str(electron_dir),
+                cwd=str(app_dir),
                 stdout=_elog, stderr=sp.STDOUT,
                 env=env,
             )


### PR DESCRIPTION
## Electron 闪退真正根因：相对路径 → "The system cannot find the path specified"

你的 `logs\electron.log` 给出了铁证：
```
cmd=['electron\node_modules\.bin\electron.cmd', '.']
The system cannot find the path specified.
```
→ **Electron 从未真正启动**（之前 GPU 崩溃的猜测不成立，那个"system 报错"就是这个）。

### 根因（我之前改动引入的 bug）
"优先用本地 electron 二进制"那次改动用了**相对路径** `electron\node_modules\.bin\electron.cmd`，但 `Popen` 的 `cwd` 又设成 `electron` → 系统按 `electron\electron\node_modules\...` 解析 → 找不到 → 每次秒退 → 闪退循环、Ctrl+Space 没用。

### 修复
二进制与 app 目录**全部用绝对路径**（`app_dir = electron_dir.resolve()`）：
- `cmd = [<abs>\node_modules\.bin\electron.cmd, <abs electron app dir>]`
- npx/npm 回退分支同样传绝对 app 目录
- `Popen(cwd=<abs app_dir>)`

彻底消除 cwd 相对解析歧义。GPU 自适应 + 崩溃诊断保留（electron 真起来后才用得上）。

### 验证
`py_compile` 通过。绝对路径解析正确，真机应不再报 "system cannot find path"，Electron 能真正启动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_