### PR TITLE
真机启动排查:模型加载/Redis/UFO/NATS/GPU 告警修复 + 克隆界面对齐

### DIFF
--- a/core/api_routes.py
+++ b/core/api_routes.py
@@ -652,12 +652,13 @@ def create_websocket_routes(app: FastAPI, service_manager=None):
         compat_ws_policy["protected_mode"],
         compat_ws_policy["system_mode"],
     )
-    logger.warning(
-        "DEPRECATED: core/api_routes.py create_websocket_routes() is a "
-        "compatibility surface. New clients MUST use "
-        "galaxy_gateway/routes/websocket.py /ws/device/{device_id} "
-        "as the sole canonical device ingress. "
-        "This compat path will be removed in a future release."
+    # 这条弃用提示每次桌面启动都会打印一遍(默认路径就会走到这里),对最终用户
+    # 是噪音——它面向的是【集成方开发者】,不是运行时故障。降到 info 级别陈述一次
+    # 即可,避免真机日志里一条 WARNING 反复吓人。
+    logger.info(
+        "core/api_routes.py create_websocket_routes() 为兼容层;新客户端应使用 "
+        "galaxy_gateway/routes/websocket.py 的 /ws/device/{device_id} 作为唯一"
+        "规范设备入口(此兼容路径未来会移除)。"
     )
 
     def _stamp_problem_closure_to_task_queue(

--- a/core/cache.py
+++ b/core/cache.py
@@ -105,7 +105,9 @@ class RedisCache:
             logger.info(f"Redis 已连接: {self.url}")
             return True
         except Exception as e:
-            logger.warning(f"Redis 连接失败: {e}")
+            # Redis 在桌面单机模式是可选项:连不上会安静降级到内存缓存(见
+            # CacheManager.initialize)。用 info 陈述,不用 warning 吓人。
+            logger.info("Redis 未连接(降级到内存缓存,桌面单机属正常): %s", e)
             self._redis = None
             return False
 
@@ -194,8 +196,15 @@ class CacheManager:
 
     async def initialize(self) -> str:
         """初始化缓存后端，返回后端类型"""
-        if self.redis_url:
-            redis_cache = RedisCache(self.redis_url)
+        url = (self.redis_url or "").strip()
+        if url:
+            # 容错:允许 .env 里只写 host:port(如 REDIS_HOST/REDIS_PORT 拼出的
+            # "localhost:6379")而漏掉 scheme —— 否则 aioredis.from_url 会直接抛
+            # "Redis URL must specify one of the following schemes"。补默认
+            # redis:// 再连。真机复现过此告警,根因即 .env 里 REDIS_URL 半配置。
+            if "://" not in url:
+                url = "redis://" + url
+            redis_cache = RedisCache(url)
             if await redis_cache.connect():
                 self._backend = redis_cache
                 self._is_redis = True

--- a/core/config_preflight.py
+++ b/core/config_preflight.py
@@ -340,11 +340,19 @@ class PreflightReport:
     # ── display ──────────────────────────────────────────────────────────
 
     def format(self, verbose: bool = True) -> str:
+        # 盒子标题按盒宽【居中计算】,不再手写空格——真机复现过标题行内宽 57、
+        # 上下边框内宽 58,导致标题右侧 ║ 比边框的 ╗ 缩进一格(整个白框歪一行)。
+        # 盒宽 58 与启动 banner(core.ascii_art)一致,两个白框从此完全对齐。
+        _box_inner = 58
+        _title = "Galaxy Pre-flight Configuration Check"
+        _pad = max(0, _box_inner - len(_title))
+        _left = _pad // 2
+        _right = _pad - _left
         lines: List[str] = [
             "",
-            "╔══════════════════════════════════════════════════════════╗",
-            "║         Galaxy Pre-flight Configuration Check           ║",
-            "╚══════════════════════════════════════════════════════════╝",
+            "╔" + "═" * _box_inner + "╗",
+            "║" + " " * _left + _title + " " * _right + "║",
+            "╚" + "═" * _box_inner + "╝",
             f"  Mode  : {self.mode}",
             f"  Checks: {len(self.findings)}  "
             f"passed={len(self.passed)}  "
@@ -353,8 +361,11 @@ class PreflightReport:
             "",
         ]
 
+        # 符号与 core.cli_render 统一(✓/⚠/✗,均为 1 显示格),不再混用 emoji
+        # ✅/⚠️/❌(带变体选择符、多数终端渲染成 2 格),避免整个克隆界面对号列
+        # 因图标宽度不一而错位——真机反馈"绿色对号没对齐成一列"根因之一。
         if self.criticals:
-            lines.append("  ❌  CRITICAL — startup blocked")
+            lines.append("  ✗  CRITICAL — startup blocked")
             lines.append("  " + "─" * 56)
             for f in self.criticals:
                 lines.append(f"  • {f.check.var}")
@@ -364,7 +375,7 @@ class PreflightReport:
                 lines.append("")
 
         if self.warnings and verbose:
-            lines.append("  ⚠️   WARNING — degraded functionality")
+            lines.append("  ⚠  WARNING — degraded functionality")
             lines.append("  " + "─" * 56)
             for f in self.warnings:
                 lines.append(f"  • {f.check.var}")
@@ -374,7 +385,7 @@ class PreflightReport:
                 lines.append("")
 
         if self.ok:
-            lines.append("  ✅  All CRITICAL checks passed.")
+            lines.append("  ✓  All CRITICAL checks passed.")
 
         lines.append("")
         return "\n".join(lines)

--- a/core/device_agent_manager.py
+++ b/core/device_agent_manager.py
@@ -308,7 +308,12 @@ class WindowsDeviceAgent(BaseDeviceAgent):
             self.ufo_available = True
             logger.info("Microsoft UFO loaded successfully")
         except ImportError as e:
-            logger.warning(f"Microsoft UFO not available: {e}")
+            # 可选重量级依赖,缺失属预期(见 microsoft_ufo_integration 说明);
+            # 设备代理无 UFO 时按 ufo_available=False 正常降级,不是故障。
+            logger.info(
+                "Microsoft UFO 未安装(可选依赖,缺失属正常),设备代理降级运行。 [%s]",
+                e,
+            )
             self.ufo_available = False
     
     async def disconnect(self) -> bool:

--- a/core/hardware_compute_profiler.py
+++ b/core/hardware_compute_profiler.py
@@ -278,7 +278,9 @@ class HardwareComputeProfiler:
                         temperature_c=temp,
                     ))
             except Exception as exc:
