### PR TITLE
v2 结构收口 + 启动 UX:503/双限流/health + 对齐/模型选择/Electron/Docker-Podman

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,10 +71,16 @@ GROQ_API_KEY=your_groq_api_key_here
 # ============================================================================
 LLM_API_KEY=your_llm_api_key_here
 
-# Local Ollama model — Google Gemma 4 E4B (default, good for regular PCs)
-# Options: gemma4:latest (E4B, ~5GB), gemma4:26b (MoE, ~15GB), gemma4:31b (~17GB)
-# E4B = 4B params, 128K context window, best for 16GB RAM laptops
-OLLAMA_MODEL=gemma4:latest
+# 本地 Ollama 主脑模型（Local Ollama main-brain model）
+# 【留空】=> 首次启动会在「AI 大脑」阶段【交互式让你选择】主脑，候选:
+#     [1] Google Gemma 4 12B        文本+视觉+原生音频(听)+工具调用, 128K
+#     [2] MiniCPM-o 4.5 (9B)        全模态: 看+听+说, 全双工(需显卡)
+#     [3] Google Gemma 4 E4B        文本+视觉+原生音频, 中等显存
+#     [4] Google Gemma 4 E2B        文本+视觉+原生音频, 小显存/轻量(纯 CPU 推荐)
+#   会按你的【实际显存】高亮推荐，回车用推荐 / 数字手选 / s 跳过。
+# 若在此【显式指定】一个 tag（如 gemma4:e2b），则跳过交互、直接用它。
+# 之后随时可用  python main.py --select-model  重新选择。
+OLLAMA_MODEL=
 
 # Memory system persistent storage path
 # Default: /app/data/ (Docker volume) or ./data/ (local dev)

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ env/
 .env.local
 *.local
 
+# Per-machine persisted choices (main-brain model / container runtime) — 本机状态，非源码
+.galaxy_model
+.galaxy_runtime
+
 # Logs
 *.log
 logs/

--- a/core/ascii_art.py
+++ b/core/ascii_art.py
@@ -225,13 +225,18 @@ def _colorize_line(line: str, banner_width: int = 60) -> str:
 # 状态图标映射 (trailing spaces removed — print_status_row adds uniform spacing)
 # ---------------------------------------------------------------------------
 
+# 与 core.cli_render 统一为【一套 1 显示格的文本符号】(不再混用 ✅/⚠️/❌ 这类带变体
+# 选择符、多数终端渲染成 2 格的 emoji)——否则同一屏里 emoji 行(2 格)、▶ 行(1 格)、
+# cli_render 的 ✓ 行(1 格)三种图标宽度不一,对勾列各自缩进,永远对不齐。统一成 1 格
+# 文本符号后,配合下面 print_status_row 的"图标+单空格"排版,标签一律从第 4 列起,
+# 与 cli_render 的 phase()/detail() 完全同列。
 _STATUS_ICONS: dict = {
-    "success": "✅",
-    "warning": "⚠️",
-    "error":   "❌",
-    "loading": "⏳",
+    "success": "✓",
+    "warning": "⚠",
+    "error":   "✗",
+    "loading": "◐",
     "step":    "▶",
-    "info":    "ℹ️",
+    "info":    "·",
 }
 
 
