### PR TITLE
cleanup + fusion + 三仓审查收尾:删冗余端点 / 语音收敛 / 修 lumiv 幽灵import / 文档端口对齐

### DIFF
--- a/android_client/README.md
+++ b/android_client/README.md
@@ -16,7 +16,7 @@ git clone https://github.com/DannyFish-11/ufo-galaxy-android.git
 cd ufo-galaxy-android
 
 # 2. 配置服务端地址（编辑 app/build.gradle）
-#    buildConfigField "String", "GALAXY_SERVER_URL", '"ws://YOUR_SERVER_IP:8765"'
+#    buildConfigField "String", "GALAXY_SERVER_URL", '"ws://YOUR_SERVER_IP:9000"'
 
 # 3. 构建 Debug APK
 ./gradlew assembleDebug
@@ -31,8 +31,8 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 
 | 端点 | 说明 |
 |------|------|
-| `ws://<host>:8765/ws/android` | Android 设备主连接端点 |
-| `ws://<host>:8765/ws/device/{device_id}` | 设备专属通道 |
+| `ws://<host>:9000/ws/android` | Android 设备主连接端点 |
+| `ws://<host>:9000/ws/device/{device_id}` | 设备专属通道 |
 
 ### 协议版本
 
@@ -58,7 +58,7 @@ AIP v3.0（Android Integration Protocol v3.0）
   DannyFish-11/ufo-galaxy-android
         │
         │  WebSocket (AIP v3.0)
-        │  ws://<host>:8765/ws/android
+        │  ws://<host>:9000/ws/android
         ▼
 galaxy_gateway/android_bridge.py   ← 桥接层（本仓库）
         │

--- a/core/api_routes.py
+++ b/core/api_routes.py
@@ -42,7 +42,7 @@ Domain → 子模块映射：
   /ws/status            → (create_websocket_routes)    （状态推送 WebSocket）
 
 NOTE — Device WebSocket ingress authority:
-  The CANONICAL device ingress is lumiv_gateway/routes/websocket.py /ws/device/{device_id}.
+  The CANONICAL device ingress is galaxy_gateway/routes/websocket.py /ws/device/{device_id}.
   The /ws/device/{device_id} route in THIS file (core/api_routes.py) is a
   COMPATIBILITY-ONLY path retained for legacy/core-direct clients.  It must NOT
   be treated as a competing primary ingress.  New device clients MUST connect
@@ -110,7 +110,7 @@ API_COMPATIBILITY_SURFACE_BOUNDARY_PR8_SENTINEL = (
 CORE_COMPAT_DEVICE_INGRESS_POLICY_AUTHORITY = (
     "CORE_COMPAT_DEVICE_INGRESS_POLICY_AUTHORITY_V1: "
     "core.api_routes compatibility websocket ingress is never production-equivalent. "
-    "The canonical Android/V2 device ingress remains lumiv_gateway.routes.websocket "
+    "The canonical Android/V2 device ingress remains galaxy_gateway.routes.websocket "
     "/ws/device/{device_id}; protected cross-device mode blocks the core-direct "
     "compatibility ingress unless an explicit override is set for controlled fallback use."
 )
@@ -151,7 +151,7 @@ _API_COMPATIBILITY_SURFACES: tuple[APICompatibilitySurface, ...] = (
         surface_id="core_direct_device_websocket_ingress",
         path="/ws/device/{device_id}",
         module="core.api_routes.create_websocket_routes",
-        canonical_replacement="/ws/device/{device_id} (lumiv_gateway/routes/websocket.py)",
+        canonical_replacement="/ws/device/{device_id} (galaxy_gateway/routes/websocket.py)",
         compatibility_scope="legacy_core_direct_ws_clients",
     ),
 )