-                logger.warning("Exception suppressed: %s", exc)
+                # pynvml 缺失 / 无 NVIDIA GPU 属预期(桌面无独显机器很常见),
+                # 不是故障——降到 debug,不刷 WARNING。
+                logger.debug("NVIDIA GPU 探测跳过(pynvml 不可用或无 N 卡): %s", exc)
 
         # AMD GPU (rocm)
         if not gpus:
@@ -297,7 +299,9 @@ class HardwareComputeProfiler:
                         utilization_percent=0.0, temperature_c=0.0,
                     ))
             except Exception as exc:
-                logger.warning("Exception suppressed: %s", exc)
+                # rocm-smi 不存在(非 AMD/无 ROCm,Windows 上必 FileNotFoundError
+                # [WinError 2])属预期,不是故障——降到 debug。
+                logger.debug("AMD GPU 探测跳过(rocm-smi 不可用): %s", exc)
 
         # Intel GPU
         if not gpus:

--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -272,7 +272,7 @@ class LocalBrainManager:
 
         # Priority 2: Ollama (most stable, easiest setup)
         if "ollama" in available:
-            # Check if Ollama is actually running
+            # Check if Ollama is actually running (快速探测)
             try:
                 import httpx
 
@@ -286,6 +286,20 @@ class LocalBrainManager:
                     return "ollama"
             except Exception as exc:
                 logger.debug("Ollama availability check failed: %s", exc)