@@ -316,7 +321,7 @@ def print_status_row(
     label: str,
     value: str = "",
     status: str = "info",
-    label_width: int = 28,
+    label_width: int = 22,
     use_color: bool = True,
 ) -> None:
     """打印对齐的状态行（图标 + 左对齐标签 + 右侧值）。
@@ -352,11 +357,13 @@ def print_status_row(
     else:
         color = end = ""
 
+    # 图标 + 【单】空格(图标现为 1 显示格),标签左对齐 —— 标签从第 4 列起,与
+    # core.cli_render 的 phase()/detail() 同列,对勾/标签跨两套打印器完全对齐。
     padded = label.ljust(label_width)
     if value:
-        print(f"  {color}{icon}  {padded}{value}{end}")
+        print(f"  {color}{icon} {padded}{end}{value}")
     else:
-        print(f"  {color}{icon}  {padded}{end}")
+        print(f"  {color}{icon} {padded}{end}")
 
 
 # ---------------------------------------------------------------------------

--- a/core/container_runtime.py
+++ b/core/container_runtime.py
@@ -1,0 +1,199 @@
+"""
+core/container_runtime.py — 容器运行时（Docker / Podman）选择与解析
+=====================================================================
+
+节点服务的基础设施(NATS/Redis/Qdrant/Neo4j/Mongo)跑在容器里。此前只支持 Docker;
+本模块把运行时抽象成【可选 Docker 或 Podman】,并仿 ``core.model_selection`` 的模式
+提供:检测 → (两者都装时)交互选择 → 持久化 → 统一的 CLI 抽象(info/compose/up)。
+
+Podman 与 Docker 的 CLI 基本兼容:``podman info`` / ``podman compose`` (或
+``podman-compose``) / ``podman ... up -d`` 对应 docker 同名命令,故一套抽象即可。
+
+解析优先级(``resolve_runtime``):
+    环境 GALAXY_CONTAINER_RUNTIME > 已保存(.galaxy_runtime)
+    > 只装了一个 → 直接用 > 两个都装且交互 → 提示选 > 都没装 → ""(跳过,不阻断)。
+
+选择结果驱动 ``unified_launcher.ensure_docker_infra`` 后台【静默拉取】基础设施镜像并
+拉起服务。全程容错,任何分支都不影响桌面启动。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.ContainerRuntime")
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_CHOICE_FILE = PROJECT_ROOT / ".galaxy_runtime"
+
+_RUNTIMES = ("docker", "podman")
+_LABELS: Dict[str, str] = {
+    "docker": "Docker —— 最广泛;Docker Desktop / Engine + docker compose",
+    "podman": "Podman —— 无守护进程、rootless、更轻;podman / podman-compose",
+}
+
+
+def detect_runtimes() -> Dict[str, Optional[str]]:
+    """返回 {runtime: 可执行路径 或 None}。"""
+    return {rt: shutil.which(rt) for rt in _RUNTIMES}
+
+
+def available_runtimes() -> List[str]:
+    """已安装(命令可用)的运行时名列表,docker 优先。"""
+    det = detect_runtimes()
+    return [rt for rt in _RUNTIMES if det.get(rt)]
+
+
+def _env_choice() -> str:
+    return os.environ.get("GALAXY_CONTAINER_RUNTIME", "").strip().lower()
+
+
+def load_choice() -> str:
+    try:
+        if _CHOICE_FILE.exists():
+            return _CHOICE_FILE.read_text(encoding="utf-8").strip().lower()
+    except Exception:  # noqa: BLE001
+        pass
+    return ""
+
+
+def save_choice(rt: str) -> None:
+    """持久化选择并写 GALAXY_CONTAINER_RUNTIME,让后续启动无需再问。"""
+    if rt not in _RUNTIMES:
+        return
+    try:
+        _CHOICE_FILE.write_text(rt, encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        pass
+    os.environ["GALAXY_CONTAINER_RUNTIME"] = rt
+
+
+def interactive_select(avail: List[str]) -> str:
+    """两个运行时都装了时,让用户选一个作后台基础设施运行时。
+
+    非交互终端(无 TTY)不阻塞:返回 avail[0](docker 优先),由调用方明确说明"已自动选用"。
+    渲染走 core.cli_render(与启动界面同一套:对齐、细线)。
+    """
+    if not avail:
+        return ""
+    if not (sys.stdin and sys.stdin.isatty()):
+        return avail[0]
+
+    from core import cli_render as r
+    from core.ascii_art import Colors
+
+    def _c(t, color):
+        return f"{color}{t}{Colors.ENDC}" if r._use_color() else t
+
+    print()
+    print("  " + _c("选择容器运行时", Colors.BOLD + Colors.CYAN)
+          + _c("  (后台拉取并运行节点基础设施)", Colors.DIM))
+    r.rule()
+    for i, rt in enumerate(avail, 1):
+        is_first = (i == 1)
+        marker = _c("▸", Colors.GREEN) if is_first else " "
+        num = _c(f"[{i}]", Colors.BOLD if is_first else Colors.DIM)
+        name = r.pad_display(rt.capitalize(), 10)
+        tail = _c("  ← 默认", Colors.GREEN) if is_first else ""
+        print(f"  {marker} {num} {name}{tail}")
+        print(f"         {_c(_LABELS.get(rt, ''), Colors.DIM)}")
+    r.rule()
+    print("  " + _c("回车=用默认 · 数字=手选", Colors.DIM))
+    while True:
+        try:
+            choice = input(f"  请选择运行时 [1-{len(avail)} / 回车]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            return avail[0]
+        if choice == "":
+            return avail[0]
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(avail):
+                return avail[idx]
+        # 也允许直接输入名字
+        if choice in avail:
+            return choice
+        print("  " + _c("⚠ 无效输入，请重新选择（或直接回车用默认）。", Colors.YELLOW))
+
+
+def resolve_runtime(interactive: bool = True) -> str:
+    """解析并持久化最终容器运行时。返回运行时名("" = 无可用运行时,跳过)。
+
+    环境 > 已保存 > 单一已装 > (两者都装且交互)提示 > 都没装 → ""。
+    """
+    env = _env_choice()
+    if env in _RUNTIMES and shutil.which(env):
+        save_choice(env)
+        return env
+
+    saved = load_choice()
+    if saved in _RUNTIMES and shutil.which(saved):
+        os.environ["GALAXY_CONTAINER_RUNTIME"] = saved
+        return saved
+
+    avail = available_runtimes()
+    if not avail:
+        return ""
+    if len(avail) == 1:
+        save_choice(avail[0])
+        return avail[0]
+
+    chosen = interactive_select(avail) if interactive else avail[0]
+    if chosen:
+        save_choice(chosen)
+    return chosen
+
+
+# ── 统一 CLI 抽象:docker / podman 命令基本同名 ──────────────────────────────
+
+def runtime_binary(rt: str) -> Optional[str]:
+    return shutil.which(rt) if rt in _RUNTIMES else None
+
+
+def daemon_up(rt: str) -> bool:
+    """运行时守护/引擎是否就绪(``<rt> info`` 成功)。Podman 无守护但 info 同样可用。"""
+    bin_ = runtime_binary(rt)
+    if not bin_:
+        return False
+    try:
+        return subprocess.run(
+            [bin_, "info"], capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=15,
+        ).returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def compose_base(rt: str) -> Optional[List[str]]:
+    """返回该运行时的 compose 命令前缀:
+    - docker → [docker, compose] 或 [docker-compose]
+    - podman → [podman, compose] 或 [podman-compose]
+    找不到返回 None。
+    """
+    bin_ = runtime_binary(rt)
+    if bin_:
+        try:
+            if subprocess.run(
+                [bin_, "compose", "version"], capture_output=True, text=True,
+                encoding="utf-8", errors="replace", timeout=15,
+            ).returncode == 0:
+                return [bin_, "compose"]
+        except Exception:  # noqa: BLE001
+            pass
+    # 独立 compose 二进制回退
+    standalone = shutil.which(f"{rt}-compose")
+    if standalone:
+        return [standalone]
+    # podman 常见另一形态:podman-compose 不在,但 docker-compose 可驱动 podman socket——
+    # 不做隐式跨用,保持清晰;返回 None 交由调用方降级。
+    return None
+
+
+def display_name(rt: str) -> str:
+    return rt.capitalize() if rt in _RUNTIMES else "容器运行时"

--- a/core/security_middleware.py
+++ b/core/security_middleware.py
@@ -650,18 +650,32 @@ class SecurityManager:
             strict=config.get("strict_validation", False)
         )
 
-    def setup_middleware(self, app):
-        """为 FastAPI 应用安装所有安全中间件"""
+    def setup_middleware(self, app, include_rate_limit: bool = True):
+        """为 FastAPI 应用安装所有安全中间件
+
+        Args:
+            include_rate_limit: 是否安装本管理器自带的 HTTP 速率限制中间件。
+                主 app 的性能中间件链(core.performance.RateLimitMiddleware,见
+                core/startup.py 步骤 3)已经是【权威 HTTP 限流层】(支持 apikey 分桶、
+                可配置 RATE_LIMIT_MAX_REQUESTS/WINDOW、回环豁免)。若在同一个 app 上
+                再装本管理器的 RateLimiter,同一条 HTTP 请求会被【两个独立限流器双重
+                计数】——两者阈值/分桶键还不同(此处 120rpm/按 IP,性能层 200/60s/按
+                apikey-or-ip),更严的那个静默生效,配置文不对题。故主 app 挂载时传
+                include_rate_limit=False,把 HTTP 限流【收口到性能层唯一一处】。
+                默认 True 以保持 SecurityManager 单独使用时(无性能层)仍自带限流。
+        """
         # 注意：中间件按添加的逆序执行
-        # 执行顺序：IP Block → Rate Limit → Input Validation → Security Headers → Audit → Handler
+        # 执行顺序：IP Block → [Rate Limit] → Input Validation → Security Headers → Audit → Handler
 
         create_audit_middleware(app, self.audit)
         create_security_headers_middleware(app)
         create_input_validation_middleware(app, self.input_validator)
-        create_rate_limit_middleware(app, self.rate_limiter)
+        if include_rate_limit:
+            create_rate_limit_middleware(app, self.rate_limiter)
         create_ip_block_middleware(app, self.ip_block)
 
-        logger.info("安全中间件已全部安装 (审计日志 + 安全头 + IP黑名单 + 速率限制 + 输入验证)")
+        _rl = "速率限制 + " if include_rate_limit else ""
+        logger.info("安全中间件已安装 (审计日志 + 安全头 + IP黑名单 + %s输入验证)", _rl)
 
     def get_dashboard(self) -> Dict:
         return {

--- a/core/startup.py
+++ b/core/startup.py
@@ -813,8 +813,44 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
     try:
         from galaxy_gateway.app import app as gateway_app
         app.mount("/gateway", gateway_app)
-        results["galaxy_gateway"] = {"status": "ok"}
-        logger.info("Galaxy Gateway 已挂载到 /gateway")
+
+        # Starlette 不会为【被挂载的子应用】运行其 lifespan —— 而 galaxy_gateway 的
+        # lifespan 负责创建 DeviceManager / WebSocketManager / TaskOrchestrator 并写入
+        # gateway_app.state。父应用又是命令式启动、根本没有自己的 lifespan(见
+        # unified_launcher 里 FastAPI(...) 无 lifespan 参数),所以子应用 lifespan 永不
+        # 触发。后果:/gateway/* 下所有走 Depends(get_device_manager/...) 的 REST 路由,
+        # 会因 app.state.X 为 None 被 dependencies._get_state 判定 503 "Service not ready"
+        # ——真机可复现的"/gateway/* 恒 503"。
+        # 修复:只补齐【必需的四个核心服务】(dependencies 里会抛 503 的那批),复用
+        # lifecycle.init_gateway_core_services()。**刻意不跑完整 lifespan**——完整 lifespan
+        # 还会连 NATS、起 TCP/UDP 监听(绑端口)、注册 AIPTransport 适配器、起 MasterBrain
+        # 等,这些要么重、要么会与主 app 已启动的同类服务【双绑端口/重复注册】。可选服务
+        # (openclawd/llm_router/nats_adapter)缺失时 dependencies 返回 None、不报 503,
+        # 所以只补必需项即可精确消除 503,不引入端口冲突。
+        # 注:设备 WebSocket(/ws/device/{id})走根路径、由 unified_launcher 独立注册,
+        # 不受此影响;本修复只补活 /gateway/* 的 REST 面。
+        try:
+            from galaxy_gateway.bootstrap.lifecycle import init_gateway_core_services
+            (
+                _gw_dm, _gw_mh, _gw_wsm, _gw_to,
+            ) = await init_gateway_core_services(gateway_app)
+
+            async def _shutdown_gateway_core() -> None:
+                import contextlib as _ctx
+                with _ctx.suppress(Exception):
+                    await _gw_to.stop()
+                with _ctx.suppress(Exception):
+                    await _gw_wsm.stop()
+
+            app.add_event_handler("shutdown", _shutdown_gateway_core)
+            results["galaxy_gateway"] = {"status": "ok", "core_services": "started"}
+            logger.info(
+                "Galaxy Gateway 已挂载到 /gateway(必需核心服务已就绪,/gateway/* 不再 503)"
+            )
+        except Exception as _le:
+            # 核心服务启动失败不应阻断整体:挂载仍在,只是 /gateway/* 可能仍 503。
+            results["galaxy_gateway"] = {"status": "degraded", "error": str(_le)}
+            logger.warning("Galaxy Gateway 已挂载,但核心服务启动失败: %s", _le)
     except Exception as e:
         logger.debug("Fallback triggered: %s", e)
         results["galaxy_gateway"] = {"status": "not_available", "error": str(e)}

--- a/core/startup.py
+++ b/core/startup.py
@@ -408,9 +408,12 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
         from core.security_middleware import get_security_manager
 
         security_mgr = get_security_manager()
-        security_mgr.setup_middleware(app)
+        # HTTP 限流收口到下面步骤 3 的性能中间件链(唯一权威限流层),这里不再重复
+        # 安装本管理器自带的 RateLimiter——否则同一请求被两个独立限流器双重计数
+        # (双层限流叠加,阈值/分桶键还不一致)。审计/安全头/IP黑名单/输入验证照装。
+        security_mgr.setup_middleware(app, include_rate_limit=False)
         results["security_middleware"] = {"status": "ok"}
-        logger.info("安全中间件已安装 (审计日志 + 安全头 + IP 黑名单)")
+        logger.info("安全中间件已安装 (审计日志 + 安全头 + IP 黑名单 + 输入验证;HTTP 限流收口到性能层)")
     except Exception as e:
         logger.debug("Fallback triggered: %s", e)
         results["security_middleware"] = {"status": "degraded", "error": str(e)}

--- a/galaxy_gateway/bootstrap/lifecycle.py
+++ b/galaxy_gateway/bootstrap/lifecycle.py
@@ -21,15 +21,23 @@ from fastapi import FastAPI
 logger = logging.getLogger(__name__)
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):  # noqa: C901  (acceptable complexity for a bootstrap)
-    """Galaxy Gateway application lifespan — startup → yield → shutdown."""
+async def init_gateway_core_services(app: FastAPI):
+    """创建并启动 Gateway 的【必需】核心服务并写入 ``app.state``。
 
-    # ------------------------------------------------------------------
-    # Startup
-    # ------------------------------------------------------------------
-    logger.info("Initializing Galaxy Gateway...")
+    这四个服务(device_manager / message_handler / websocket_manager /
+    task_orchestrator)是 ``galaxy_gateway.dependencies`` 里【会因缺失而抛 503】
+    的 required 依赖 —— ``/gateway/*`` 下所有 REST 路由都靠它们。
 
+    抽成独立函数,供两条启动路径共用、避免逻辑漂移:
+      1. 独立运行 Gateway 时:``lifespan`` 调用它;
+      2. 作为子应用被主 app ``app.mount('/gateway', ...)`` 挂载时:Starlette
+         不会跑子应用 lifespan,由 ``core.startup`` 在挂载后直接调用它,让 required
+         依赖照样就绪(不再 503)。**只做这四个必需服务**——不碰 NATS 连接、TCP/UDP
+         监听、AIPTransport 适配器、MasterBrain 等重/会绑端口/可能与主 app 重复的项,
+         避免挂载路径下双绑端口/重复注册。
+
+    返回 (device_manager, message_handler, websocket_manager, task_orchestrator)。
+    """
     from galaxy_gateway.transport import WebSocketManager
     from galaxy_gateway.handlers import DeviceManager, MessageHandler
     from galaxy_gateway.orchestrator import TaskOrchestrator
@@ -82,6 +90,35 @@ async def lifespan(app: FastAPI):  # noqa: C901  (acceptable complexity for a bo
     app.state.message_handler = message_handler
     app.state.websocket_manager = websocket_manager
     app.state.task_orchestrator = task_orchestrator
+
+    # 同步旧的模块级 backward-compat 全局(legacy import 路径)
+    try:
+        import galaxy_gateway.app as _gw_app
+        _gw_app.device_manager = device_manager
+        _gw_app.message_handler = message_handler
+        _gw_app.websocket_manager = websocket_manager
+        _gw_app.task_orchestrator = task_orchestrator
+    except Exception as _bc_err:
+        logger.debug("core-services backward-compat globals update failed: %s", _bc_err)
+
+    return device_manager, message_handler, websocket_manager, task_orchestrator
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):  # noqa: C901  (acceptable complexity for a bootstrap)
+    """Galaxy Gateway application lifespan — startup → yield → shutdown."""
+
+    # ------------------------------------------------------------------
+    # Startup
+    # ------------------------------------------------------------------
+    logger.info("Initializing Galaxy Gateway...")
+
+    (
+        device_manager,
+        message_handler,
+        websocket_manager,
+        task_orchestrator,
+    ) = await init_gateway_core_services(app)
 
     # Initialize optional services — these start as None; set to real
     # objects if initialization succeeds.

