### PR TITLE
fix: OLLAMA_URL 空字符串传播导致 Ollama 连接静默失败

### DIFF
--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -126,7 +126,14 @@ class LocalBrainManager:
         """
         self.backend_name = backend
         self._backend = None  # LocalModelBackend instance
-        self.ollama_url = ollama_url or os.environ.get("OLLAMA_URL", self.OLLAMA_DEFAULT_URL)
+        # 修复: os.environ.get("OLLAMA_URL", DEFAULT) 在 key 存在但值为空字符串时
+        # 返回 "" 而非 DEFAULT —— 空字符串是 falsy，or 链断裂，self.ollama_url 变成 ""。
+        # 这会导致 _ping_ollama()/_refresh_model_list()/_pull_model()/_warm_up_ollama_model()
+        # 全部使用相对 URL (如 '/api/tags')，httpx 抛 InvalidURL，Ollama 被静默标记不可用。
+        # 改为先取 env 值、strip 后判断，空值才走 DEFAULT —— 与 _warm_up_ollama_model() 中
+        # 已有的 (self.ollama_url or DEFAULT) 兜底保持一致。
+        _env_ollama_url = os.environ.get("OLLAMA_URL", "")
+        self.ollama_url = ollama_url or (_env_ollama_url.strip() if _env_ollama_url.strip() else self.OLLAMA_DEFAULT_URL)
         self.available_models: List[str] = []
         # 主脑模型：优先用启动时选定的 OLLAMA_MODEL（见 core.model_selection / Phase 5），
         # 未选时回退 Gemma 4 12B —— 让"第 5 步选的主脑"真正驱动本地大脑加载。
@@ -405,7 +412,7 @@ class LocalBrainManager:
         # 对着一台明明已经装了 Ollama、只是服务启动慢的机器打印"not found"
         # 并尝试"自动安装"，白白浪费时间还产生误导性日志。命令已存在时，
         # 真实问题是"服务没起来"，不是"没装"，应该直接进入下面的失败分支，
-        # 给出准确、可操作的提示，而不是去下载一个本来就不需要的安装包。
+        # 给出准确、可操作的提示，而不是去下载一个根本就不需要的安装包。
         if not ollama_cmd_found:
             logger.info("未检测到 ollama 命令，尝试自动安装...")
             installed = await self._auto_install_ollama()

--- a/core/model_selection.py
+++ b/core/model_selection.py
@@ -243,7 +243,12 @@ def background_pull(tag: str) -> None:
     def _pull() -> None:
         try:
             import httpx
-            base = os.environ.get("OLLAMA_URL", "http://localhost:11434").rstrip("/")
+            # 修复: os.environ.get("OLLAMA_URL", DEFAULT) 在 key 存在但值为空字符串时
+            # 返回 "" 而非 DEFAULT —— httpx 随后尝试用相对 URL (如 '/api/tags') 请求，
+            # 抛 InvalidURL。改为先取 env 值、strip 后判断，空值才走 DEFAULT，
+            # 与 local_brain_manager 中的修复保持一致。
+            _env_ollama_url = os.environ.get("OLLAMA_URL", "")
+            base = (_env_ollama_url.strip() or "http://localhost:11434").rstrip("/")
             have: List[str] = []
             try:
                 r = httpx.get(f"{base}/api/tags", timeout=3.0)


### PR DESCRIPTION
## 问题

当 `os.environ["OLLAMA_URL"]` 存在但值为空字符串 `""` 时，`os.environ.get("OLLAMA_URL", DEFAULT)` 返回 `""` 而非 `DEFAULT`。空字符串是 falsy，但 `or` 链在遇到它时断裂，导致 `self.ollama_url = ""`。

这会毒化所有下游 URL 构造：
- `_ping_ollama()`: `""/api/tags"` → `httpx.InvalidURL`
- `_refresh_model_list()`: `""/api/tags"` → 同上
- `_pull_model()`: `""/api/pull"` → 同上
- `_warm_up_ollama_model()`: `""/api/generate"` → 同上

触发条件：Dashboard `setConfig` 直接写 `os.environ` 时写入空值、或手动 `export OLLAMA_URL=""`、或非 `main.py` 入口启动。

## 修复

**`core/local_brain_manager.py`** (line 263):
```python
# Before (buggy)
self.ollama_url = ollama_url or os.environ.get("OLLAMA_URL", self.OLLAMA_DEFAULT_URL)

# After (fixed)
_env_ollama_url = os.environ.get("OLLAMA_URL", "")
self.ollama_url = ollama_url or (_env_ollama_url.strip() if _env_ollama_url.strip() else self.OLLAMA_DEFAULT_URL)
```

**`core/model_selection.py`** (`background_pull()`):
```python
# Before (buggy)
base = os.environ.get("OLLAMA_URL", "http://localhost:11434").rstrip("/")

# After (fixed)
_env_ollama_url = os.environ.get("OLLAMA_URL", "")
base = (_env_ollama_url.strip() or "http://localhost:11434").rstrip("/")
```

两处修复对齐了 `_warm_up_ollama_model()` 中已有的正确模式 `(self.ollama_url or DEFAULT)`。

## 验证

- `self.brain_model` 的赋值（`os.environ.get("OLLAMA_MODEL", "").strip() or "gemma4:12b"`）已经是正确写法，不受影响
- `_discover_providers()` 有默认地址探测兜底，不受影响
- `_warm_up_ollama_model()` 已有 `(self.ollama_url or DEFAULT)` 兜底，不受影响

## 改动范围

仅 2 个文件，各改 1 行核心逻辑 + 注释说明。无 API 变更、无行为变更（仅在空字符串 edge case 下从"错误"变为"正确"）。