+
+            # 快速探测失败 ≠ 没装 Ollama。真机复现:Ollama 首次冷启动、或正在把
+            # 大模型(如用户后台 pull 的 12B)载入内存时,/api/tags 可能几秒内不回;
+            # 若此时配置的主脑模型是 Ollama 标签(如 "gemma4:latest",带冒号、由
+            # ollama pull 管理),绝不能因为探测超时就跌落到 transformers——
+            # transformers 会把这个 Ollama 标签当 HuggingFace repo 加载,必然
+            # "模型加载失败"。只要 ollama 二进制在,就选 ollama:后续
+            # _ensure_ollama_running() 有 ~50s 冷启动等待窗口来正确拉起并就绪。
+            if shutil.which("ollama"):
+                logger.info(
+                    "自动选择 ollama 后端 (Ollama 已安装但快速探测未响应,"
+                    "转由冷启动长等待路径处理)"
+                )
+                return "ollama"
 
         # Priority 3: llama_cpp without GPU (still works on CPU)
         if "llama_cpp" in available:

--- a/core/microsoft_ufo_integration.py
+++ b/core/microsoft_ufo_integration.py
@@ -228,8 +228,15 @@ class MicrosoftUFOAutomator(BaseUIAutomator):
             return True
 
         except ImportError as e:
-            logger.warning(f"Microsoft UFO not available: {e}")
-            # 降级到 pyautogui
+            # Microsoft UFO(github.com/microsoft/UFO)是可选的重量级依赖,默认不随
+            # Galaxy 安装。缺失属预期,不是错误——UI 自动化会自动降级到 pyautogui,
+            # 功能可用。用 info 级别陈述事实 + 给出安装指引,避免真机上被误读为故障。
+            logger.info(
+                "Microsoft UFO 未安装(可选依赖,缺失属正常),UI 自动化降级到 "
+                "pyautogui。如需启用 UFO 深度控制,请安装 microsoft/UFO 到 PYTHONPATH。"
+                " [%s]",
+                e,
+            )
             return await self._initialize_fallback()
         except Exception as e:
             logger.error(f"Failed to initialize Microsoft UFO: {e}")

--- a/core/nats_bus.py
+++ b/core/nats_bus.py
@@ -1188,7 +1188,17 @@ class NATSBus:
 
     async def _on_error(self, exc: Exception) -> None:
         self._stats["errors"] += 1
-        logger.error(f"NATSBus: error — {exc}")
+        # nats-py 在向【可选/未就绪】的 NATS 反复重连时会不断回调此处,而 exc 常
+        # stringify 为空 —— 真机上刷出一串刺眼的 "NATSBus: error —"(消息为空)。
+        # 桌面单机默认 NATS 可选(GALAXY_NATS_ENABLED=false,见 .env.example),
+        # 这类重连期错误降噪:用 repr 保证信息不为空;非 fabric 严格模式降到 debug,
+        # 严格模式仍保留 error,不掩盖真正需要 NATS 时的故障。
+        detail = repr(exc) if not str(exc).strip() else str(exc)
+        _strict = os.environ.get("GALAXY_FABRIC_STRICT", "").strip().lower() in ("1", "true", "yes", "on")
+        if _strict:
+            logger.error("NATSBus: error — %s", detail)
+        else:
+            logger.debug("NATSBus: error(重连期,NATS 桌面单机可选,已降噪)— %s", detail)
 
 
 # ── Module-level singleton (constraint C1) ─────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -28,6 +28,20 @@ try:
 except Exception:
     pass
 
+# ── 第三方库的已知噪音告警降噪 ─────────────────────────────────────────────
+# 真机启动日志里有几条来自【第三方依赖】的 UserWarning,与 Galaxy 自身无关、
+# 用户既无法也无需处理,却每次启动都刷屏。用精确匹配把这几条静音(只针对已知
+# 来源,不做全局吞并,避免掩盖真正的告警):
+#   - webrtcvad → "pkg_resources is deprecated"(setuptools 弃用,第三方未适配)
+#   - pywinauto → "Revert to STA COM threading mode"(Windows COM 线程模式提示)
+import warnings as _warnings
+try:
+    _warnings.filterwarnings("ignore", message=r".*pkg_resources is deprecated.*")
+    _warnings.filterwarnings("ignore", message=r".*Revert to STA COM threading mode.*")
+    _warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"webrtcvad.*")
+except Exception:
+    pass
+
 if sys.platform == "win32":
     # Set console to UTF-8 mode (Python 3.7+)
     try:

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -1479,12 +1479,12 @@ class GalaxyUnified:
         
         print(f"\n{Colors.BOLD}LLM API:{Colors.ENDC}")
         for api, configured in status["llm_apis"].items():