--- a/health_monitor.py
+++ b/health_monitor.py
@@ -1,15 +1,34 @@
 """
-Galaxy 健康监控系统
-========================
+Galaxy 健康监控系统（可选独立看门狗 / Prometheus 导出器）
+========================================================
 
-实时监控所有节点的健康状态，自动重启失败的节点
+实时监控所有节点的健康状态，自动重启失败的节点，并暴露 Prometheus /metrics。
 
 功能：
 1. 实时监控所有节点
 2. 自动重启失败的节点
 3. 发送告警通知
 4. 生成健康报告
-5. Web 仪表板
+5. Web 仪表板 + Prometheus /metrics
+
+【它与主应用的关系 —— 避免"隐藏入口点"误解】
+--------------------------------------------------------------------
+本文件是一个【独立进程】服务(自带 FastAPI app + uvicorn,默认端口 9100),
+**不由 `python main.py` 启动**,也【不需要】被它启动:
+
+  - 主应用(端口 9000)已经通过 `core/routes/monitoring.py` 暴露了等价的
+    `/metrics`(Prometheus)、`/api/v1/slo/metrics`、`/health/ready` —— 用的是
+    同一个 `core.slo_metrics.get_slo_metrics()`。所以跑 `python main.py` 时这些
+    指标/就绪端点【已经有了】,不缺。
+  - 节点健康巡检 + 自动重启,在主路径上由已接线的
+    `core.health_integration.UnifiedHealthManager`(core/startup.py 步骤 15)承担。
+
+因此本文件定位为【可选的独立看门狗 / 导出器】:
+  - 由 `daemon/galaxy_daemon.py` 作为受管子进程拉起(`python -m health_monitor
+    --watchdog`),用于不跑完整主应用、只想要一个轻量节点看门狗的部署;
+  - 或手动 `python health_monitor.py` 单独起一个健康仪表板 / Prometheus 抓取点。
+既不是死代码(daemon 与若干结构测试都依赖它),也不该塞进主启动(会与上述两处
+重复巡检 / 重复暴露端点)。
 
 作者：Galaxy Team
 日期：2026-01-23
@@ -404,12 +423,38 @@ async def startup_event():
     asyncio.create_task(monitor.monitor_loop())
 
 if __name__ == "__main__":
+    import argparse
     import uvicorn
 
-    # 启动 Web 服务（监控循环通过 startup 事件自动启动）
+    # daemon/galaxy_daemon.py 以 `python -m health_monitor --watchdog` 拉起本进程,
+    # 但此前 __main__ 直接 uvicorn.run、把 --watchdog 静默丢弃(argv 根本没被解析)。
+    # 这里显式解析,让守护进程的调用意图变得诚实可读,并允许覆盖端口。
     try:
         from core.port_config import get_service_port
-        _hm_port = get_service_port("health_monitor")
+        _default_port = get_service_port("health_monitor")
     except Exception:
-        _hm_port = 9100
-    uvicorn.run(app, host="0.0.0.0", port=_hm_port)
+        _default_port = 9100
+
+    _parser = argparse.ArgumentParser(
+        description="Galaxy 独立健康看门狗 / Prometheus 导出器(可选;主应用已内置等价端点)"
+    )
+    _parser.add_argument(
+        "--watchdog", action="store_true",
+        help="以看门狗模式运行(节点巡检 + 自动重启循环由 startup 事件启动;"
+             "本进程即独立看门狗,该标志用于让 daemon 的调用意图显式化)",
+    )
+    _parser.add_argument(
+        "--port", type=int, default=_default_port,
+        help=f"HTTP 监听端口(默认 {_default_port})",
+    )
+    _parser.add_argument("--host", default="0.0.0.0", help="HTTP 监听地址(默认 0.0.0.0)")
+    _args = _parser.parse_args()
+
+    print(
+        f"🩺 Galaxy Health Monitor 独立启动 "
+        f"(watchdog={'on' if _args.watchdog else 'off'}, "
+        f"http://{_args.host}:{_args.port}) —— 主应用(:9000)已内置等价 /metrics"
+        f"、/api/v1/slo/metrics、/health/ready,本进程为可选独立看门狗/导出器。"
+    )
+    # 启动 Web 服务（监控循环通过 startup 事件自动启动）
+    uvicorn.run(app, host=_args.host, port=_args.port)

--- a/main.py
+++ b/main.py
@@ -441,8 +441,19 @@ def phase0_env_check() -> dict:
         print_item("Node.js 未安装", "warn")
     status["node_installed"] = node_ok
 
-    # Electron deps
-    electron_deps_ok = (ELECTRON_DIR / "node_modules").exists() if npm_ok else False
+    # Electron deps —— 判定"完整"而非仅"node_modules 目录存在"。
+    # 只看目录存在会漏掉【残缺安装】(npm install 中断:electron.cmd 存根在、但
+    # electron/cli.js 缺失),那样会跳过安装、直接拉起 electron 然后崩。用
+    # electron_package_intact 做完整性检查:缺失或残缺都判 False,让下面的
+    # `npm install`(正常下载)照跑并把缺的补齐——这就是"正常下载 + 缺失/残缺才补"。
+    if npm_ok:
+        try:
+            from core.electron_launch_guard import electron_package_intact
+            electron_deps_ok = electron_package_intact(str(ELECTRON_DIR))
+        except Exception:
+            electron_deps_ok = (ELECTRON_DIR / "node_modules").exists()
+    else:
+        electron_deps_ok = False
     status["electron_deps_ok"] = electron_deps_ok
 
     # Ollama
@@ -621,20 +632,29 @@ def phase2_ensure_deps(env_status: dict) -> bool:
                 if not node_installed:
                     print_item("Node.js 安装失败", "warn", "请手动安装: https://nodejs.org/")
 
-    # 2.4 Electron / npm deps
+    # 2.4 Electron / npm deps —— 正常下载 + 缺失/残缺自动补齐
+    #   electron_deps_ok 现在是【完整性】判定(见 check_environment):
+    #     - node_modules 不存在        → 全新正常下载(npm install)
+    #     - node_modules 在但 cli.js 缺 → 残缺,同样跑 npm install 把缺的补齐
+    #     - 完整                        → 跳过
+    #   npm install 本身是幂等的:该下的下、已在的跳过,既是"正常下载"也是"补齐"。
     npm_cmd = shutil.which("npm")
     if npm_cmd and not env_status.get("electron_deps_ok"):
-        print_item("正在安装 Electron 依赖...", "ok")
+        _node_modules_exists = (ELECTRON_DIR / "node_modules").exists()
+        if _node_modules_exists:
+            print_item("检测到 Electron 依赖残缺，正在补齐...", "ok")
+        else:
+            print_item("正在下载 Electron 依赖...", "ok")
         try:
             rc = sp.run(
                 [npm_cmd, "install"],
                 cwd=str(ELECTRON_DIR),
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=180,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=300,
             ).returncode
             if rc == 0:
-                print_item("Electron 依赖安装完成", "ok")
+                print_item("Electron 依赖就绪", "ok")
             else:
-                print_item("npm install 失败", "warn")
+                print_item("npm install 失败", "warn", "可手动进入 electron/ 跑 npm install")
         except Exception as exc:
             print_item(f"npm install 异常: {exc}", "warn")
 

--- a/tests/test_config_preflight.py
+++ b/tests/test_config_preflight.py
@@ -233,7 +233,8 @@ class TestPreflightReportFormat(unittest.TestCase):
         with patch.dict(os.environ, {"__GALAXY_FORMAT_OK__": "real-value"}, clear=False):
             report = run_preflight(dry_run=True, checks=checks, mode="all", verbose=False)
         text = report.format(verbose=False)
-        self.assertIn("✅", text)
+        # 符号已统一为 core.cli_render 的文本 ✓(不再用 emoji ✅,避免跨打印器对不齐)。
+        self.assertIn("✓", text)
 
 
 # ===========================================================================

--- a/tests/test_container_runtime_selection.py
+++ b/tests/test_container_runtime_selection.py
@@ -1,0 +1,60 @@
+"""tests/test_container_runtime_selection.py
+==============================================
+容器运行时(Docker / Podman)选择解析回归防护。
+
+resolve_runtime 优先级:环境 GALAXY_CONTAINER_RUNTIME > 已保存(.galaxy_runtime)
+> 单一已装 > (两者都装且交互)提示 > 都没装 → ""。非交互终端不阻塞。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core import container_runtime as cr
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    # 隔离持久化文件与环境,避免污染真实 .galaxy_runtime。
+    monkeypatch.setattr(cr, "_CHOICE_FILE", tmp_path / ".galaxy_runtime")
+    monkeypatch.delenv("GALAXY_CONTAINER_RUNTIME", raising=False)
+
+
+def test_env_var_wins_when_installed(monkeypatch):
+    monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/podman" if name == "podman" else None)
+    monkeypatch.setenv("GALAXY_CONTAINER_RUNTIME", "podman")
+    assert cr.resolve_runtime(interactive=False) == "podman"
+
+
+def test_single_installed_auto_selected_no_prompt(monkeypatch):
+    monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+    # interactive=True 但只装了一个 → 不应提示,直接用它
+    assert cr.resolve_runtime(interactive=True) == "docker"
+
+
+def test_none_installed_returns_empty(monkeypatch):
+    monkeypatch.setattr(cr.shutil, "which", lambda name: None)
+    assert cr.resolve_runtime(interactive=True) == ""
+
+
+def test_both_installed_noninteractive_defaults_to_docker_first(monkeypatch):
+    monkeypatch.setattr(cr.shutil, "which", lambda name: f"/usr/bin/{name}" if name in ("docker", "podman") else None)
+    # 非交互(interactive=False)→ avail[0]=docker(docker 优先),不阻塞
+    assert cr.resolve_runtime(interactive=False) == "docker"
+
+
+def test_saved_choice_used_when_no_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(cr.shutil, "which", lambda name: f"/usr/bin/{name}" if name in ("docker", "podman") else None)
+    (tmp_path / ".galaxy_runtime").write_text("podman", encoding="utf-8")
+    monkeypatch.setattr(cr, "_CHOICE_FILE", tmp_path / ".galaxy_runtime")
+    assert cr.resolve_runtime(interactive=False) == "podman"
+
+
+def test_compose_base_shape(monkeypatch):
+    # docker compose 子命令可用 → [docker, compose]
+    monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+
+    class _OK:
+        returncode = 0
+    monkeypatch.setattr(cr.subprocess, "run", lambda *a, **k: _OK())
+    assert cr.compose_base("docker") == ["/usr/bin/docker", "compose"]