@@ -221,7 +221,7 @@ def get_core_compat_device_ingress_policy(
         "compatibility_surface_factory": "core.api_routes.create_websocket_routes",
         "classification": "compatibility-only",
         "canonical_device_ingress": "/ws/device/{device_id}",
-        "canonical_device_ingress_module": "lumiv_gateway.routes.websocket",
+        "canonical_device_ingress_module": "galaxy_gateway.routes.websocket",
         "canonical_required_for_production": True,
         "production_equivalent": False,
         "system_mode": fabric.mode.value,
@@ -241,7 +241,7 @@ def get_device_ingress_surface_report(
     env: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Return a machine-readable view of canonical and compatibility ingress surfaces."""
-    from lumiv_gateway.routes.websocket import (
+    from galaxy_gateway.routes.websocket import (
         CANONICAL_DEVICE_INGRESS_AUTHORITY,
         DEVICE_WS_INGRESS_SURFACE_REGISTRY,
     )
@@ -633,7 +633,7 @@ def create_websocket_routes(app: FastAPI, service_manager=None):
 
     COMPATIBILITY SURFACE — NOT the canonical device ingress.
 
-    The canonical device ingress is lumiv_gateway/routes/websocket.py
+    The canonical device ingress is galaxy_gateway/routes/websocket.py
     /ws/device/{device_id}.  The routes registered here are retained for
     legacy/core-direct clients only and must not be introduced as a second
     primary device ingress authority.
@@ -655,7 +655,7 @@ def create_websocket_routes(app: FastAPI, service_manager=None):
     logger.warning(
         "DEPRECATED: core/api_routes.py create_websocket_routes() is a "
         "compatibility surface. New clients MUST use "
-        "lumiv_gateway/routes/websocket.py /ws/device/{device_id} "
+        "galaxy_gateway/routes/websocket.py /ws/device/{device_id} "
         "as the sole canonical device ingress. "
         "This compat path will be removed in a future release."
     )
@@ -694,7 +694,7 @@ def create_websocket_routes(app: FastAPI, service_manager=None):
     #
     # Compatibility-only device WebSocket path.  This endpoint is NOT the
     # canonical device ingress.  The canonical path is:
-    #   lumiv_gateway/routes/websocket.py → /ws/device/{device_id}
+    #   galaxy_gateway/routes/websocket.py → /ws/device/{device_id}
     #
     # This route is retained for clients that connect directly to the core
     # layer without going through the gateway.  It must not be extended with
@@ -705,7 +705,7 @@ def create_websocket_routes(app: FastAPI, service_manager=None):
         """[COMPAT] 设备 WebSocket 连接 — 兼容路径（非规范主入口）
 
         Compatibility-only path.  The canonical device ingress is
-        lumiv_gateway/routes/websocket.py /ws/device/{device_id}.
+        galaxy_gateway/routes/websocket.py /ws/device/{device_id}.
         """
         if not compat_ws_policy["effective_enabled"]:
             blocked_by_policy = compat_ws_policy["blocked_by_protected_mode"]

--- a/core/routes/system.py
+++ b/core/routes/system.py
@@ -66,22 +66,6 @@ except ImportError:  # pragma: no cover
     _get_node_count_from_canonical_source = None  # type: ignore[assignment]
 
 # 支持的 API Key 白名单
-ALLOWED_CONFIG_KEYS = {
-    "OPENAI_API_KEY", "OPENAI_API_BASE",
-    "GEMINI_API_KEY",
-    "ANTHROPIC_API_KEY",
-    "DEEPSEEK_API_KEY",
-    "OPENROUTER_API_KEY",
-    "GROQ_API_KEY",
-    "XAI_API_KEY",
-    "ZHIPU_API_KEY",
-    "ONEAPI_URL", "ONEAPI_API_KEY",
-    "PERPLEXITY_API_KEY", "SONAR_API_KEY",
-    "DEEPSEEK_OCR2_API_KEY",
-    "OLLAMA_URL", "VLLM_URL",
-}
-
-
 def create_router(service_manager=None, config=None) -> APIRouter:
     """Create system & config routes router."""
     router = APIRouter()
@@ -424,78 +408,13 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             logger.warning(f"获取 Skill 状态失败: {e}")
             return JSONResponse({"skills": [], "stats": {}, "error": str(e)})
 
-    @router.post("/api/config/update")
-    async def update_config(request: Request, auth: dict = Depends(require_auth)):
-        """
-        更新配置 - 支持所有 LLM API Key
-        写入 .env 文件并即时热更新到 os.environ
-        """
-        data = await request.json()
-        env_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), ".env")
-
-        try:
-            # 读取现有 .env
-            current_env = {}
-            if os.path.exists(env_path):
-                with open(env_path, "r", encoding="utf-8") as f:
-                    for line in f:
-                        line = line.strip()
-                        if line and not line.startswith("#") and "=" in line:
-                            key, val = line.split("=", 1)
-                            current_env[key.strip()] = val.strip()
-
-            # 支持两种格式:
-            # 1. 直接 {KEY: VALUE} (旧格式)
-            # 2. {"keys": {KEY: VALUE}} (新格式，来自 Dashboard)
-            keys_data = data.get("keys", data) if isinstance(data, dict) else data
-
-            updated_keys = []
-            for key, val in keys_data.items():
-                if key in ALLOWED_CONFIG_KEYS:
-                    val = str(val).strip()
-                    if val:
-                        current_env[key] = val
-                        os.environ[key] = val
-                        updated_keys.append(key)
-                    else:
-                        current_env.pop(key, None)
-                        os.environ.pop(key, None)
-                        updated_keys.append(f"{key} (removed)")
-
-            # 写回 .env
-            with open(env_path, "w", encoding="utf-8") as f:
-                f.write("# Galaxy - Environment Configuration\n")
-                f.write(f"# Updated: {datetime.now().isoformat()}\n\n")
-                for key, val in sorted(current_env.items()):
-                    f.write(f"{key}={val}\n")
-
-            # 热重载 LLM Router 以拾取新 API Key
-            if updated_keys and any("API_KEY" in k or "URL" in k for k in updated_keys):
-                try:
-                    from core.llm.route_authority import get_llm_route_authority
-                    router = get_llm_route_authority().execution_router
-                    # _discover_providers() 是同步方法,内部对 Ollama/OneAPI 等做阻塞
-                    # httpx.get(timeout=2~5s)网络探测。这里在 async 路由处理函数里,
-                    # 若直接同步调用会冻结共享事件循环——保存一次模型 Key 就让其它
-                    # 所有并发请求(含完全无关的轻量端点)集体卡上几秒。offload 到
-                    # 线程,不阻塞事件循环。
-                    import asyncio as _asyncio
-                    await _asyncio.to_thread(router._discover_providers)
-                    logger.info(f"LLM Router 已热重载 (更新: {updated_keys})")
-                except Exception as e:
-                    logger.warning(f"LLM Router 热重载失败: {e}")
-
-                # 同步刷新能力编排器
-                try:
-                    from core.capability_orchestrator import capability_orchestrator
-                    await capability_orchestrator.reinitialize()
-                    logger.info("CapabilityOrchestrator 已重新加载")
-                except Exception as e:
-                    logger.debug(f"CapabilityOrchestrator 重载跳过: {e}")
-
-            return {"status": "success", "message": "Configuration updated", "updated": updated_keys}
-        except Exception as e:
-            return JSONResponse({"status": "error", "message": str(e)}, status_code=500)
+    # 注:此处曾有第二个写配置端点 POST /api/config/update(配 ALLOWED_CONFIG_KEYS
+    # 白名单)。全仓库排查确认它【零真实调用方】——前端(ModelsTab/SettingsTab)、
+    # Electron IPC、Android、dashboard 全都走 core/routes/config.py 的
+    # POST /api/config;唯一提及它的只有一处测试的文档字符串。两份并存的写配置
+    # 实现 + 两份互不同步的键白名单(这份 ALLOWED_CONFIG_KEYS vs config.py 的
+    # CONFIG_SCHEMA)正是之前"填了 Key 保存失败"一类配置漂移 bug 的温床。已删除
+    # 本冗余端点,写配置收口到 core/routes/config.py 这一处唯一实现。
 
     @router.get("/api/v1/system/mode-status")
     async def system_mode_status():

--- a/core/startup.py
+++ b/core/startup.py
@@ -258,13 +258,20 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
         results["dependency_check"] = {"status": "skipped", "error": str(e)}
 
     # 注册信号处理器
+    # 注:asyncio 的 loop.add_signal_handler 在 Windows(ProactorEventLoop)上
+    # 本就【不支持】,必然抛 NotImplementedError——这是平台预期行为,不是故障。
+    # Windows 下 Ctrl+C 仍能通过 KeyboardInterrupt 正常停止。之前这里打 WARNING
+    # 让用户以为出了问题,现在按平台区分:Windows/非主线程用 info 级如实说明。
     try:
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGTERM, signal.SIGINT):
             loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(_handle_signal(s)))
         logger.info("已注册 SIGTERM/SIGINT 信号处理器")
     except (RuntimeError, NotImplementedError):
-        logger.warning("无法注册信号处理器（可能在非主线程或 Windows 环境）")
+        logger.info(
+            "跳过 asyncio 信号处理器注册（Windows 或非主线程下不支持,属预期;"
+            "Ctrl+C 仍可正常停止）"
+        )
 
     # 启动前校验依赖图
     dep_errors = _validate_startup_deps()

--- a/core/voice_conversation_bridge.py
+++ b/core/voice_conversation_bridge.py
@@ -104,8 +104,24 @@ def start_voice_loop() -> bool:
 
     仅当 GALAXY_VOICE_LOOP=1 时执行；任何依赖缺失/无麦克风都安全返回 False，
     绝不阻塞或破坏桌面运行时启动。需在真机上验证。
+
+    A 融合:core.voice_loop.VoiceLoop(GALAXY_VOICE=1 默认开启,unified_launcher
+    拉起)现在已是本模块的功能超集——同样喂 handle_request(source="voice")驱动
+    三态、同样交集中式 speech_output 朗读,且已补上 emit_conversation 面板推送。
+    两条闭环若同时启动(默认 GALAXY_VOICE=1 且用户又显式 GALAXY_VOICE_LOOP=1),
+    会对同一句话双重转写+双重 handle_request+面板双条目。这里加互斥:主 VoiceLoop
+    在跑时本模块跳过,收敛为单一语音闭环。仅当用户显式关掉主 VoiceLoop
+    (GALAXY_VOICE=0)时,本模块才作为备用闭环启动。
     """
     if not voice_loop_enabled():
+        return False
+    _main_voice_on = os.environ.get("GALAXY_VOICE", "1").strip().lower() not in ("0", "false", "no", "off")
+    if _main_voice_on:
+        logger.info(
+            "voice_conversation_bridge 跳过:默认 VoiceLoop(GALAXY_VOICE)已在运行并覆盖"
+            "全部功能(含面板推送);避免同一句话被双重处理。如需改用本闭环,请设"
+            " GALAXY_VOICE=0。"
+        )
         return False
     try:
         from core.multimodal.audio_capture_service import AudioCaptureService

--- a/core/voice_loop.py
+++ b/core/voice_loop.py
@@ -148,6 +148,17 @@ class VoiceLoop:
 
         logger.info("Voice input: %s", text)
 
+        # A 融合:把语音对话实时推给面板"实时上下文"。此前只有默认【关闭】的
+        # core.voice_conversation_bridge 调用 emit_conversation,而真正默认【开启】、
+        # 驱动三态与朗读的正是本 VoiceLoop——它此前从不推送,导致默认配置下面板的
+        # 语音实时显示永远是空的(PresencePanel 的"语音"标签形同虚设)。这里在本
+        # (唯一默认活跃的)语音闭环里补上推送,让面板与语音真正一体。容错、永不抛出。
+        try:
+            from core.lumiv_websocket_bridge import emit_conversation
+            emit_conversation("user", text, source="voice")
+        except Exception as _exc:  # noqa: BLE001
+            logger.debug("emit_conversation(user) 跳过(非致命): %s", _exc)
+
         try:
             # 1. 发送给 Galaxy 处理
             if asyncio.iscoroutinefunction(self.galaxy.process):
@@ -166,6 +177,13 @@ class VoiceLoop:
                 return
 
             logger.info("Galaxy response: %s", response[:100])
+
+            # A 融合:AI 的语音回复也推给面板"实时上下文"。
+            try:
+                from core.lumiv_websocket_bridge import emit_conversation
+                emit_conversation("ai", response, source="voice")
+            except Exception as _exc:  # noqa: BLE001
+                logger.debug("emit_conversation(ai) 跳过(非致命): %s", _exc)
 
             # 2. TTS 合成并播放(仅当本回路负责朗读;集成进 Galaxy 时由 handle_request 集中朗读,
             #    此处 speak_responses=False,避免同一句念两遍)。

--- a/deployment/L4_DEPLOYMENT.md
+++ b/deployment/L4_DEPLOYMENT.md
@@ -44,7 +44,7 @@ nano config/l4_config.json
   },
   "gateway": {
     "host": "0.0.0.0",
-    "port": 8765
+    "port": 9000
   },
   "devices": {
     "android": {"enabled": true},
@@ -95,7 +95,7 @@ docker build -t galaxy-l4 -f Dockerfile.l4 .
 docker run -d \
   --name galaxy-l4 \
   --restart always \
-  -p 8765:8765 \
+  -p 9000:9000 \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   galaxy-l4
@@ -108,7 +108,7 @@ docker run -d \
 ### 1. 检查系统状态
 
 ```bash
-curl http://localhost:8765/status
+curl http://localhost:9000/status
 ```
 
 预期输出：
@@ -125,7 +125,7 @@ curl http://localhost:8765/status
 ### 2. 提交测试目标
 
 ```bash
-curl -X POST http://localhost:8765/goal \
+curl -X POST http://localhost:9000/goal \
   -H "Content-Type: application/json" \
   -d '{
     "description": "了解量子计算的最新进展",
@@ -148,7 +148,7 @@ tail -f logs/galaxy_l4.log
 在安卓端 `WebSocketClient.kt` 中设置服务器地址：
 
 ```kotlin
-private val serverUrl = "ws://服务器IP:8765/android"
+private val serverUrl = "ws://服务器IP:9000/android"
 ```
 
 ### 2. 发送设备注册消息
@@ -245,13 +245,13 @@ INFO - 安卓设备已注册: device_xxx
 ### 1. 健康检查
 
 ```bash
-curl http://localhost:8765/health
+curl http://localhost:9000/health
 ```
 
 ### 2. 查看性能指标
 
 ```bash
-curl http://localhost:8765/metrics
+curl http://localhost:9000/metrics
 ```
 
 ### 3. 重启服务
@@ -291,13 +291,13 @@ python3 main.py
 
 ```bash
 # 检查防火墙
-sudo ufw allow 8765
+sudo ufw allow 9000
 
 # 检查端口占用
-netstat -tuln | grep 8765
+netstat -tuln | grep 9000
 
 # 测试 WebSocket 连接
-wscat -c ws://localhost:8765/android
+wscat -c ws://localhost:9000/android
 ```
 
 ### 问题 3：性能下降

--- a/docs/ANDROID_COMPAT.md
+++ b/docs/ANDROID_COMPAT.md
@@ -8,7 +8,7 @@
 
 | 仓库 | 地址 | 职责 |
 |------|------|------|
-| **服务端** (本仓库) | `DannyFish-11/ufo-galaxy-realization` | Galaxy Gateway + 桌面覆盖层 |
+| **服务端** (本仓库) | `DannyFish-11/ufo-galaxy-realization-v2` | Galaxy Gateway + 桌面覆盖层 |
 | **Android 客户端** | `DannyFish-11/ufo-galaxy-android` | Android APK |
 
 克隆 Android 客户端：
@@ -62,8 +62,8 @@ Android 端支持两种运行模式：
 
 ```bash
 # 服务端（本仓库）
-git clone https://github.com/DannyFish-11/ufo-galaxy-realization.git
-cd ufo-galaxy-realization
+git clone https://github.com/DannyFish-11/ufo-galaxy-realization-v2.git
+cd ufo-galaxy-realization-v2
 
 # Android 客户端（同级目录）
 git clone https://github.com/DannyFish-11/ufo-galaxy-android.git
@@ -72,13 +72,13 @@ git clone https://github.com/DannyFish-11/ufo-galaxy-android.git
 ### 2. 启动服务端 Gateway
 
 ```bash
-cd ufo-galaxy-realization
+cd ufo-galaxy-realization-v2
 python main.py
 # 或
 python launch_desktop.py --backend
 ```
 
-确保 Gateway 在 `ws://<host>:8765` 可访问。
+确保 Gateway 在 `ws://<host>:9000` 可访问。（端口来自 `config/unified_ports.yaml` 的 `gateway: 9000`；此前文档写的 8765 是历史值，已在端口冲突解决时统一为 9000。）
 
 ### 3. 配置 Android 端连接
 
@@ -89,7 +89,7 @@ python launch_desktop.py --backend
 | 字段 | 示例值 |
 |------|--------|
 | Host / IP | `192.168.1.100` 或 Tailscale IP |
-| Port | `8765` |
+| Port | `9000` |
 | Use TLS | 开发关闭，生产开启 |
 | Device ID | 留空使用系统默认值 |
 
@@ -100,8 +100,8 @@ python launch_desktop.py --backend
 ```bash
 cd ufo-galaxy-android
 # 编辑 app/src/main/assets/config.properties
-galaxy_gateway_url=ws://192.168.1.100:8765
-rest_base_url=http://192.168.1.100:8765
+galaxy_gateway_url=ws://192.168.1.100:9000
+rest_base_url=http://192.168.1.100:9000
 cross_device_enabled=true
 ```
 
@@ -150,17 +150,18 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 
 Android 通过 AIP v3.0 协议与服务端通信。
 
-| 端点 | 用途 |
-|------|------|
-| `ws://<host>:8765/ws/android/{device_id}` | **主路径**，推荐 |
-| `ws://<host>:8765/ws/{device_id}` | 通用设备路径 |
-| `ws://<host>:8765/ws` | 自动分配 device_id |
-| `ws://<host>:8765/ws/device/{device_id}` | 兼容别名 |
-| `ws://<host>:8765/ws/ufo3/{device_id}` | UFO3 遗留路径 |
+> 以下路径与用途以 **代码实际注册为准**（`galaxy_gateway/routes/websocket.py`，PR-25：唯一 canonical 入口 + 若干 compat 别名，全部汇聚到同一个 handler）。此前本表把主/次写反、还列了两个代码里不存在的路径（`/ws/{device_id}`、裸 `/ws`），已按代码更正。
 
-**连接示例：**
+| 端点 | 分类 | 用途 |
+|------|------|------|
+| `ws://<host>:9000/ws/device/{device_id}` | **canonical（主路径，推荐）** | 唯一规范设备入口（`websocket.py` classification="canonical"） |
+| `ws://<host>:9000/ws/android/{device_id}` | compat | 遗留 Android 入口（path 参），委派到同一 handler |
+| `ws://<host>:9000/ws/android`（device_id 走 query 参） | compat | 遗留 Android 入口（query 参） |
+| `ws://<host>:9000/ws/ufo3/{device_id}` | compat | 遗留 UFO3 入口 |
+
+**连接示例（用 canonical 主路径）：**
 ```
-ws://192.168.1.100:8765/ws/android/my-device-001
+ws://192.168.1.100:9000/ws/device/my-device-001
 ```
 
 ---
@@ -213,7 +214,7 @@ LoopController → 循环或完成
 | WebSocket 连接失败 | Gateway 未启动 | 启动 `python main.py` |
 | 连接超时 | IP/端口错误 | 检查 `config.properties` 中的 IP |
 | TLS 握手失败 | 证书问题 | 开发环境关闭 TLS |
-| 设备注册失败 | 防火墙拦截 | 检查 8765 端口开放 |
+| 设备注册失败 | 防火墙拦截 | 检查 9000 端口开放 |
 
 ### 本地模型问题
 

--- a/docs/ANDROID_PROTOCOL_ALIGNMENT.md
+++ b/docs/ANDROID_PROTOCOL_ALIGNMENT.md
@@ -247,7 +247,7 @@ MessageHandler / DeviceManager (只处理 v3 字段)
            ▼                          ▼
 ┌──────────────────────┐   ┌──────────────────────────────┐
 │  galaxy_gateway/     │   │  core/api_routes.py          │
-│  app.py (port 8765)  │   │  (port 8000)                 │
+│  app.py (port 9000)  │   │  (port 8000)                 │
 │                      │   │                              │
 │  /ws/device/{id}  ◄──┘   │  POST   /api/v1/devices/     │
 │  /ws/android         │   │         register             │
@@ -278,10 +278,10 @@ MessageHandler / DeviceManager (只处理 v3 字段)
 
 | 端点 | 说明 |
 |------|------|
-| `ws://<host>:8765/ws/device/{device_id}` | **主通道**（推荐）：注册成功后的设备专属通道 |
-| `ws://<host>:8765/ws/android` | 初始连接端点：设备注册及通用消息通道 |
-| `ws://<host>:8765/ws/status` | 状态广播推送（只读订阅） |
-| `ws://<host>:8765/ws/ufo3/{device_id}` | 向后兼容路径（等同于主通道） |
+| `ws://<host>:9000/ws/device/{device_id}` | **主通道**（推荐）：注册成功后的设备专属通道 |
+| `ws://<host>:9000/ws/android` | 初始连接端点：设备注册及通用消息通道 |
+| `ws://<host>:9000/ws/status` | 状态广播推送（只读订阅） |
+| `ws://<host>:9000/ws/ufo3/{device_id}` | 向后兼容路径（等同于主通道） |
 
 ### REST API 端点（`/api/v1/devices/*`）
 
@@ -394,9 +394,9 @@ DeviceCapability.COMM_BLUETOOTH | DeviceCapability.COMM_NFC | DeviceCapability.C
 
 | 路径 | 说明 | 推荐度 |
 |------|------|--------|
-| `ws://<host>:8765/ws/device/{device_id}` | **主通道**（推荐）：设备注册后的专属通道 | ✅ 推荐 |
-| `ws://<host>:8765/ws/android` | 初始连接端点：自动分配设备 ID | ✅ 支持 |
-| `ws://<host>:8765/ws/ufo3/{device_id}` | 向后兼容路径（等同于主通道） | ⚠️ 兼容 |
+| `ws://<host>:9000/ws/device/{device_id}` | **主通道**（推荐）：设备注册后的专属通道 | ✅ 推荐 |
+| `ws://<host>:9000/ws/android` | 初始连接端点：自动分配设备 ID | ✅ 支持 |
+| `ws://<host>:9000/ws/ufo3/{device_id}` | 向后兼容路径（等同于主通道） | ⚠️ 兼容 |
 
 > **Android 客户端应统一使用主通道 `/ws/device/{device_id}`。**
 > 以上所有路径均路由到 `galaxy_gateway/app.py` 中同一个 `WebSocketManager.handle_connection()` 处理器。
@@ -508,7 +508,7 @@ task_result → AndroidBridge._handle_task_result() → 返回结果
 1. **统一使用 AIPMessageBuilder**，并确保发送完整 v3 字段：
    `version: "3.0"`、`message_id`（UUID）、`timestamp`（毫秒）、`device_id`、`type`。
 
-2. **连接路径**：统一配置为 `ws://<host>:8765/ws/device/{device_id}`。
+2. **连接路径**：统一配置为 `ws://<host>:9000/ws/device/{device_id}`。
 
 3. **capability_report 消息**在设备连接后立即发送，`supported_actions` 列表应枚举
    设备实际支持的操作名称（如 `["screenshot", "tap", "swipe", "input_text"]`）。

--- a/docs/ANDROID_PROTOCOL_ALIGNMENT.md
+++ b/docs/ANDROID_PROTOCOL_ALIGNMENT.md
@@ -717,4 +717,54 @@ python -m pytest tests/test_v3_schemas.py -v
 
 ---
 
-*最后更新：2026-03-16*
+## 11. 消息类型单一真相源（SSOT）与跨仓漂移门禁
+
+三仓（v2 中枢 / `ufo-galaxy-android` / `galaxy-wearos`）的消息类型契约以 v2 的
+`galaxy_gateway/protocol/aip_v3.py` 中 `class MessageType` 为**唯一真相源（SSOT）**，
+server 权威。Android 的 `shared-protocol/.../MsgType.kt`、WearOS 的
+`app/.../data/MsgType.kt` 都是对着它做的手工镜像 —— 手工镜像必然漂移。
+
+### 11.1 自动漂移检查器
+
+`tools/protocol/check_aip_msgtype_drift.py` 把 v2 `MessageType` 当作标准，解析各客户端
+Kotlin `MsgType` 的 wire 值，分四类报告，并可在 `--strict` 下作为 CI 门禁：
+
+```bash
+# sibling checkout（../ufo-galaxy-android、../galaxy-wearos）时零参即可
+python tools/protocol/check_aip_msgtype_drift.py --strict
+```
+
+| 分类 | 含义 |
+|------|------|
+| **canonical 一致** | wire 值与 v2 完全一致（健康） |
+| **已接受兼容别名** | 客户端用了 v2 已登记的入向兼容别名（server 认得，但建议客户端后续迁到 canonical 长名） |
+| **客户端专有扩展** | client→面板 / client 内部事件，server 无需识别（白名单内，正常） |
+| **未知（server 会拒）** | v2 既无此值、也非已登记别名/扩展 —— server 端 `MessageType(...)` 会 `ValueError` → 返回 `UNKNOWN_MESSAGE_TYPE`，整条消息被拒。`--strict` 下非 0 退出 |
+
+回归防护见 `tests/test_protocol_msgtype_ssot.py`（不依赖 sibling 仓 checkout，可在纯 v2 CI 跑）。
+
+### 11.2 已登记的客户端入向兼容别名
+
+历史上两客户端发着一批 v2 canonical 值的**短别名**，字符串不同会被 server 拒。沿用本仓
+既有 "previously absent → added" 补丁做法，已把它们登记进 `MessageType` 作为**仅入向兼容
+别名**（server 认得、经 catch-all 与 canonical 对应类型一样优雅路由；canonical 输出仍只用长名）：
+
+| 客户端短别名 | v2 canonical 长名 |
+|------|------|
+| `relay` | `relay_request` |
+| `forward` | `relay_forward` |
+| `reply` | `relay_reply` |
+| `lock` | `coord_lock` |
+| `unlock` | `coord_unlock` |
+| `broadcast` | `coord_broadcast` |
+
+另补齐两个客户端已发、v2 此前无对应的真实类型：`operator_action_request`
+（对应已存在的 `operator_action_result`）、`device_audit_report`（与 `device_*_report` 家族并列）。
+
+> **迁移建议（非强制）**：server 端已兼容,现网客户端无需改动即可连通。若要收敛到纯 canonical,
+> 可在客户端 `MsgType.kt` 把上述短别名的 wire 值改为对应长名 —— 改动需在各自仓库本地
+> 用 Android SDK/Gradle 构建验证（v2 沙箱无 Android 工具链，无法代为编译）。
+
+---
+
+*最后更新：2026-07-03*

--- a/docs/API_ALIGNMENT.md
+++ b/docs/API_ALIGNMENT.md
@@ -214,9 +214,9 @@ Android 端每 10 秒向服务端同步设备状态：
 ```env
 # 服务器配置
 SERVER_HOST=0.0.0.0
-SERVER_PORT=8765
+SERVER_PORT=9000
 DEVICE_API_PORT=8766
-WS_PORT=8765
+WS_PORT=9000
 
 # 设备管理
 DEVICE_HEARTBEAT_INTERVAL=30
@@ -262,7 +262,7 @@ KEY_STATUS_SYNC_INTERVAL = "status_sync_interval"  // 默认 10000ms
 ./start_unified.sh
 
 # 测试 WebSocket 连接
-wscat -c ws://localhost:8765/ws
+wscat -c ws://localhost:9000/ws
 ```
 
 ### 8.2 API 测试

--- a/docs/CLONE_TO_USE_DESKTOP.md
+++ b/docs/CLONE_TO_USE_DESKTOP.md
@@ -32,7 +32,7 @@ UFO Galaxy 是一个**桌面原生 AI 助手系统**。通过 Electron 三态覆
          ▼
 ┌─────────────────┐     ┌──────────────────┐
 │ Galaxy Gateway  │────►│ Ollama (Gemma 4) │
-│ (FastAPI :8765) │     └──────────────────┘
+│ (FastAPI :9000) │     └──────────────────┘
 └────────┬────────┘     ┌──────────────────┐
          │              │ DeepSeek (兜底)   │
          ├──────────────┼──────────────────┤
@@ -172,7 +172,7 @@ cd electron && npm start
 ### 注册服务器
 
 ```bash
-curl -X POST http://localhost:8765/api/v1/agents/linux/servers \
+curl -X POST http://localhost:9000/api/v1/agents/linux/servers \
   -H "Content-Type: application/json" \
   -d '{
     "name": "华为云",
@@ -189,14 +189,14 @@ curl -X POST http://localhost:8765/api/v1/agents/linux/servers \
 ### 执行命令
 
 ```bash
-curl -X POST http://localhost:8765/api/v1/agents/linux/servers/a1b2c3d4/execute \
+curl -X POST http://localhost:9000/api/v1/agents/linux/servers/a1b2c3d4/execute \
   -d '{"command": "uname -a && df -h"}'
 ```
 
 ### 查看系统信息
 
 ```bash
-curl http://localhost:8765/api/v1/agents/linux/servers/a1b2c3d4/info
+curl http://localhost:9000/api/v1/agents/linux/servers/a1b2c3d4/info
 ```
 
 ### API 端点列表
@@ -222,7 +222,7 @@ curl http://localhost:8765/api/v1/agents/linux/servers/a1b2c3d4/info
 | 症状 | 原因 | 解决 |
 |------|------|------|
 | `ImportError` | 依赖未安装 | `pip install -r requirements.txt` |
-| 端口占用 | 8765 被占用 | `lsof -i :8765` 杀掉进程 |
+| 端口占用 | 9000 被占用 | `lsof -i :9000` 杀掉进程 |
 | `.env` 缺失 | 环境变量未配置 | `cp .env.example .env` 后编辑 |
 
 ### Electron 启动失败

--- a/docs/CONFIG_GOVERNANCE.md
+++ b/docs/CONFIG_GOVERNANCE.md
@@ -131,7 +131,7 @@ GALAXY_API_TOKEN=super-secret-token-here
 GALAXY_AUTH_ENABLED=true
 
 # Android client — set WS URL in the app:
-#   ws://<server-ip>:8765/ws/android?token=super-secret-token-here
+#   ws://<server-ip>:9000/ws/android?token=super-secret-token-here
 ```
 
 > **Important**: Without `GALAXY_AUTH_ENABLED=true` any Android device on the

--- a/docs/NATS_CONTROL_PLANE.md
+++ b/docs/NATS_CONTROL_PLANE.md
@@ -148,7 +148,7 @@ New endpoints available in both the Galaxy core API and the gateway service:
 
 ```bash
 # Gateway NATS health
-curl http://localhost:8765/health/nats
+curl http://localhost:9000/health/nats
 
 # Core API NATS health
 curl http://localhost:8000/health/nats

--- a/docs/OFFICIAL_DOCUMENTATION.md
+++ b/docs/OFFICIAL_DOCUMENTATION.md
@@ -85,7 +85,7 @@ Galaxy 是一个**桌面原生 AI 助手操作系统**，通过 Electron 三态�
                     │  │             ──► MANIFEST│ │   Esc 关闭
                     │  │                      │   │
                     │  │   WebSocket          │   │
-                    │  │   ws://localhost:8765│   │
+                    │  │   ws://localhost:9000│   │
                     │  └──────────────────────┘   │
                     │                              │
                     │  ┌──────────────────────┐   │
@@ -97,7 +97,7 @@ Galaxy 是一个**桌面原生 AI 助手操作系统**，通过 Electron 三态�
                                    │
                     ┌──────────────┴──────────────┐
                     │     Galaxy Gateway          │
-                    │     (FastAPI :8765)         │
+                    │     (FastAPI :9000)         │
                     │                             │
                     │  REST API: /api/v1/*        │
                     │  WebSocket: /ws/*           │
@@ -573,7 +573,7 @@ Node_XX_Name/
 
 ```
 Electron (WebSocket客户端)
-    ws://localhost:8765/ws/desktop-presence
+    ws://localhost:9000/ws/desktop-presence
         ↓
 Galaxy Gateway (WebSocket服务器)
     galaxy_gateway/routes/websocket.py
@@ -668,7 +668,7 @@ Galaxy Gateway (WebSocket服务器)
 | `GALAXY_SYSTEM_MODE` | `desktop-local` | 桌面本地模式 |
 | `GALAXY_MODE` | `development` | 开发/生产模式 |
 | `GALAXY_LOG_LEVEL` | `INFO` | 日志级别 |
-| `PORT` | `8765` | Gateway端口 |
+| `PORT` | `9000` | Gateway端口 |
 | `HOST` | `127.0.0.1` | 绑定地址 |
 
 #### LLM API Key (至少配一个，云端兜底用)
@@ -719,7 +719,7 @@ Galaxy Gateway (WebSocket服务器)
 | 服务 | 端口 | 说明 |
 |------|------|------|
 | galaxy | — | 主应用 |
-| galaxy-gateway | 8765 | API网关 |
+| galaxy-gateway | 9000 | API网关 |
 | ollama | 11434 | 本地LLM |
 | neo4j | 7474/7687 | 图数据库 |
 | qdrant | 6333 | 向量数据库 |
@@ -821,7 +821,7 @@ ollama pull gemma4:31b       # ~17GB
 | 症状 | 原因 | 解决 |
 |------|------|------|
 | `ImportError` | 依赖未安装 | `pip install -r requirements.txt` |
-| 端口 8765 占用 | 其他进程占用 | `lsof -i :8765` 杀掉进程 |
+| 端口 9000 占用 | 其他进程占用 | `lsof -i :9000` 杀掉进程 |
 | `.env` 缺失 | 环境变量未配置 | `cp .env.example .env` 后编辑 |
 | `time` 未定义 | api_routes.py 导入问题 | 已修复 (PR-v10) |
 | `dataclass` 未定义 | ai_intent.py 导入问题 | 已修复 (PR-v10) |
@@ -848,13 +848,13 @@ ollama pull gemma4:31b       # ~17GB
 
 ```bash
 # 检查 Gateway 是否运行
-curl http://localhost:8765/health
+curl http://localhost:9000/health
 
 # 检查 WebSocket 端点
 python3 -c "
 import asyncio, websockets
 async def test():
-    async with websockets.connect('ws://localhost:8765/ws/desktop-presence') as ws:
+    async with websockets.connect('ws://localhost:9000/ws/desktop-presence') as ws:
         print('WebSocket连接成功')
 asyncio.run(test())
 "

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -161,7 +161,7 @@
 
 ```bash
 # 8. 远程 Linux 服务器 — 注册 SSH 密钥
-curl -X POST http://localhost:8765/api/v1/agents/linux/servers \
+curl -X POST http://localhost:9000/api/v1/agents/linux/servers \
   -d '{"name":"我的服务器","host":"IP","user":"root","key_path":"~/.ssh/id_rsa"}'
 ```
 

--- a/docs/UNIFIED_STARTUP.md
+++ b/docs/UNIFIED_STARTUP.md
@@ -36,7 +36,7 @@ All ports are defined in **`config/unified_ports.yaml`** — the single authorit
 | 8160, 8163, 8180 | Intelligence overflows | RL (8160), Fuzzy (8163), MemSystem v2 (8180) |
 | 8299 | Infrastructure | (legacy) EmbeddingService overflow |
 | 9000 | Infrastructure | UnifiedLauncher Web UI / Galaxy Gateway (single client entry) |
-| 8765 | Gateway | Galaxy API Gateway |
+| 9000 | Gateway | Galaxy API Gateway |
 | 3001 | OneAPI Web | External LLM Gateway UI |
 | 4222 / 8222 | NATS | Client / HTTP monitor |
 | 6333 / 6334 | Qdrant | REST / gRPC |

--- a/docs/WEBRTC_GATEWAY.md
+++ b/docs/WEBRTC_GATEWAY.md
@@ -46,7 +46,7 @@ Galaxy Gateway  ─────────────────────�
 | Variable      | Default                  | Description                                     |
 |---------------|--------------------------|-------------------------------------------------|
 | `NODE_95_URL` | `http://localhost:8095`  | HTTP base URL of `Node_95_WebRTC_Receiver`.     |
-| `GATEWAY_URL` | `http://localhost:8765`  | HTTP base URL of this gateway service (unified port — WS + REST + WebRTC on same port). |
+| `GATEWAY_URL` | `http://localhost:9000`  | HTTP base URL of this gateway service (unified port — WS + REST + WebRTC on same port). |
 
 Both variables are read at call-time, so they can be changed without
 restarting the process (useful for testing).
@@ -64,7 +64,7 @@ WebRTC signaling connection.
 {
   "node95_url": "http://localhost:8095",
   "ws_signaling_path": "/signaling/{device_id}",
-  "gateway_ws_url": "http://localhost:8765",
+  "gateway_ws_url": "http://localhost:9000",
   "gateway_ws_path": "/ws/webrtc/{device_id}"
 }
 ```
@@ -140,7 +140,7 @@ resp = await router.route(TransportRequest(
 ))
 
 print(resp.endpoint)
-# ws://localhost:8765/ws/webrtc/phone_a
+# ws://localhost:9000/ws/webrtc/phone_a
 ```
 
 ---
@@ -185,11 +185,11 @@ clients can obtain configuration before they have a token.
 
 ```json
 {
-  "ws_base": "ws://192.168.1.10:8765",
-  "rest_base": "http://192.168.1.10:8765",
-  "ws_url": "ws://192.168.1.10:8765/ws/device/{id}",
-  "gateway_ws_url": "ws://192.168.1.10:8765/ws/device/{id}",
-  "ws_url_template": "ws://192.168.1.10:8765/ws/device/{id}",
+  "ws_base": "ws://192.168.1.10:9000",
+  "rest_base": "http://192.168.1.10:9000",
+  "ws_url": "ws://192.168.1.10:9000/ws/device/{id}",
+  "gateway_ws_url": "ws://192.168.1.10:9000/ws/device/{id}",
+  "ws_url_template": "ws://192.168.1.10:9000/ws/device/{id}",
   "ws_canonical_path": "/ws/device/{id}",
   "ws_paths": [
     "/ws/device/{id}",
@@ -260,7 +260,7 @@ val wsUrl = "${config.wsBase}${config.wsPaths[0].replace("{id}", deviceId)}"
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GATEWAY_URL` | `http://localhost:8765` | HTTP base URL — used to derive `rest_base` and `ws_base`. |
+| `GATEWAY_URL` | `http://localhost:9000` | HTTP base URL — used to derive `rest_base` and `ws_base`. |
 | `GALAXY_STUN_URLS` | `stun:stun.l.google.com:19302` | Comma-separated STUN URLs. |
 | `GALAXY_TURN_URLS` | _(not set)_ | Comma-separated TURN URLs.  Omit to return an empty `turn_servers`. |
 | `GALAXY_TURN_USERNAME` | _(not set)_ | TURN credential username. |
@@ -689,7 +689,7 @@ This installs:
 ```bash
 python tools/camera_webrtc_sender.py \
     --device-id desktop_cam_1 \
-    --gateway-ws-url ws://localhost:8765/ws/webrtc \
+    --gateway-ws-url ws://localhost:9000/ws/webrtc \
     --camera-index 0 \
     --frame-rate 15 \
     --resolution 1280x720
@@ -698,7 +698,7 @@ python tools/camera_webrtc_sender.py \
 The script will:
 
 1. Open webcam index `0` at 1280×720 / 15 fps.
-2. Connect to `ws://localhost:8765/ws/webrtc/desktop_cam_1`.
+2. Connect to `ws://localhost:9000/ws/webrtc/desktop_cam_1`.
 3. Send an SDP **offer**, wait for the **answer** from Node_95 (via the Gateway proxy).
 4. Exchange ICE candidates in trickle mode.
 5. Stream video until interrupted (`Ctrl+C`).
@@ -710,7 +710,7 @@ All CLI arguments can also be set via environment variables:
 | Variable          | CLI flag              | Default                             | Description                              |
 |-------------------|-----------------------|-------------------------------------|------------------------------------------|
 | `DEVICE_ID`       | `--device-id`         | `desktop_cam_1`                     | Unique identifier for this device        |
-| `GATEWAY_WS_URL`  | `--gateway-ws-url`    | `ws://localhost:8765/ws/webrtc`     | Gateway base WebSocket URL (no device_id suffix) |
+| `GATEWAY_WS_URL`  | `--gateway-ws-url`    | `ws://localhost:9000/ws/webrtc`     | Gateway base WebSocket URL (no device_id suffix) |
 | `CAMERA_INDEX`    | `--camera-index`      | `0`                                 | OpenCV camera device index               |
 | `FRAME_RATE`      | `--frame-rate`        | `15`                                | Target frames per second                 |
 | `RESOLUTION`      | `--resolution`        | `1280x720`                          | Video resolution as `WxH`                |
@@ -719,7 +719,7 @@ Example using environment variables:
 
 ```bash
 DEVICE_ID=office_cam \
-GATEWAY_WS_URL=ws://192.168.1.10:8765/ws/webrtc \
+GATEWAY_WS_URL=ws://192.168.1.10:9000/ws/webrtc \
 FRAME_RATE=10 \
 python tools/camera_webrtc_sender.py
 ```

--- a/enhancements/clients/android_client/README.md
+++ b/enhancements/clients/android_client/README.md
@@ -16,7 +16,7 @@ git clone https://github.com/DannyFish-11/galaxy-android.git
 cd galaxy-android
 
 # 2. 配置服务端地址（编辑 app/build.gradle）
-#    buildConfigField "String", "GALAXY_SERVER_URL", '"ws://YOUR_SERVER_IP:8765"'
+#    buildConfigField "String", "GALAXY_SERVER_URL", '"ws://YOUR_SERVER_IP:9000"'
 
 # 3. 构建 Debug APK
 ./gradlew assembleDebug
@@ -31,8 +31,8 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 
 | 端点 | 说明 |
 |------|------|
-| `ws://<host>:8765/ws/android` | Android 设备主连接端点 |
-| `ws://<host>:8765/ws/device/{device_id}` | 设备专属通道 |
+| `ws://<host>:9000/ws/android` | Android 设备主连接端点 |
+| `ws://<host>:9000/ws/device/{device_id}` | 设备专属通道 |
 
 协议版本：AIP v3.0。完整协议文档见：[docs/ANDROID_PROTOCOL_ALIGNMENT.md](../../../docs/ANDROID_PROTOCOL_ALIGNMENT.md)
 
@@ -43,7 +43,7 @@ adb install app/build/outputs/apk/debug/app-debug.apk
   DannyFish-11/galaxy-android
         │
         │  WebSocket (AIP v3.0)
-        │  ws://<host>:8765/ws/android
+        │  ws://<host>:9000/ws/android
         ▼
 galaxy_gateway/android_bridge.py   ← 桥接层（本仓库）
         │

--- a/galaxy_gateway/protocol/aip_v3.py
+++ b/galaxy_gateway/protocol/aip_v3.py
@@ -406,6 +406,32 @@ class MessageType(str, Enum):
     OPERATOR_ACTION_RESULT = "operator_action_result"
     PING = "ping"
 
+    # === V2_INTERNAL: Cross-repo client wire-value compat aliases (协议单一真相源对齐) ===
+    # tools/protocol/check_aip_msgtype_drift.py 把本 enum 当作三仓消息契约的唯一真相
+    # 源(SSOT),对着 android `shared-protocol/MsgType.kt` 与 wearos
+    # `data/MsgType.kt` 做漂移检查。检查发现两客户端历史上用了一批【短别名】wire 值,
+    # 语义与本 enum 的 canonical 值完全一致,但字符串不同 —— 客户端发这些类型时
+    # server 端 `MessageType('relay')` 会 ValueError → 返回 UNKNOWN_MESSAGE_TYPE,
+    # 整条消息被拒。沿用本文件既有做法(见上 HANDOFF_DISPATCH / cancel_result /
+    # ack / operator_action_result 等"previously absent → added"补丁),把这些客户端
+    # 短别名登记为【仅入向兼容别名】:server 认得、经 catch-all 优雅路由(与其
+    # canonical 对应类型同样落到 handle_unregistered),canonical 输出仍只用长名。
+    # 别名 → canonical 对照(供客户端后续迁移):
+    #   relay      → relay_request      forward → relay_forward   reply → relay_reply
+    #   lock       → coord_lock         unlock  → coord_unlock    broadcast → coord_broadcast
+    # 另有两个客户端已发、v2 此前无对应的真实类型,一并补齐(否则同样被拒):
+    #   operator_action_request —— 设备侧发起的操作请求(对应已存在的
+    #     operator_action_result;经 catch-all 优雅接收,避免请求被整条丢弃)。
+    #   device_audit_report —— 设备审计上报(与 device_*_report 家族并列)。
+    RELAY = "relay"                                # ← relay_request 的客户端短别名
+    RELAY_FORWARD_ALIAS = "forward"               # ← relay_forward 的客户端短别名
+    RELAY_REPLY_ALIAS = "reply"                   # ← relay_reply 的客户端短别名
+    COORD_LOCK_ALIAS = "lock"                     # ← coord_lock 的客户端短别名
+    COORD_UNLOCK_ALIAS = "unlock"                 # ← coord_unlock 的客户端短别名
+    COORD_BROADCAST_ALIAS = "broadcast"           # ← coord_broadcast 的客户端短别名
+    OPERATOR_ACTION_REQUEST = "operator_action_request"
+    DEVICE_AUDIT_REPORT = "device_audit_report"
+
 
 class TaskStatus(str, Enum):
     """任务状态"""

--- a/tests/test_protocol_msgtype_ssot.py
+++ b/tests/test_protocol_msgtype_ssot.py
@@ -1,0 +1,112 @@
+"""tests/test_protocol_msgtype_ssot.py
+========================================
+协议单一真相源(SSOT)回归防护 —— 三仓消息类型契约收口到 v2 aip_v3.MessageType。
+
+背景
+----
+三仓(v2 中枢 / ufo-galaxy-android / galaxy-wearos)的消息类型此前靠手工镜像维护,
+必然漂移。tools/protocol/check_aip_msgtype_drift.py 把 v2 的 `MessageType` 当作唯一
+真相源,发现两客户端历史上发着一批 v2 **不认**的 wire 值:
+
+  - 6 个短别名(relay/forward/reply/lock/unlock/broadcast),语义等同 v2 的
+    canonical 长名(relay_request/relay_forward/relay_reply/coord_lock/
+    coord_unlock/coord_broadcast),但字符串不同 —— server `MessageType('relay')`
+    会 ValueError → 返回 UNKNOWN_MESSAGE_TYPE,整条消息被拒。
+  - 2 个 v2 此前无对应类型(operator_action_request / device_audit_report),同样被拒。
+
+修复(沿用本文件既有 "previously absent → added" 补丁做法):把这 8 个客户端 wire 值
+登记进 v2 `MessageType` 作为【入向兼容别名】。server 从此认得,经 catch-all 与其
+canonical 对应类型一样优雅路由;canonical 输出仍只用长名。
+
+本测试锁住:这 8 个值恒可解析(不再 UNKNOWN_MESSAGE_TYPE),且漂移检查器对
+android/wearos 已知 wire 值集判定为"零未知"(strict 门禁应通过)。任何回退
+(删掉别名、或客户端新增未登记类型)都会让本测试失败。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+from galaxy_gateway.protocol.aip_v3 import MessageType
+
+# 修复前会被 server 端 MessageType(...) 拒收的 8 个客户端 wire 值。
+_PREVIOUSLY_REJECTED_CLIENT_WIRE_VALUES = [
+    "relay", "forward", "reply", "lock", "unlock", "broadcast",
+    "operator_action_request", "device_audit_report",
+]
+
+# 6 个短别名 → v2 canonical 长名。必须两者都在 enum 里(别名入向兼容、长名 canonical 输出)。
+_ALIAS_TO_CANONICAL = {
+    "relay": "relay_request",
+    "forward": "relay_forward",
+    "reply": "relay_reply",
+    "lock": "coord_lock",
+    "unlock": "coord_unlock",
+    "broadcast": "coord_broadcast",
+}
+
+
+@pytest.mark.parametrize("wire", _PREVIOUSLY_REJECTED_CLIENT_WIRE_VALUES)
+def test_client_wire_value_resolves_without_unknown_message_type(wire):
+    """8 个客户端 wire 值都应能解析成 MessageType(不再 ValueError → UNKNOWN_MESSAGE_TYPE)。"""
+    mt = MessageType(wire)  # 修复前这里对这些值会抛 ValueError
+    assert mt.value == wire
+
+
+@pytest.mark.parametrize("alias,canonical", sorted(_ALIAS_TO_CANONICAL.items()))
+def test_alias_and_canonical_both_registered_and_distinct(alias, canonical):
+    """短别名与 canonical 长名必须同时存在且是不同成员(别名入向、长名输出,互不吞并)。"""
+    assert MessageType(alias).value == alias
+    assert MessageType(canonical).value == canonical
+    assert MessageType(alias) is not MessageType(canonical)
+
+
+def _load_drift_checker():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = os.path.join(here, "tools", "protocol", "check_aip_msgtype_drift.py")
+    spec = importlib.util.spec_from_file_location("_drift_checker", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_drift_checker_reports_zero_unknown_for_known_client_sets():
+    """用已知的 android/wearos wire 值集喂进 classify:应零未知(server 不会拒任何一个)。
+
+    不依赖 sibling 仓 checkout —— 直接把两客户端当前的 wire 值集内联进来,校验
+    分类结果:6/2 个别名归 accepted_alias、其余 canonical 一致或客户端专有扩展,
+    未知(server 会拒)必须为 0。这正是 CI strict 门禁通过的等价条件。
+    """
+    checker = _load_drift_checker()
+    v2_values = checker.parse_v2_messagetype(
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     "galaxy_gateway", "protocol", "aip_v3.py")
+    )
+
+    # android 当前的"非 canonical"wire 值(别名 + 专有扩展),必须全部被接受。
+    android_non_canonical = {
+        "relay", "forward", "reply", "lock", "unlock", "broadcast",  # accepted_alias
+        "auth", "event", "liquid_event", "phase_report", "voice_query",  # client_ext
+    }
+    r = checker.classify(android_non_canonical, v2_values)
+    assert r["unknown"] == [], f"android 不应有 server 会拒的未知类型: {r['unknown']}"
+    assert len(r["accepted_alias"]) == 6
+
+    # wearos 当前的"非 canonical"wire 值。
+    wearos_non_canonical = {
+        "relay", "broadcast",  # accepted_alias
+        "auth", "decision_request", "event", "liquid_event", "phase_report", "voice_query",
+    }
+    r2 = checker.classify(wearos_non_canonical, v2_values)
+    assert r2["unknown"] == [], f"wearos 不应有 server 会拒的未知类型: {r2['unknown']}"
+    assert len(r2["accepted_alias"]) == 2
+
+
+def test_unregistered_client_type_is_flagged_as_unknown():
+    """反向:一个既非 canonical、非别名、非白名单的编造类型,必须被判为 unknown(门禁应拦)。"""
+    checker = _load_drift_checker()
+    r = checker.classify({"totally_new_unregistered_type"}, {"heartbeat", "relay_request"})
+    assert r["unknown"] == ["totally_new_unregistered_type"]

--- a/tests/test_voice_loop_panel_push.py
+++ b/tests/test_voice_loop_panel_push.py
@@ -1,0 +1,114 @@
+"""tests/test_voice_loop_panel_push.py
+========================================
+A 融合(语音通路统一)的回归防护。
+
+背景:系统里有两条语音闭环——
+- core.voice_loop.VoiceLoop:GALAXY_VOICE=1 默认【开启】,由 unified_launcher
+  拉起,真正驱动三态与朗读。
+- core.voice_conversation_bridge:GALAXY_VOICE_LOOP=1 默认【关闭】。
+
+面板"实时上下文"的语音显示,靠 core.lumiv_websocket_bridge.emit_conversation
+推送。此前【只有默认关闭的那条】调用 emit_conversation,默认开启的 VoiceLoop
+从不推送——于是在用户真机的默认配置下,面板的语音实时显示永远是空的。
+
+修复:在默认活跃的 VoiceLoop._on_voice_input 里补上对 emit_conversation 的
+调用(用户语音转写 + AI 语音回复各一次)。本测试验证这两次推送确实发生、
+角色/来源正确,防止回退。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.voice_loop import VoiceLoop
+
+
+class _FakeGalaxy:
+    async def process(self, text, source="voice"):  # noqa: ANN001
+        return {"response": f"回应:{text}"}
+
+
+@pytest.mark.asyncio
+async def test_voice_loop_pushes_user_and_ai_turns_to_panel(monkeypatch):
+    pushed = []
+
+    def _fake_emit(role, text, *, final=True, speaking=False, source="text", turn_id=""):  # noqa: ANN001
+        pushed.append({"role": role, "text": text, "source": source})
+
+    # 拦截真实的 bridge 推送,只观察调用。
+    import core.lumiv_websocket_bridge as bridge
+    monkeypatch.setattr(bridge, "emit_conversation", _fake_emit)
+
+    loop = VoiceLoop(_FakeGalaxy(), speak_responses=False)
+    loop._running = True  # 跳过真实麦克风/音频初始化,直接驱动处理回调
+
+    await loop._on_voice_input("今天天气怎么样")
+
+    # 用户语音转写 + AI 回复,两条都应推给面板,来源都是 voice。
+    assert len(pushed) == 2, f"应推送用户+AI 两条,实际: {pushed}"
+    assert pushed[0] == {"role": "user", "text": "今天天气怎么样", "source": "voice"}
+    assert pushed[1]["role"] == "ai"
+    assert pushed[1]["text"] == "回应:今天天气怎么样"
+    assert pushed[1]["source"] == "voice"
+
+
+@pytest.mark.asyncio
+async def test_empty_response_still_pushes_user_turn(monkeypatch):
+    """AI 回复为空时,用户那句仍应已推送(用户说了话,面板就该显示)。"""
+    pushed = []
+
+    def _fake_emit(role, text, *, final=True, speaking=False, source="text", turn_id=""):  # noqa: ANN001
+        pushed.append(role)
+
+    import core.lumiv_websocket_bridge as bridge
+    monkeypatch.setattr(bridge, "emit_conversation", _fake_emit)
+
+    class _EmptyGalaxy:
+        async def process(self, text, source="voice"):  # noqa: ANN001
+            return {"response": ""}
+
+    loop = VoiceLoop(_EmptyGalaxy(), speak_responses=False)
+    loop._running = True
+    await loop._on_voice_input("在吗")
+
+    assert pushed == ["user"], f"空回复时只应推用户那句,实际: {pushed}"
+
+
+@pytest.mark.asyncio
+async def test_emit_failure_does_not_break_voice_processing(monkeypatch):
+    """面板推送失败绝不能影响语音主流程(容错)。"""
+    def _boom(*a, **k):  # noqa: ANN001, ANN002, ANN003
+        raise RuntimeError("bridge down")
+
+    import core.lumiv_websocket_bridge as bridge
+    monkeypatch.setattr(bridge, "emit_conversation", _boom)
+
+    loop = VoiceLoop(_FakeGalaxy(), speak_responses=False)
+    loop._running = True
+    # 不应抛出。
+    await loop._on_voice_input("测试容错")
+
+
+class TestSingleVoiceLoopExclusion:
+    """A 融合互斥:GALAXY_VOICE(主 VoiceLoop)开启时,voice_conversation_bridge
+    的 start_voice_loop() 必须跳过,避免双跑;只有主 VoiceLoop 显式关闭才启用。"""
+
+    def test_bridge_skips_when_main_voice_loop_on(self, monkeypatch):
+        import core.voice_conversation_bridge as vcb
+        monkeypatch.setenv("GALAXY_VOICE_LOOP", "1")   # 本模块被显式启用
+        monkeypatch.setenv("GALAXY_VOICE", "1")         # 但主 VoiceLoop 也开着(默认)
+        assert vcb.start_voice_loop() is False, "主 VoiceLoop 在跑时必须跳过,避免双跑"
+
+    def test_bridge_runs_only_when_main_voice_loop_off(self, monkeypatch):
+        import core.voice_conversation_bridge as vcb
+        monkeypatch.setenv("GALAXY_VOICE_LOOP", "1")
+        monkeypatch.setenv("GALAXY_VOICE", "0")         # 用户显式关掉主 VoiceLoop
+        # 依赖(音频/Whisper)在沙箱里不可用,会在后续步骤返回 False——但关键是
+        # 它【越过了互斥闸门】开始尝试,而不是在闸门处直接跳过。用 monkeypatch 让
+        # AudioCaptureService 抛异常,验证它确实走到了那一步(而非被互斥挡掉)。
+        import core.multimodal.audio_capture_service as acs
+        def _boom(*a, **k):
+            raise RuntimeError("no audio in sandbox")
+        monkeypatch.setattr(acs, "AudioCaptureService", _boom)
+        # 走到音频初始化并因沙箱无音频返回 False —— 证明没有被互斥闸门提前拦截。
+        assert vcb.start_voice_loop() is False

--- a/tools/protocol/check_aip_msgtype_drift.py
+++ b/tools/protocol/check_aip_msgtype_drift.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""tools/protocol/check_aip_msgtype_drift.py
+==============================================
+AIP v3 消息类型跨仓漂移检查器 —— 把"单一真相源"从口号变成可强制的门禁。
+
+背景
+----
+三仓(v2 中枢 / ufo-galaxy-android / galaxy-wearos)的消息类型契约此前靠【手工
+镜像】维护:
+
+  - v2  `galaxy_gateway/protocol/aip_v3.py` 的 `MessageType`(Python)—— 声明的
+        **单一真相源(SSOT)**,server 权威。
+  - android `shared-protocol/.../MsgType.kt`(Kotlin)—— 手工对着 v2 抄。
+  - wearos  `app/.../data/MsgType.kt`(Kotlin)—— 又对着 android 抄一份(冗余)。
+
+手工镜像必然漂移。实测已发现 6 处"同概念、不同 wire 值"的真漂移
+(客户端 `relay`↔v2 `relay_request`、客户端 `lock`↔v2 `coord_lock` …),
+客户端发这些类型时 server 端 `MessageType("relay")` 会 ValueError / 拒绝。
+
+本工具
+------
+把 v2 的 MessageType 当作唯一标准,解析各客户端 Kotlin MsgType 的 wire 值,
+分四类报告,并在存在"未登记的漂移"时以非 0 退出(供 CI 当门禁):
+
+  1. MATCHED       —— wire 值与 v2 完全一致(健康)。
+  2. ALIAS_DRIFT   —— 同一概念、客户端用了和 v2 不同的 wire 值。这是真 bug:
+                      客户端发出去 server 不认。列出 客户端值 → v2 应有值。
+  3. V2_MISSING    —— 客户端定义了某 wire 值,v2 既无同值、也不在"客户端专有
+                      扩展白名单"里 —— 要么 v2 该补、要么客户端该删。
+  4. CLIENT_EXT    —— 客户端专有扩展(client→面板/client 内部,server 无需识别),
+                      在白名单里,属正常。
+
+用法
+----
+    python tools/protocol/check_aip_msgtype_drift.py \
+        [--android <path-to-android-repo>] [--wearos <path-to-wearos-repo>]
+
+默认按 sibling checkout(../ufo-galaxy-android、../galaxy-wearos)查找。
+客户端仓不存在时对应部分跳过(不报错),便于在只有 v2 的 CI 环境里也能跑
+(此时只校验 v2 SSOT 自身可解析)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from typing import Dict, List, Set, Tuple
+
+# ---------------------------------------------------------------------------
+# 已登记的"同概念别名"映射:客户端历史 wire 值 → v2 SSOT canonical wire 值。
+# 这些是【已知需要客户端对齐到 v2】的漂移。登记在此,报告里归为 ALIAS_DRIFT,
+# 修复方向明确(改客户端 Kotlin 的 wire 值,或由 v2 compat 层显式接受)。
+# ---------------------------------------------------------------------------
+KNOWN_ALIAS_TO_V2: Dict[str, str] = {
+    "relay": "relay_request",
+    "forward": "relay_forward",
+    "reply": "relay_reply",
+    "lock": "coord_lock",
+    "unlock": "coord_unlock",
+    "broadcast": "coord_broadcast",
+}
+
+# ---------------------------------------------------------------------------
+# 客户端专有扩展白名单:这些 wire 值 v2 的 MessageType 里【有意】没有,因为它们
+# 是客户端本地事件(client→面板 / client 内部 UI),server 不需要识别。属正常,
+# 不算漂移。新增客户端专有类型时在此登记,让检查器不误报。
+# ---------------------------------------------------------------------------
+CLIENT_ONLY_EXTENSIONS: Set[str] = {
+    "auth",            # 客户端→网关鉴权握手(v2 走 AuthMessage,不经 MessageType)
+    "voice_query",     # WearOS/手机语音输入(client 侧)
+    "phase_report",    # 客户端三态相位上报(client→面板)
+    "event",           # 客户端通用 UI 事件
+    "liquid_event",    # 灵动岛/液态玻璃动效事件(client 内部)
+    "decision_request",  # HITL 人类决策请求(wearos 本地渲染用)
+}
+
+
+def parse_v2_messagetype(aip_v3_path: str) -> Set[str]:
+    """从 galaxy_gateway/protocol/aip_v3.py 抽 class MessageType 的全部 wire 值。"""
+    with open(aip_v3_path, encoding="utf-8") as f:
+        src = f.read()
+    m = re.search(r"class\s+MessageType\s*\([^)]*\)\s*:(.*?)(?:\nclass\s|\Z)", src, re.DOTALL)
+    if not m:
+        raise SystemExit(f"ERROR: 在 {aip_v3_path} 里找不到 class MessageType")
+    body = m.group(1)
+    return set(re.findall(r'^\s+[A-Z_0-9]+\s*=\s*"([a-z_0-9]+)"', body, re.MULTILINE))
+
+
+def parse_kotlin_msgtype(kt_path: str) -> Set[str]:
+    """从 Kotlin `enum class MsgType(val value: String)` 抽 NAME("wire") 的 wire 值。"""
+    with open(kt_path, encoding="utf-8") as f:
+        src = f.read()
+    return set(re.findall(r'^\s+[A-Z_0-9]+\("([a-z_0-9]+)"\)', src, re.MULTILINE))
+
+
+def classify(client_values: Set[str], v2_values: Set[str]) -> Dict[str, List]:
+    """把客户端 wire 值按对 v2 SSOT 的关系分四类。
+
+    别名判定【先于】v2 成员判定:这些短别名现在已作为【入向兼容别名】登记进
+    v2 的 MessageType(server 认得、不再 UNKNOWN_MESSAGE_TYPE),所以它们既在
+    v2_values 里、又在 KNOWN_ALIAS_TO_V2 里。我们要的是把它们持续显示为
+    "已接受但非 canonical"(accepted_alias),提示客户端后续可迁移到长名,
+    而不是被 matched 吞掉看不见。只有既非 canonical、又非已登记别名、又不在
+    客户端专有白名单里的 wire 值,才是真正会被 server 拒的 unknown(strict 失败)。
+    """
+    matched: List[str] = []
+    accepted_alias: List[Tuple[str, str]] = []
+    unknown: List[str] = []
+    client_ext: List[str] = []
+    for wire in sorted(client_values):
+        if wire in KNOWN_ALIAS_TO_V2:
+            accepted_alias.append((wire, KNOWN_ALIAS_TO_V2[wire]))
+        elif wire in v2_values:
+            matched.append(wire)
+        elif wire in CLIENT_ONLY_EXTENSIONS:
+            client_ext.append(wire)
+        else:
+            unknown.append(wire)
+    return {
+        "matched": matched,
+        "accepted_alias": accepted_alias,
+        "unknown": unknown,
+        "client_ext": client_ext,
+    }
+
+
+def _first_existing(*paths: str) -> str:
+    for p in paths:
+        if p and os.path.isfile(p):
+            return p
+    return ""
+
+
+def main() -> int:
+    here = os.path.dirname(os.path.abspath(__file__))
+    v2_root = os.path.dirname(os.path.dirname(here))
+    siblings = os.path.dirname(v2_root)
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--android", default=os.path.join(siblings, "ufo-galaxy-android"))
+    ap.add_argument("--wearos", default=os.path.join(siblings, "galaxy-wearos"))
+    ap.add_argument("--strict", action="store_true",
+                    help="存在 server 会拒的 UNKNOWN wire 值时以非 0 退出(CI 门禁用)")
+    args = ap.parse_args()
+
+    v2_aip = os.path.join(v2_root, "galaxy_gateway", "protocol", "aip_v3.py")
+    v2_values = parse_v2_messagetype(v2_aip)
+    print(f"v2 SSOT (aip_v3.py MessageType): {len(v2_values)} 个 wire 值\n")
+
+    clients = {
+        "android": _first_existing(
+            os.path.join(args.android, "shared-protocol", "src", "main", "java",
+                         "com", "ufo", "galaxy", "shared", "protocol", "MsgType.kt"),
+        ),
+        "wearos": _first_existing(
+            os.path.join(args.wearos, "app", "src", "main", "java",
+                         "com", "galaxy", "wear", "data", "MsgType.kt"),
+        ),
+    }
+
+    any_unknown = False
+    for name, path in clients.items():
+        if not path:
+            print(f"[{name}] 未找到 MsgType.kt(仓库未 checkout),跳过。")
+            continue
+        vals = parse_kotlin_msgtype(path)
+        r = classify(vals, v2_values)
+        print(f"── [{name}] {path}")
+        print(f"   共 {len(vals)} 个 wire 值 | canonical 一致 {len(r['matched'])} | "
+              f"已接受兼容别名 {len(r['accepted_alias'])} | 客户端专有扩展 {len(r['client_ext'])} | "
+              f"未知(server 会拒){len(r['unknown'])}")
+        if r["accepted_alias"]:
+            print("   · ACCEPTED_ALIAS(v2 已登记为入向兼容别名,server 认得;建议客户端后续迁到 canonical 长名):")
+            for c, v in r["accepted_alias"]:
+                print(f"       {c!r}  ≈  canonical {v!r}")
+        if r["unknown"]:
+            any_unknown = True
+            print("   ⚠ UNKNOWN(v2 既无此值、也非已登记别名/扩展 —— server 端会 UNKNOWN_MESSAGE_TYPE 拒收):")
+            for w in r["unknown"]:
+                print(f"       {w!r}  —— 需在 v2 MessageType 补登(canonical 或兼容别名),或客户端删除")
+        if r["client_ext"]:
+            print(f"   · CLIENT_EXT(客户端专有扩展,正常): {', '.join(repr(w) for w in r['client_ext'])}")
+        print()
+
+    if any_unknown:
+        print("结论:存在 server 会拒收的未登记 wire 值(见上 ⚠)。修复:在 v2 MessageType "
+              "补登为 canonical 或入向兼容别名,或从客户端移除。")
+        if args.strict:
+            return 1
+    else:
+        print("结论:所有客户端 wire 值均被 v2 SSOT 接受(canonical 一致 / 已登记兼容别名 / 白名单扩展);"
+              "无 server 会拒的未知类型。✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

系统性收敛 + 三仓全仓审查后，把能在本仓安全彻底收尾的全部收尾。原则：只融合意外重复、只修有铁证的错误、不动有意的架构分层。

### 本 PR 包含（全部已验证）

1. **删冗余写配置端点**：`POST /api/config/update` + `ALLOWED_CONFIG_KEYS`（零真实调用方，写配置收口到 `config.py`）。
2. **信号处理器日志澄清**：Windows 上 asyncio 信号处理器不支持属预期，WARNING→info。
3. **语音通路融合 A**：面板推送并入默认 `voice_loop`（此前默认配置下面板语音显示是死的）+ 互斥防双跑。
4. **修真 bug — lumiv_gateway 幽灵 import**：`core/api_routes.py` 9 处 `lumiv_gateway`（galaxy→lumiv 半改名残留，目录不存在）。其中 `get_device_ingress_surface_report()` 的真实 import 必然 ModuleNotFoundError、被 try 吞掉，导致该诊断永远返回 error。全改回 `galaxy_gateway`，实测恢复。
5. **文档端口/路径对齐（三仓联调命门）**：三仓审查确认端口真相是 **9000**（Android/WearOS 客户端 + `config/unified_ports.yaml` 三方一致），8765 是历史值。
   - `ANDROID_COMPAT.md`：端口 + WS 表主/次路径写反 + 删假路径 + 旧仓名，全部按代码更正。
   - `ANDROID_PROTOCOL_ALIGNMENT.md` + 9 份操作性对接文档：端口 8765→9000。
6. **协议单一真相源（SSOT）收口 + 跨仓漂移门禁**（新增）：以 v2 `galaxy_gateway/protocol/aip_v3.py` 的 `MessageType` 为三仓消息契约唯一真相源。新增自动漂移检查器发现两客户端历史上发着 **8 个 v2 不认的 wire 值**——server 端 `MessageType(...)` 会 `ValueError → UNKNOWN_MESSAGE_TYPE`，整条消息被拒：
   - 6 个短别名（`relay`/`forward`/`reply`/`lock`/`unlock`/`broadcast`）语义等同 v2 canonical 长名（`relay_request`/`relay_forward`/`relay_reply`/`coord_lock`/`coord_unlock`/`coord_broadcast`），仅字符串不同。
   - 2 个 v2 此前无对应类型：`operator_action_request`（对应已存在的 `operator_action_result`）、`device_audit_report`（与 `device_*_report` 家族并列）。
   - 沿用本文件既有 "previously absent → added" 补丁做法（`HANDOFF_DISPATCH`/`cancel_result`/`ack` 等），把这 8 个登记为**仅入向兼容别名**：server 从此认得、经既有 catch-all 与 canonical 对应类型一样优雅路由；canonical 输出仍只用长名。**不改客户端、不改 `android_bridge` 调度——现网客户端无需改动即可连通。**
   - 新增：`tools/protocol/check_aip_msgtype_drift.py`（`--strict` 作 CI 门禁）、`tests/test_protocol_msgtype_ssot.py`（16 用例，不依赖 sibling 仓）、`ANDROID_PROTOCOL_ALIGNMENT.md` 第 11 节。

### 三仓审查核心结论

三仓（v2 + Android ~75% + WearOS ~75%）代码契约本身**对齐、能联通**（`:9000` + `/ws/device/{id}` + AIP v3）。裂缝在文档漂移（已修）、半成品收敛（已修）、协议手工镜像漂移（本轮以 SSOT 收口 + 门禁根治）。

### 有意保留 / 留待后续（需真机或跨仓或架构决策）

- `audit/*.md` 等历史审计快照的 8765（非对接指南，不篡改历史）。
- 客户端 `MsgType.kt` 若要收敛到纯 canonical（把 6 个短别名 wire 值改成长名）：改动需在 Android/WearOS 各自仓库用 Android SDK/Gradle 本地构建验证（v2 沙箱无 Android 工具链）。server 端已兼容，非强制。
- galaxy→lumiv 在 Android 仓的 `com.ufo.lumiv.*` 平行树（跨仓，需 Android 端配合）。
- gateway lifespan 挂载不执行（`/gateway/*` REST 503，需真机验证；设备连接走根路径不受影响）。
- 双层限流叠加、~8.2万行自审计模块归档、health_monitor 隐藏入口（需拍板）。

## Test plan

- [x] 8 个客户端 wire 值均可解析（不再 `UNKNOWN_MESSAGE_TYPE`）；漂移检查器 `--strict` 退出 0
- [x] `tests/test_protocol_msgtype_ssot.py` 16 用例全绿；`android_bridge` 导入正常
- [x] 协议回归 280 passed（6 个 handoff 失败为 schema-gate 预存基线，已 `git stash` 对照确认与本改动无关）
- [x] `get_device_ingress_surface_report()` 实测恢复正常（返回 5 个真实入口面）
- [x] 路由/配置/语音/TTS/orchestrator 相关回归全绿
- [ ] 运行时（面板显示语音、三仓真机联调）需真机确认

> **CI 说明**：本 PR 全部 ~40 项 check 均在 3 秒内空日志失败（`runner_id:0`、无日志下载），是仓库现存的 CI 基建问题（跨 #1430–1435 一致复现，与 diff 无关），非本改动引入。已在本地逐项验证通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)