### PR TITLE
fix(desktop+warnings): 覆盖层唤醒快捷键(修"按不开") + device_registry/StateEventBus/system-info 3警告

### DIFF
--- a/core/device_registry.py
+++ b/core/device_registry.py
@@ -1056,4 +1056,9 @@ class DeviceRegistry:
 # 全局实例
 # ============================================================================
 
-device_reg
+device_registry = DeviceRegistry()
+
+
+def get_device_registry() -> "DeviceRegistry":
+    """Return the process-wide DeviceRegistry singleton."""
+    return device_registry

--- a/core/lumiv_websocket_bridge.py
+++ b/core/lumiv_websocket_bridge.py
@@ -99,8 +99,8 @@ class GalaxyPresenceBridge:
             self._loop = None
 
         try:
-            from core.state_event_bus import StateEventBus
-            bus = StateEventBus.get_instance()
+            from core.state_event_bus import get_state_event_bus
+            bus = get_state_event_bus()
 
             # 订阅三态转换事件
             bus.subscribe("phase.silent",   self._on_phase_silent)

--- a/electron/main.js
+++ b/electron/main.js
@@ -246,6 +246,24 @@ app.whenReady().then(() => {
         console.log(`[Main] 面板快捷键已注册: ${registeredShortcuts.join(', ')}`);
     }
 
+    // ── 三态覆盖层「唤醒/隐藏」全局快捷键 ──
+    // 之前没有任何唤醒快捷键被真正注册（启动横幅写的 Ctrl+Space 是假的），而且
+    // Ctrl+Space 在中文 Windows 会被输入法抢去切换中英文 → 用户「按不开」。
+    // 这里注册一组【不与输入法/系统冲突】的候选键，任一成功即可唤出覆盖层。
+    const WAKE_SHORTCUTS = [
+        'CommandOrControl+Alt+Space', 'CommandOrControl+Shift+Space',
+        'CommandOrControl+Alt+G', 'CommandOrControl+Shift+G',
+    ];
+    const wakeRegistered = WAKE_SHORTCUTS.filter((accel) => {
+        try { return globalShortcut.register(accel, () => toggleOverlayWake()); }
+        catch (e) { return false; }
+    });
+    const HIDE_SHORTCUTS = ['CommandOrControl+Alt+H', 'CommandOrControl+Shift+H'];
+    HIDE_SHORTCUTS.forEach((accel) => {
+        try { globalShortcut.register(accel, () => setOverlayPhase(false)); } catch (e) { /* ignore */ }
+    });
+    console.log('[Main] 覆盖层唤醒快捷键: ' + (wakeRegistered.join(', ') || '(全部注册失败)'));
+
     app.on('browser-window-created', (event, window) => {
         if (mainWindow) {
             mainWindow.setAlwaysOnTop(true, 'screen-saver');
@@ -320,6 +338,33 @@ function createPanelWindow() {
     });
 
     return panelWindow;
+}
+
+// ── 三态覆盖层手动唤醒/隐藏 ──
+// 覆盖层渲染层(app.js)根据 presence-state 的 depth_factor 决定 silent/liminal/manifest
+// 的可见度：depth≈0 几乎不可见(silent)，depth≈0.9 完全显现(manifest)。手动唤醒即向
+// 渲染层推一个高 depth 的 manifest 态并取消鼠标穿透以便交互；隐藏则推 silent。
+let _overlayAwake = false;
+function setOverlayPhase(awake) {
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    _overlayAwake = awake;
+    const payload = awake
+        ? { phase: 'manifest', depth_factor: 0.92, intent: 'manual_wake', speaking: false, source: 'hotkey' }
+        : { phase: 'silent', depth_factor: 0.0, intent: 'manual_sleep', speaking: false, source: 'hotkey' };
+    try { mainWindow.webContents.send('presence-state', payload); } catch (e) { /* ignore */ }
+    try {
+        // 唤醒时允许点击交互并置顶聚焦；隐藏时恢复点击穿透(不挡操作)。
+        mainWindow.setIgnoreMouseEvents(!awake, { forward: true });
+        if (awake) {
+            mainWindow.show();
+            mainWindow.setAlwaysOnTop(true, 'screen-saver');
+            mainWindow.focus();
+        }
+    } catch (e) { /* ignore */ }
+    console.log('[Overlay] ' + (awake ? '已唤醒(manifest)' : '已隐藏(silent)'));
+}
+function toggleOverlayWake() {
+    setOverlayPhase(!_overlayAwake);
 }
 
 function togglePanel() {

--- a/launcher/health_checks.py
+++ b/launcher/health_checks.py
@@ -88,10 +88,10 @@ async def run_startup_health_check(web_ui_port: int) -> None:
 
     # 2) system info
     try:
-        code = await asyncio.to_thread(_http_code, f"{base_url}/api/v1/system/info", 5)
-        print_status(f"system/info: HTTP {code}", "success")
+        code = await asyncio.to_thread(_http_code, f"{base_url}/api/v1/system/status", 5)
+        print_status(f"system/status: HTTP {code}", "success")
     except Exception as exc:
-        print_status(f"system/info: 失败 — {exc}", "warning")
+        print_status(f"system/status: 失败 — {exc}", "warning")
 
     # 3) Node_71 health
     try:

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -752,7 +752,7 @@ class GalaxyUnified:
                 logger.error(
                     "Electron 在 GPU 与软件渲染下均反复崩溃，已停止自动重启。"
                     "崩溃详情见 logs/electron.log；后端与 API 仍在 "
-                    "http://localhost:%d 正常运行（Ctrl+Space 覆盖层暂不可用）。",
+                    "http://localhost:%d 正常运行（Ctrl+Alt+Space 覆盖层暂不可用）。",
                     self.config.web_ui_port,
                 )
                 continue
@@ -903,7 +903,7 @@ class GalaxyUnified:
             print_status_row("Electron — v28.2.0", True)
             print_status_row("Three.js 3D 覆盖层 — 就绪", True)
             print_status_row("三态 UI — Active / Standby / Dormant", True)
-            print_status_row("快捷键 — Ctrl+Space 唤醒 / Ctrl+H 隐藏", True)
+            print_status_row("快捷键 — Ctrl+Alt+Space 唤醒 / Ctrl+Alt+H 隐藏 (避开输入法占用的 Ctrl+Space)", True)
         else:
             print_status_row("桌面覆盖层未启动 — 后端/API 仍完全可用", False)
             logger.warning(
@@ -933,7 +933,7 @@ class GalaxyUnified:
         print(f"  {Colors.CYAN}WebSocket:{Colors.ENDC}    ws://localhost:{self.config.web_ui_port}/ws")
         print(f"  {Colors.CYAN}状态面板:{Colors.ENDC}     http://localhost:{self.config.web_ui_port}/api/v1/projection/operability-contract")
         print(f"  {Colors.CYAN}API 文档:{Colors.ENDC}     http://localhost:{self.config.web_ui_port}/docs")
-        print(f"  {Colors.CYAN}桌面覆盖层:{Colors.ENDC}   Ctrl+Space 唤醒")
+        print(f"  {Colors.CYAN}桌面覆盖层:{Colors.ENDC}   Ctrl+Alt+Space 唤醒 (Ctrl+Alt+H 隐藏)")
         print(f"  {Colors.CYAN}进程保活:{Colors.ENDC}     Gateway + Electron 监控中")
         print()
         print(f"  {Colors.DIM}按 Ctrl+C 停止系统{Colors.ENDC}")


### PR DESCRIPTION
## 修「按不开」+ 3 个启动警告

系统已能起来（Electron launched、托盘常驻、9000 API 全绿），但覆盖层「按不开」。

### 1) 🔴 覆盖层按不开 —— 根本没注册唤醒快捷键
`main.js` 之前**只**注册了面板键（F12）；启动横幅写的 "Ctrl+Space 唤醒" 是**假的**，而且 `Ctrl+Space` 在中文 Windows 会被**输入法抢去切换中英文**。
- 注册一组不冲突的唤醒键：`Ctrl+Alt+Space` / `Ctrl+Shift+Space` / `Ctrl+Alt+G` / `Ctrl+Shift+G`（任一成功即可）；隐藏：`Ctrl+Alt+H` / `Ctrl+Shift+H`。
- `setOverlayPhase/toggleOverlayWake`：向渲染层推 `presence-state`（高 `depth_factor`=manifest 唤出 / 0=silent 隐藏）+ 切换鼠标穿透，让覆盖层真正显隐可交互。
- 横幅文案同步成真实快捷键。

### 2) 🔴 device_registry 单例缺失（顺带修，影响面更大）
`core/device_registry.py` 末尾是**一行裸 `device_reg`**（单例定义被截断）→ 整个模块 import 抛 `NameError: name 'device_reg' is not defined` → **13+ 处 `from core.device_registry import device_registry` 全部降级**（你日志里 "EventBridge: DeviceRegistry 连接失败" 即此）。补全为 `device_registry = DeviceRegistry()` + `get_device_registry()`。

### 3) 🟠 StateEventBus 访问器写错
`lumiv_websocket_bridge` 用了不存在的 `StateEventBus.get_instance()` → 改 `get_state_event_bus()`。消除 "StateEventBus subscription failed"。

### 4) 🟠 健康检查探了 404 路径
`/api/v1/system/info` 不存在 → 改探实际存在的 `/api/v1/system/status`。

### 验证
5 文件 `py_compile` + `node --check` 通过；`device_registry`/`get_device_registry`/`get_state_event_bus` 实例化均 OK。

### ⚠️ 诚实边界
沙箱无显示器，覆盖层显隐 + 快捷键需 Windows 实测。请 `git pull` 后 `python main.py`，**按 `Ctrl+Alt+Space`**（不是 Ctrl+Space）看覆盖层是否显现；若某个键被占用，日志 `[Main] 覆盖层唤醒快捷键: ...` 会列出实际注册成功的键。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_