--- a/tests/test_gateway_mounted_lifespan_503.py
+++ b/tests/test_gateway_mounted_lifespan_503.py
@@ -1,0 +1,102 @@
+"""tests/test_gateway_mounted_lifespan_503.py
+================================================
+回归防护:被主 app 挂载(app.mount("/gateway", gateway_app))时,Gateway 的
+必需核心服务必须就绪,/gateway/* 不再恒返回 503。
+
+背景
+----
+Starlette 不会为【被挂载的子应用】运行其 lifespan;而 galaxy_gateway 的 lifespan
+负责创建 device/message/websocket/task 四个服务并写入 gateway_app.state。主 app
+又是命令式启动、没有自己的 lifespan(unified_launcher 的 FastAPI(...) 无 lifespan
+参数),于是子应用 lifespan 永不触发 → gateway_app.state.X 恒为 None →
+galaxy_gateway.dependencies._get_state 对这四个 required 依赖抛 HTTP 503
+"Service not ready" → 真机上 /gateway/* 全部 503。
+
+修复(core/startup.py 挂载后调用 lifecycle.init_gateway_core_services):只补齐
+这四个【必需】服务(可选服务缺失时 dependencies 返回 None、不 503),刻意不跑完整
+lifespan(避免 NATS/TCP/UDP 监听/AIPTransport 与主 app 双绑端口/重复注册)。
+
+本测试锁住:init 前 required 依赖抛 503;init 后四个依赖都能取到实例;可选依赖
+(nats_adapter 等)在只跑 core 服务时仍安全返回 None(不 503)。
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+
+class _Req:
+    """最小请求替身:dependencies 只读 request.app.state。"""
+    def __init__(self, app):
+        self.app = app
+
+
+@pytest.mark.asyncio
+async def test_required_deps_503_before_init_and_resolve_after():
+    from galaxy_gateway.app import app as gw
+    from galaxy_gateway.bootstrap.lifecycle import init_gateway_core_services
+    from galaxy_gateway.dependencies import (
+        get_device_manager,
+        get_message_handler,
+        get_websocket_manager,
+        get_task_orchestrator,
+        get_nats_adapter,
+    )
+
+    # 用一个干净的 state,确保"init 前"确实是未就绪态(其它测试可能已 init 过全局 app)。
+    from starlette.datastructures import State
+    gw.state = State()
+    req = _Req(gw)
+
+    # BEFORE：required 依赖必须 503。
+    for getter in (get_device_manager, get_message_handler,
+                   get_websocket_manager, get_task_orchestrator):
+        with pytest.raises(HTTPException) as ei:
+            getter(req)
+        assert ei.value.status_code == 503, f"{getter.__name__} 未按预期 503"
+
+    # INIT：只补必需核心服务。
+    dm, mh, wsm, to = await init_gateway_core_services(gw)
+    try:
+        # AFTER：四个 required 依赖都应取到实例,不再 503。
+        assert get_device_manager(req) is dm
+        assert get_message_handler(req) is mh
+        assert get_websocket_manager(req) is wsm
+        assert get_task_orchestrator(req) is to
+        assert type(dm).__name__ == "DeviceManager"
+        assert type(wsm).__name__ == "WebSocketManager"
+        assert type(to).__name__ == "TaskOrchestrator"
+
+        # 可选依赖:只跑 core 服务时未设置 → dependencies 应安全返回 None(绝不 503)。
+        assert get_nats_adapter(req) is None
+    finally:
+        # 干净收尾(与 core/startup 的 shutdown 钩子一致)。
+        import contextlib
+        with contextlib.suppress(Exception):
+            await to.stop()
+        with contextlib.suppress(Exception):
+            await wsm.stop()
+
+
+@pytest.mark.asyncio
+async def test_init_also_updates_legacy_module_globals():
+    """旧 import 路径(from galaxy_gateway.app import websocket_manager)也要被填上。"""
+    from galaxy_gateway.app import app as gw
+    from galaxy_gateway.bootstrap.lifecycle import init_gateway_core_services
+    import galaxy_gateway.app as gw_app
+
+    from starlette.datastructures import State
+    gw.state = State()
+
+    dm, mh, wsm, to = await init_gateway_core_services(gw)
+    try:
+        assert gw_app.device_manager is dm
+        assert gw_app.websocket_manager is wsm
+        assert gw_app.task_orchestrator is to
+    finally:
+        import contextlib
+        with contextlib.suppress(Exception):
+            await to.stop()
+        with contextlib.suppress(Exception):
+            await wsm.stop()

--- a/tests/test_rate_limit_single_layer.py
+++ b/tests/test_rate_limit_single_layer.py
@@ -1,0 +1,63 @@
+"""tests/test_rate_limit_single_layer.py
+==========================================
+回归防护:HTTP 限流【单层收口】—— 主 app 不再叠加两个独立限流器。
+
+背景
+----
+主 app 曾同时安装两个 HTTP 速率限制中间件:
+  1. core.performance.RateLimitMiddleware —— core/startup.py 步骤 3
+     (apikey-or-ip 分桶、可配置、回环豁免)。权威层。
+  2. core.security_middleware 的 RateLimitMiddleware —— SecurityManager.setup_middleware
+     经 create_rate_limit_middleware 安装(按 IP、120rpm)。
+
+两者挂在同一个 app 上 → 同一条 HTTP 请求被两个独立限流器双重计数,阈值/分桶键
+还不一致(更严的静默生效)。这是意外重复,非有意分层。
+
+修复:SecurityManager.setup_middleware 增加 include_rate_limit 开关;主 app 挂载时
+传 False,把 HTTP 限流收口到性能层唯一一处。SecurityManager 单独使用(无性能层)时
+默认仍自带限流。
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from core.security_middleware import SecurityManager
+
+
+def test_setup_middleware_can_omit_rate_limit_layer():
+    """include_rate_limit=False 时,应恰好少装一个中间件(那一层限流)。"""
+    with_rl = FastAPI()
+    SecurityManager().setup_middleware(with_rl, include_rate_limit=True)
+
+    without_rl = FastAPI()
+    SecurityManager().setup_middleware(without_rl, include_rate_limit=False)
+
+    delta = len(with_rl.user_middleware) - len(without_rl.user_middleware)
+    assert delta == 1, (
+        f"include_rate_limit 应恰好切换一个限流中间件,实际差 {delta} 个"
+    )
+
+
+def test_default_still_includes_rate_limit_for_standalone_use():
+    """默认(不传参)保持含限流——SecurityManager 单独用时不丢保护。"""
+    default_app = FastAPI()
+    SecurityManager().setup_middleware(default_app)
+
+    explicit_off = FastAPI()
+    SecurityManager().setup_middleware(explicit_off, include_rate_limit=False)
+
+    assert len(default_app.user_middleware) == len(explicit_off.user_middleware) + 1
+
+
+def test_startup_wires_security_without_its_own_rate_limit():
+    """core/startup.py 必须以 include_rate_limit=False 调 setup_middleware,
+    确保 HTTP 限流只由性能层承担(源码级断言,避免有人日后又叠回去)。"""
+    import inspect
+    import core.startup as startup
+
+    src = inspect.getsource(startup)
+    assert "include_rate_limit=False" in src, (
+        "core/startup.py 应以 include_rate_limit=False 安装安全中间件,"
+        "把 HTTP 限流收口到性能层唯一一处"
+    )

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -742,44 +742,41 @@ class GalaxyUnified:
         if flag in ("0", "false", "no", "off"):
             return ("warn", "已禁用 (GALAXY_AUTO_DOCKER=0)", "")
 