-            icon = "✅" if configured else "❌"
+            icon = "✓" if configured else "✗"
             print(f"  {icon} {api.upper()}")
             
         print(f"\n{Colors.BOLD}数据库:{Colors.ENDC}")
         for db, configured in status["database"].items():
-            icon = "✅" if configured else "❌"
+            icon = "✓" if configured else "✗"
             print(f"  {icon} {db}")
             
         print_section("节点统计")


### PR DESCRIPTION
## Summary

依据用户真机 `python main.py` 启动日志逐条排查修复(用户从 gitee 镜像克隆,故均采用**防御式消费端加固**——即使 `.env` 半配置也能自愈,不依赖上游过滤)。

### 1. 模型加载失败(核心功能 bug)
真机现象:后台已 `ollama pull` 好模型,启动却"模型加载失败 [transformers]"→"服务未响应/模型未就绪"。根因:`_auto_select_backend` 用 3s `/api/tags` 快速探测判断 Ollama;Ollama 首次冷启动 / 正把大模型(12B)载入内存时探测超时,于是**跌落到 transformers,又把 Ollama 标签 `gemma4:latest` 当 HF repo 加载**,必然失败。
**修复**:快速探测失败但 `ollama` 二进制在 → 仍选 ollama,交由 `_ensure_ollama_running()` 的 ~50s 冷启动等待窗口正确拉起。

### 2. Redis "must specify scheme"
`.env` 里 `REDIS_URL` 半配置(只 `host:port` 缺 scheme)会让 `aioredis.from_url` 直接抛错。`CacheManager` 补默认 `redis://` 再连,连不上安静降级内存;连接失败告警 `warning→info`(桌面单机 Redis 本可选)。已本地验证 schemeless/empty 均降级 memory 无异常。

### 3. Microsoft UFO "not available"
`ufo` 是可选重依赖,缺失属预期且已降级 pyautogui。两处 `warning→info`,措辞改为"可选依赖缺失属正常 + 安装指引",不再像故障。

### 4. NATSBus 空 error 刷屏
重连可选/未就绪 NATS 时 exc 常为空 → 刷一串刺眼 `NATSBus: error —`。用 `repr` 保证非空;非 fabric 严格模式降 `debug`,严格模式仍 `error`。

### 5. GPU 探测 & 第三方噪音告警
- `pynvml` 缺失 / `rocm-smi` 不存在(WinError 2)在无独显机器属预期 → `warning→debug`。
- `webrtcvad`(pkg_resources 弃用)、`pywinauto`(STA COM)启动最早期精确静音。
- `create_websocket_routes` 弃用提示每次启动刷屏 → `warning→info` 陈述一次。

### 6. 克隆界面对齐
- 预检白框标题行内宽 57 vs 边框 58 → 标题右 `║` 歪一格。改为**按盒宽居中计算**(盒宽 58,与 banner 一致),断言三行显示宽度均 60。
- 界面符号统一:预检段 emoji `✅/⚠️/❌`(变体选择符,多数终端 2 格)与 `cli_render` 文本 `✓/⚠/✗`(1 格)混用导致"绿色对号没对齐成一列" → 全部统一为文本符号集。

## Test plan
- [x] `CacheManager('localhost:6379')` / `('')` 均降级 memory,无 scheme ValueError(本地实测)
- [x] 预检白框 top/title/bot 三行显示宽度断言均为 60
- [x] 全部改动文件语法校验通过
- [ ] 真机 `python main.py` 复跑确认:模型经 ollama 就绪、告警消音、界面对齐(需你本地验证)

## 说明
本仓 CI 为已知基建问题(所有 check 3 秒内空日志失败,跨多个 PR 一致,与 diff 无关)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_