### PR TITLE
启动修复合集:gateway崩溃 + 对勾对齐 + Ollama常驻 + Docker/Podman选择 + 空URL加固

### DIFF
--- a/core/api_manager.py
+++ b/core/api_manager.py
@@ -551,11 +551,18 @@ class APIManager:
         
         if not model_config or not model_config.api_key:
             return {"success": False, "error": "Model not configured"}
-        
+
+        # base_url 为空/缺 scheme 时,f"{base_url}/chat/completions" 会变成
+        # "/chat/completions" → httpx 抛 "Request URL is missing an 'http://'…"。
+        # .env 半配置(base_url 空)时这是常见来源。这里直接判为未配置,不发请求。
+        _bu = (model_config.base_url or "").strip()
+        if "://" not in _bu:
+            return {"success": False, "error": "Model base_url not configured (missing scheme)"}
+
         try:
             async with httpx.AsyncClient(timeout=60.0) as client:
                 response = await client.post(
-                    f"{model_config.base_url}/chat/completions",
+                    f"{_bu.rstrip('/')}/chat/completions",
                     headers={
                         "Authorization": f"Bearer {model_config.api_key}",
                         "Content-Type": "application/json"

--- a/core/container_runtime.py
+++ b/core/container_runtime.py
@@ -122,10 +122,64 @@ def interactive_select(avail: List[str]) -> str:
         print("  " + _c("⚠ 无效输入，请重新选择（或直接回车用默认）。", Colors.YELLOW))
 
 
-def resolve_runtime(interactive: bool = True) -> str:
-    """解析并持久化最终容器运行时。返回运行时名("" = 无可用运行时,跳过)。
+_INSTALL_HINTS: Dict[str, str] = {
+    "docker": "https://docs.docker.com/get-docker/ (Windows 装 Docker Desktop)",
+    "podman": "https://podman.io/get-started (Windows: winget install RedHat.Podman)",
+}
 
-    环境 > 已保存 > 单一已装 > (两者都装且交互)提示 > 都没装 → ""。
+
+def interactive_install_guide() -> str:
+    """两者都【未安装】且交互时:仍展示选择菜单,让用户选定偏好运行时并给出安装指引。
+
+    容器运行时的二进制需系统级安装(需管理员/重启,无法静默拉取),故这里不"下载",
+    而是【选偏好 + 给安装链接】,并把选择持久化——装好后下次启动即自动采用、后台静默
+    拉取节点镜像。非交互终端直接返回 "" 不打扰。返回持久化的偏好名(仍 "" 表示当前不可用)。
+    """
+    if not (sys.stdin and sys.stdin.isatty()):
+        return ""
+    from core import cli_render as r
+    from core.ascii_art import Colors
+
+    def _c(t, color):
+        return f"{color}{t}{Colors.ENDC}" if r._use_color() else t
+
+    print()
+    print("  " + _c("选择容器运行时", Colors.BOLD + Colors.CYAN)
+          + _c("  (节点基础设施需要;两者都未检测到,先选一个偏好并安装)", Colors.DIM))
+    r.rule()
+    for i, rt in enumerate(_RUNTIMES, 1):
+        marker = _c("▸", Colors.GREEN) if i == 1 else " "
+        num = _c(f"[{i}]", Colors.BOLD if i == 1 else Colors.DIM)
+        name = r.pad_display(rt.capitalize(), 10)
+        tail = _c("  ← 默认", Colors.GREEN) if i == 1 else ""
+        print(f"  {marker} {num} {name}{tail}")
+        print(f"         {_c(_LABELS.get(rt, ''), Colors.DIM)}")
+        print(f"         {_c('安装: ' + _INSTALL_HINTS.get(rt, ''), Colors.DIM)}")
+    r.rule()
+    print("  " + _c("回车=记住默认(Docker) · 数字=记住偏好 · s=跳过(桌面照常运行)", Colors.DIM))
+    try:
+        choice = input(f"  选择偏好运行时 [1-{len(_RUNTIMES)} / 回车 / s]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return ""
+    if choice == "s":
+        return ""
+    pick = _RUNTIMES[0]
+    if choice.isdigit() and 1 <= int(choice) <= len(_RUNTIMES):
+        pick = _RUNTIMES[int(choice) - 1]
+    elif choice in _RUNTIMES:
+        pick = choice
+    save_choice(pick)  # 记住偏好;装好后下次即自动采用
+    print("  " + _c(f"已记住偏好: {pick.capitalize()} —— 安装后重跑即自动使用并后台拉取节点镜像。",
+                    Colors.GREEN))
+    print("  " + _c(f"  安装: {_INSTALL_HINTS.get(pick, '')}", Colors.DIM))
+    return ""  # 当前仍不可用(未安装),但偏好已持久化
+
+
+def resolve_runtime(interactive: bool = True) -> str:
+    """解析并持久化最终容器运行时。返回运行时名("" = 当前无可用运行时)。
+
+    环境 > 已保存(且已装) > 单一已装 > (两者都装且交互)提示 > 都没装:交互则展示
+    选择+安装指引菜单(记住偏好、返回 ""),非交互则返回 ""。
     """
     env = _env_choice()
     if env in _RUNTIMES and shutil.which(env):
@@ -139,6 +193,9 @@ def resolve_runtime(interactive: bool = True) -> str:
 
     avail = available_runtimes()
     if not avail:
+        # 都没装:交互时也【给出选择菜单 + 安装指引】(而不是静默跳过),记住偏好。
+        if interactive:
+            return interactive_install_guide()
         return ""
     if len(avail) == 1:
         save_choice(avail[0])

--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -672,22 +672,44 @@ class LocalBrainManager:
             return False
 
     async def _start_ollama(self) -> bool:
-        """尝试启动 Ollama 服务"""
+        """把 Ollama 作为【常驻服务】拉起(ollama serve 必须一直在,模型才能加载)。
+
+        真机复现的两个坑,这里一并修:
+        1) 之前 stdout/stderr=PIPE 且【没有任何人读取】——ollama serve 会持续往
+           stderr 写日志,OS 管道缓冲(约 64KB)填满后写操作阻塞,serve 主循环被
+           卡住 → 表现为"Ollama 已安装,但服务在等待窗口内未响应"。改为把输出重定向
+           到日志文件(logs/ollama.log),彻底避免管道回压。
+        2) start_new_session 是 POSIX 专有,Windows 上不生效、进程会绑到当前控制台,
+           父进程/控制台一退,serve 跟着被杀,不"常驻"。Windows 改用
+           DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP 真正脱离控制台常驻。
+        """
         try:
-            # 检查 ollama 命令是否存在
             ollama_cmd = shutil.which("ollama")
             if not ollama_cmd:
                 logger.warning("ollama 命令未找到，请安装 Ollama")
                 return False
 
-            # 后台启动 ollama serve
-            subprocess.Popen(
-                [ollama_cmd, "serve"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                start_new_session=True,
-            )
-            logger.info("Ollama 服务已启动")
+            import os as _os
+            from pathlib import Path as _Path
+            _log_dir = _Path("logs")
+            try:
+                _log_dir.mkdir(exist_ok=True)
+                _out = open(_log_dir / "ollama.log", "ab")
+            except Exception:
+                _out = subprocess.DEVNULL  # 连日志都开不了也不能用 PIPE
+
+            _popen_kwargs = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL)
+            if sys.platform == "win32":
+                # 脱离父控制台常驻(避免父进程/终端退出时被连带杀掉)。
+                _flags = 0
+                _flags |= getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+                _flags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+                _popen_kwargs["creationflags"] = _flags
+            else:
+                _popen_kwargs["start_new_session"] = True
+
+            subprocess.Popen([ollama_cmd, "serve"], **_popen_kwargs)
+            logger.info("Ollama 服务已作为常驻进程启动(日志: logs/ollama.log)")
             return True
 
         except Exception as e:

--- a/core/model_selection.py
+++ b/core/model_selection.py
@@ -271,7 +271,7 @@ def background_pull(tag: str) -> None:
                           f"(status={show_r.status_code})——当作未安装，重新拉取。")
                 except Exception as exc:
                     print(f"  ⚠ Ollama 列表里有 {matched}，但核实可用性失败({exc})——当作未安装，重新拉取。")
-            print(f"  ▶  正在后台拉取本地主脑模型 ollama pull {tag} …(不阻塞启动)")
+            print(f"  ▶ 正在后台拉取本地主脑模型 ollama pull {tag} …(不阻塞启动)")
             proc = subprocess.run(["ollama", "pull", tag], capture_output=True, text=True,
                                   encoding="utf-8", errors="replace", timeout=3600)
             if proc.returncode == 0:

--- a/core/startup.py
+++ b/core/startup.py
@@ -838,14 +838,29 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
                 _gw_dm, _gw_mh, _gw_wsm, _gw_to,
             ) = await init_gateway_core_services(gateway_app)
 
-            async def _shutdown_gateway_core() -> None:
-                import contextlib as _ctx
-                with _ctx.suppress(Exception):
-                    await _gw_to.stop()
-                with _ctx.suppress(Exception):
-                    await _gw_wsm.stop()
+            # 到这里【必需核心服务已就绪、/gateway/* 已不再 503】——这才是本修复的实质。
+            # 下面注册进程退出时的清理钩子只是【尽力而为】:不同 Starlette/FastAPI 版本
+            # 注册 shutdown 的接口不一(部分版本 app.add_event_handler 已被移除,只有
+            # app.router.on_shutdown),真机上就因 'FastAPI' object has no attribute
+            # 'add_event_handler' 抛错,把明明已修好的网关误报成 degraded。故把钩子注册
+            # 单独 try 掉,任何失败都不得回退核心服务"已就绪"的结论。
+            def _register_gateway_shutdown() -> None:
+                async def _shutdown_gateway_core() -> None:
+                    import contextlib as _ctx
+                    with _ctx.suppress(Exception):
+                        await _gw_to.stop()
+                    with _ctx.suppress(Exception):
+                        await _gw_wsm.stop()
+                if hasattr(app, "add_event_handler"):
+                    app.add_event_handler("shutdown", _shutdown_gateway_core)
+                elif hasattr(getattr(app, "router", None), "on_shutdown"):
+                    app.router.on_shutdown.append(_shutdown_gateway_core)
 
-            app.add_event_handler("shutdown", _shutdown_gateway_core)
+            try:
+                _register_gateway_shutdown()
+            except Exception as _she:  # noqa: BLE001
+                logger.debug("gateway shutdown 钩子注册跳过(非致命,不影响 /gateway/* 已就绪): %s", _she)
+
             results["galaxy_gateway"] = {"status": "ok", "core_services": "started"}
             logger.info(
                 "Galaxy Gateway 已挂载到 /gateway(必需核心服务已就绪,/gateway/* 不再 503)"

--- a/main.py
+++ b/main.py
@@ -173,7 +173,10 @@ def print_item(name: str, status: str = "ok", detail: str = "") -> None:
     printed = False
     try:
         from core import cli_render as r
-        r.detail(name, detail, _status_map.get(status, "info"))
+        # 用 phase()(2 格缩进,标签第 4 列)而非 detail()(6 格缩进)——让 Phase 0/1/2
+        # 的状态项与「系统启动」后的运行时项(核心服务/基础设施/... 也走 phase)以及
+        # ▶ 启动行处在【同一列】。此前 Phase 段 6 格、运行时段 2 格,对勾对不齐。
+        r.phase(name, detail, _status_map.get(status, "info"))
         printed = True
     except Exception:
         printed = False


### PR DESCRIPTION
## Summary

真机复跑克隆界面后的修复合集(两个提交)。

### 提交 1:gateway `add_event_handler` 崩溃 + 对勾全局对齐
- **`'FastAPI' object has no attribute 'add_event_handler'`**:gateway 503 修复里注册 shutdown 钩子用的 API 在你的 Starlette/FastAPI 版本已移除 → 抛错把【已就绪】的网关误报 degraded(核心服务初始化在抛错前已完成)。改:钩子注册单独 try + 能力探测(`add_event_handler` → 否则 `router.on_shutdown`),失败不回退"已就绪"。
- **对勾没对齐成一列**:Phase 0/1/2 项(`print_item→detail`,6 格)与运行时项(`_emit→phase`,2 格)错开。改 `print_item` 用 `phase`,**Phase 项 / 运行时项 / `▶` 行标签全部第 4 列**。逐一枚举所有打印器路径(含两套 `print_status` 都转发到同一 `print_status_row`)验证。菜单/警告子说明**故意**保留层次缩进。

### 提交 2:Ollama 常驻 + Docker/Podman 选择 + 空URL加固
- **Ollama"模型加载不出来"** —— 根因是 serve 没常驻:`_start_ollama` 用 `PIPE` 且无人读取 → OS 管道缓冲填满**阻塞 `ollama serve`** → "服务在等待窗口内未响应";`start_new_session` 是 POSIX 专有,Windows 不生效、serve 绑控制台随父进程被杀。改:输出重定向到 `logs/ollama.log`;Windows 用 `DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP` 真正脱离控制台常驻。
- **Docker/Podman 都没装也给选择**:交互时弹出选择菜单(带各自安装链接),选定偏好并持久化——装好后下次自动采用、后台静默拉取节点镜像;非交互不打扰。
- **空 `base_url` → "Request URL missing http://"**:`api_manager._call_model` 在 base_url 空/缺 scheme 时判未配置、不发请求(消除该类告警一个明确来源)。

### 关于"替换 Ollama"的调研结论(你让我搜的)
- **vllama**(erkkimon/vllama)= Ollama 管理 + vLLM 推理的混合服务,但**面向 GPU + 推荐跑在 Docker 里**;**vLLM 本身是 GPU 生产级引擎**。你这台**纯 CPU 无独显**,上 vLLM/vllama 反而更重更不易用。
- **CPU 机的正解**:① Ollama 作**常驻服务**(本 PR 已修 serve 常驻);② 或用**内嵌 `llama-cpp-python`**(进程内推理、**根本不需要单独的常驻服务**)——仓库已有 `llama_cpp` 后端骨架。若你想彻底不依赖 `ollama serve`,我可以把默认后端切到内嵌 llama.cpp(需要 GGUF 模型)。

## Test plan
- [x] 对齐:三类打印器标签全部第 4 列(断言)
- [x] gateway 503 回归 2 项、container_runtime 6 项全绿
- [x] 全部改动文件语法/导入校验
- [ ] 真机复跑:gateway 不再报 degraded、Ollama serve 常驻后模型加载、Docker/Podman 选择弹出(需你本地验证)

## 仍待定位(非致命)
启动期另一处 `Exception suppressed: Request URL is missing…` 属某节点 URL 消费方,需真机进一步定位(已 suppressed,不影响功能)。

## 说明
本仓 CI 为已知基建问题(所有 check 3 秒内空日志失败,与 diff 无关)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)