-        docker = shutil.which("docker")
-        if not docker:
-            return ("warn", "未安装 — 依赖基础设施的节点将跳过（不影响桌面）",
-                    "启用全部节点：装 Docker 后重跑 — https://docs.docker.com/get-docker/")
+        # 选择容器运行时:Docker 或 Podman(两者都装时首启会让你选,单一已装直接用,
+        # 都没装则跳过)。选择结果持久化到 .galaxy_runtime,并驱动后台【静默拉取】。
+        from core import container_runtime as cr
+        runtime = await asyncio.to_thread(cr.resolve_runtime, True)
+        if not runtime:
+            return ("warn", "未安装 Docker/Podman — 依赖基础设施的节点将跳过（不影响桌面）",
+                    "启用全部节点：装 Docker 或 Podman 后重跑 — "
+                    "https://docs.docker.com/get-docker/ 或 https://podman.io/get-started")
+        rt_bin = cr.runtime_binary(runtime)
+        rt_name = cr.display_name(runtime)
 
         compose_file = PROJECT_ROOT / "docker-compose.yml"
         if not compose_file.exists():
-            return ("warn", "docker-compose.yml 缺失 — 跳过 Docker 基础设施", "")
+            return ("warn", f"docker-compose.yml 缺失 — 跳过 {rt_name} 基础设施", "")
 
         # 仅基础设施后端；排除 galaxy/galaxy-gateway(应用本身) 与 ollama(避免与本地 Ollama 冲突)。
         services = ["nats", "redis", "qdrant", "neo4j", "mongodb"]
 
-        def _run(cmd, timeout=None):
-            return sp.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout)
-
         def _daemon_up() -> bool:
-            try:
-                return _run([docker, "info"], timeout=15).returncode == 0
-            except Exception:
-                return False
+            return cr.daemon_up(runtime)
 
         def _compose_base():
-            try:
-                if _run([docker, "compose", "version"], timeout=15).returncode == 0:
-                    return [docker, "compose"]
-            except Exception:
-                pass
-            dc = shutil.which("docker-compose")
-            return [dc] if dc else None
+            return cr.compose_base(runtime)
 
         def _bring_up():
             if not _daemon_up():
-                _try_start_docker_daemon(docker)
-                deadline = _time.time() + float(os.environ.get("GALAXY_AUTO_DOCKER_DAEMON_WAIT", "60"))
-                while _time.time() < deadline:
-                    if _daemon_up():
-                        break
-                    _time.sleep(3)
+                # Podman 无守护进程(rootless),info 不通多半是配置问题,不尝试"启动守护";
+                # 仅 Docker 尝试拉起 Docker Desktop/daemon 并轮询等待。
+                if runtime == "docker":
+                    _try_start_docker_daemon(rt_bin)
+                    deadline = _time.time() + float(os.environ.get("GALAXY_AUTO_DOCKER_DAEMON_WAIT", "60"))
+                    while _time.time() < deadline:
+                        if _daemon_up():
+                            break
+                        _time.sleep(3)
                 if not _daemon_up():
                     return ("daemon_down", None)
             base = _compose_base()
@@ -801,15 +798,18 @@ class GalaxyUnified:
 
         status, rc = await asyncio.to_thread(_bring_up)
         if status == "up" and rc == 0:
-            return ("ok", "nats / redis / qdrant / neo4j / mongodb 已就绪", "")
+            return ("ok", f"nats / redis / qdrant / neo4j / mongodb 已就绪 · via {rt_name}", "")
         if status == "pulling":
-            return ("warn", "首次镜像下载中（后台）",
+            return ("warn", f"首次镜像下载中（{rt_name} 后台静默拉取）",
                     "进度见 logs/docker.log；本轮先跳过依赖节点，下次启动即生效")
         if status == "daemon_down":
-            return ("warn", "守护未能自动启动 — 手动启动 Docker Desktop 后重跑", "")
+            _hint = ("手动启动 Docker Desktop 后重跑" if runtime == "docker"
+                     else "Podman 引擎/machine 未就绪 — 试 `podman machine start` 后重跑")
+            return ("warn", f"{rt_name} 未就绪 — {_hint}", "")
         if status == "no_compose":
-            return ("warn", "未找到 docker compose 命令 — 跳过", "")
-        return ("warn", f"启动异常 (rc={rc})，详情见 logs/docker.log", "")
+            return ("warn", f"未找到 {runtime} compose 命令 — 跳过 "
+                            f"(装 {runtime}-compose 或启用 compose 插件)", "")
+        return ("warn", f"{rt_name} 启动异常 (rc={rc})，详情见 logs/docker.log", "")
 
     async def start_electron(self) -> bool:
         """启动 Electron 桌面三态覆盖层。"""
@@ -1243,17 +1243,20 @@ class GalaxyUnified:
             _emit("核心服务", "启动失败", "fail")
             logger.error(f"Core services: {exc}")
 
-        # ── 基础设施 (Docker，自动拉起；依赖它的节点才能起来) ──
+        # ── 基础设施 (Docker / Podman，自动拉起；依赖它的节点才能起来) ──
         try:
             d_status, d_value, d_note = await self.ensure_docker_infra()
         except Exception as exc:
             d_status, d_value, d_note = "warn", "基础设施启动异常（非致命）", ""
             logger.warning("ensure_docker_infra failed: %s", exc)
-        d_details = [("Docker 基础设施", d_value, d_status)]
+        # 标签反映实际选中的运行时(Docker / Podman);resolve_runtime 已把选择写入
+        # GALAXY_CONTAINER_RUNTIME,未选到则统一显示 "容器"。
+        _rt = os.environ.get("GALAXY_CONTAINER_RUNTIME", "").strip().capitalize() or "容器"
+        d_details = [(f"{_rt} 基础设施", d_value, d_status)]
         if d_note:
             d_details.append(("下一步", d_note, "info"))
-        _emit("基础设施 · Docker", d_value, d_status, details=d_details,
-              hint="装后重跑即恢复" if d_status != "ok" else None)
+        _emit(f"基础设施 · {_rt}", d_value, d_status, details=d_details,
+              hint="装 Docker/Podman 后重跑即恢复" if d_status != "ok" else None)
 
         # ── 消息总线 ──
         bus_details: List[Tuple[str, str, str]] = []


### PR DESCRIPTION
## Summary

两批改动:**v2 结构三项** + **真机启动 UX 六项**,均逐一查清证据、修复、加回归测试(沙箱可验证)。

## A. v2 结构项

1. **`/gateway/*` 恒 503**:挂载子应用的 lifespan 不被 Starlette 运行、主 app 又无 lifespan → 四个必需服务恒 None → `dependencies` 抛 503。抽 `init_gateway_core_services` 只补必需四项(不跑完整 lifespan,避免双绑端口/重复注册)。`tests/test_gateway_mounted_lifespan_503.py`。
2. **双层限流叠加**:性能层 + 安全层两个独立 HTTP 限流器挂同一 app、双重计数。安全层加 `include_rate_limit` 开关,主 app 传 False,收口到性能层唯一一处。`tests/test_rate_limit_single_layer.py`。
3. **health_monitor 隐藏入口**:是独立看门狗进程,主 app 已内置等价 `/metrics`+SLO+`/health/ready`,不该塞进主启动;修 daemon 的 `--watchdog` 被静默丢弃。

## B. 真机启动 UX(依据启动日志逐条)

4. **对勾没对齐成一列**:`cli_render`(文本 ✓/⚠/✗,1 格)与 `ascii_art`(emoji ✅/▶,2 格+双空格)两套打印器图标宽度不一 → 标签列错位。统一 `ascii_art` 为 1 格文本符号 + 单空格 + label_width 22,两套打印器标签一律第 4 列(含灰色"模型已就绪")。断言 index 4 对齐。
5. **Ollama 模型选择不见了(MiniCPM 4.5 + 三 Gemma)**:清单一直在 `core.model_selection`,但 `.env.example` 写死 `OLLAMA_MODEL=gemma4:latest` → 生成的 `.env` 每次让 `resolve_main_brain` 走"env 已指定"分支【跳过交互选择】。改 `.env.example` 的 `OLLAMA_MODEL` 留空(附候选说明),首启即在「AI 大脑」交互选择;显式填 tag 仍跳过。
6. **Ollama 拉不了 / 加载失败**:根因之一是 5(被 `gemma4:latest` 顶掉、且它不在候选里);拉取路径本身(`background_pull`:/api/tags→/api/show 核实→pull→HF 回退→版本指引)完好。另,后端选择在 Ollama 冷启动探测超时时误跌 transformers 的 bug 已在前序 PR 修复。
7. **Electron 正常下载没了**:`electron_deps_ok` 只判 `node_modules` 目录存在 → 残缺安装(cli.js 缺失)被当"已就绪"跳过 → 起 electron 崩。改用 `electron_package_intact` 完整性判定:缺失=下载、残缺=补齐、完整=跳过(npm install 幂等,既正常下载也补齐)。
8. **Docker/Podman 选择 + 节点基础设施后台静默拉取**:新增 `core/container_runtime.py`(检测→两者都装时交互选择→持久化→统一 CLI 抽象);`ensure_docker_infra` 泛化为运行时无关(Podman 无守护故不尝试启动守护),首次镜像后台静默拉取,状态标签随所选运行时显示。`tests/test_container_runtime_selection.py`。

## Test plan
- [x] 新增/相关测试全绿:gateway 503(2)、限流单层(3)、容器运行时(6)、config_preflight(44)、结构测试(32)
- [x] main/unified_launcher/model_selection/container_runtime/ascii_art 导入 + 语法校验
- [x] 两套打印器标签列对齐 index 4;模型清单含 MiniCPM 4.5 + 三 Gemma
- [ ] 真机复跑确认:对勾对齐、模型选择弹出并可拉取、Electron 补齐、Docker/Podman 选择(需你本地验证)

## 说明
本仓 CI 为已知基建问题(所有 check 3 秒内空日志失败,跨多 PR 一致,与 diff 无关)。客户端 Kotlin 收敛(#22)仍需在 Android/WearOS 仓用 Gradle 构建验证,不在本 PR;lumiv 死岛清理见 ufo-galaxy-android#504。

🤖 Generated with [Claude Code](https://claude.com/claude-code)