### PR TITLE
fix: stale AI 大脑 summary status after Ollama race fix

### DIFF
--- a/tests/test_ai_brain_status_recheck.py
+++ b/tests/test_ai_brain_status_recheck.py
@@ -1,0 +1,98 @@
+"""tests/test_ai_brain_status_recheck.py
+==========================================
+
+The "AI 大脑" summary-card entry was computed once, immediately after
+select_and_start_brain() returned - but background_pull() (a deliberately
+non-blocking daemon thread) and even Ollama's own service startup could
+still be in progress at that exact moment. A real machine run showed the
+final summary still printing "AI 大脑 → 未安装(拉取失败/未完成)" even
+though the model had, moments later, actually finished pulling
+successfully ("✓ 本地主脑模型已就绪" was printed right above it) - the
+displayed status was a stale snapshot, not the true state.
+
+_recheck_ai_brain_phase() re-probes Ollama right before the summary card
+is printed (by which point node startup, L4 modules, Electron, tray, and
+voice interaction have all also run, giving the background pull much
+more time to finish) and corrects the phases_state entry in place if
+the real state has improved.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from unified_launcher import _recheck_ai_brain_phase
+
+
+def _make_brain(healthy: bool, available_models: list, ping_result: bool = None):
+    brain = SimpleNamespace()
+    brain._healthy = healthy
+    brain.available_models = available_models
+    brain.brain_model = "gemma4:e2b"
+    brain._ping_ollama = AsyncMock(return_value=ping_result if ping_result is not None else healthy)
+    brain._refresh_model_list = AsyncMock()
+    return brain
+
+
+class TestAiBrainStatusRecheck:
+    def test_upgrades_warn_to_ok_when_model_now_installed(self):
+        """Exactly the real-machine scenario: was unhealthy/uninstalled at
+        snapshot time, but Ollama + the model are actually ready by the time
+        we recheck."""
+        brain = _make_brain(healthy=False, available_models=[], ping_result=True)
+
+        async def refresh():
+            brain.available_models = ["gemma4:e2b"]
+        brain._refresh_model_list.side_effect = refresh
+
+        phases_state = [("AI 大脑", "warn", "未安装(拉取失败/未完成)")]
+        asyncio.run(_recheck_ai_brain_phase(brain, phases_state, 0))
+
+        name, status, hint = phases_state[0]
+        assert status == "ok", phases_state
+        assert hint is None
+        brain._ping_ollama.assert_awaited()
+        brain._refresh_model_list.assert_awaited()
+
+    def test_leaves_ok_status_alone(self):
+        """Already 'ok' at snapshot time - must not be touched (and shouldn't
+        even bother re-probing, since there's nothing to correct)."""
+        brain = _make_brain(healthy=True, available_models=["gemma4:e2b"])
+        phases_state = [("AI 大脑", "ok", None)]
+        asyncio.run(_recheck_ai_brain_phase(brain, phases_state, 0))
+        assert phases_state[0] == ("AI 大脑", "ok", None)
+
+    def test_leaves_warn_alone_when_still_genuinely_not_ready(self):
+        """If the recheck confirms the same negative result, don't fabricate
+        an improvement that isn't real."""
+        brain = _make_brain(healthy=False, available_models=[], ping_result=False)
+        phases_state = [("AI 大脑", "warn", "未安装(拉取失败/未完成)—— 已配置云端 API Key 可兜底")]
+        # "warn" (rather than "fail") requires a configured cloud fallback key.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("OPENAI_API_KEY", "sk-real-test-key")
+            asyncio.run(_recheck_ai_brain_phase(brain, phases_state, 0))
+        name, status, hint = phases_state[0]
+        assert status == "warn"
+        assert hint is not None
+
+    def test_no_brain_is_a_safe_noop(self):
+        phases_state = [("AI 大脑", "fail", "启动失败")]
+        asyncio.run(_recheck_ai_brain_phase(None, phases_state, 0))
+        assert phases_state[0] == ("AI 大脑", "fail", "启动失败")
+
+    def test_out_of_range_index_is_a_safe_noop(self):
+        brain = _make_brain(healthy=True, available_models=["gemma4:e2b"])
+        phases_state = [("其他阶段", "ok", None)]
+        asyncio.run(_recheck_ai_brain_phase(brain, phases_state, 5))
+        assert phases_state == [("其他阶段", "ok", None)]
+
+    def test_probe_exception_is_swallowed_non_fatal(self):
+        brain = _make_brain(healthy=False, available_models=[])
+        brain._ping_ollama.side_effect = RuntimeError("network boom")
+        phases_state = [("AI 大脑", "warn", "未安装(拉取失败/未完成)")]
+        # Must not raise.
+        asyncio.run(_recheck_ai_brain_phase(brain, phases_state, 0))
+        assert phases_state[0][1] == "warn"

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -264,6 +264,40 @@ def ai_brain_readiness(
     return status, model_installed, label
 
 
+async def _recheck_ai_brain_phase(brain, phases_state: list, ai_brain_phase_idx: int) -> None:
+    """在总结卡打印前，重新探测一次 AI 大脑真实状态，好转了就更新对应条目。
+
+    真机复现过:"AI 大脑"这一行的状态是在 select_and_start_brain() 刚返回那一刻
+    算出来、写死进 phases_state 的——但 background_pull() 是故意不阻塞启动的
+    后台线程，那一刻很可能还没跑完(甚至 Ollama 服务本身当时都还在冷启动，没
+    来得及在 _ensure_ollama_running() 的等待窗口内响应)。等到节点系统、L4
+    模块、Electron、托盘、语音这些阶段都跑完、真正要打总结卡时，Ollama 大概率
+    已经起来、模型也大概率已经拉好了，但总结卡"降级"栏用的还是那份过时快照，
+    导致用户看到"AI 大脑 → 未安装(拉取失败/未完成)"，实际上模型已经真的装好
+    可用——这是过期状态展示的问题，不是模型真的没装好。
+
+    只在这里把状态往"更好"的方向纠正(never downgrade)，且只在探测到真实证据
+    (ping 通 + 模型列表刷新)时才改，不主观放宽判定标准。
+    """
+    try:
+        if brain is None or not (0 <= ai_brain_phase_idx < len(phases_state)):
+            return
+        healthy2 = bool(getattr(brain, "_healthy", False)) or await brain._ping_ollama()
+        if healthy2:
+            brain._healthy = True
+            await brain._refresh_model_list()
+        bm2 = getattr(brain, "brain_model", None) or os.environ.get("OLLAMA_MODEL", "") or "未选择"
+        avail2 = list(getattr(brain, "available_models", []) or [])
+        st2, model_installed2, label2 = ai_brain_readiness(bm2, avail2, healthy2)
+        name0, status0, _hint0 = phases_state[ai_brain_phase_idx]
+        if status0 != "ok" and st2 != status0:
+            phases_state[ai_brain_phase_idx] = (
+                name0, st2, (None if model_installed2 else label2)
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("AI 大脑状态复核跳过(非致命): %s", exc)
+
+
 # ============================================================================
 # Launcher sub-module imports
 # (Enums, config, service management, core/node/health/shutdown)
@@ -1330,6 +1364,7 @@ class GalaxyUnified:
             # 打 ✓、显示"就绪",用户看着一片绿实际上一句话都问不出来(每次调用都
             # 404)。ai_brain_readiness() 额外核实选中模型是否真的在已安装列表里。
             st, model_installed, model_status_label = ai_brain_readiness(bm, avail, healthy)
+            ai_brain_phase_idx = len(phases_state)
             _emit("AI 大脑", f"{bm}  ·  {hw}" + ("" if model_installed else "  ⚠ 模型未就绪"), st,
                   hint=(None if model_installed else model_status_label), details=[
                 ("Ollama 推理服务", "就绪" if healthy else "未就绪（检查 ollama 是否运行）",
@@ -1339,6 +1374,7 @@ class GalaxyUnified:
                 ("硬件", hw, "ok"),
             ])
         except Exception as exc:
+            ai_brain_phase_idx = len(phases_state)
             _emit("AI 大脑", "启动失败", "fail")
             logger.error(f"Local brain: {exc}")
 
@@ -1439,6 +1475,19 @@ class GalaxyUnified:
              else "未启用（详见上方日志；GALAXY_VOICE=0 永久关闭）"),
             "ok" if voice_ok else "warn",
         )
+
+        # ── AI 大脑状态复核（总结卡打印前）──
+        # 真机复现过:"AI 大脑"这一行的状态是在 select_and_start_brain() 刚返回
+        # 那一刻算出来、写死进 phases_state 的——但 background_pull() 是故意
+        # 不阻塞启动的后台线程，此时很可能还没跑完(甚至 Ollama 服务本身当时都
+        # 还在冷启动、没来得及在 _ensure_ollama_running() 的等待窗口内响应)。
+        # 等到节点系统、L4 模块、Electron、托盘、语音这些阶段都跑完、真正要打
+        # 总结卡的这一刻，Ollama 大概率已经起来、模型也大概率已经拉好了，但
+        # 总结卡的"降级"栏之前一直用的是那个过时快照，导致用户看到"AI 大脑 →
+        # 未安装(拉取失败/未完成)"，实际上模型已经真的装好可用——这是过期状态
+        # 展示的问题，不是模型真的没装好。这里在打印总结卡前重新探测一次真实
+        # 状态，好转了就更新对应条目，不去猜、不主观放宽判定标准。
+        await _recheck_ai_brain_phase(getattr(self, "_brain", None), phases_state, ai_brain_phase_idx)
 
         # ── 总结卡：状态 + 关键入口 + 降级项 + 下一步 ──
         ok_n = sum(1 for _, s, _h in phases_state if s == "ok")


### PR DESCRIPTION
## Summary

用户拉最新代码在真机重新跑了一遍(验证上一个 PR #1444 里"模型拉取顺序颠倒"的
修复)。日志显示:

```
20:01:32 | WARNING | Ollama 已安装，但服务在等待窗口内未响应（可能仍在冷启动…）
  ⚠ AI 大脑                 gemma4:e2b  ·  CPU 模式（无独显，软件推理）  ⚠ 模型未就绪
  ▶ 正在后台拉取本地主脑模型 ollama pull gemma4:e2b …(不阻塞启动)
  ✓ 本地主脑模型已就绪:gemma4:e2b        ← 拉取本身其实成功了！
  ...
  降级   ...  ·  AI 大脑 → 未安装(拉取失败/未完成)—— 已配置云端 API Key 可兜底
```

模型明明已经拉好、`✓ 本地主脑模型已就绪` 都打出来了，但最终总结卡的"降级"栏
还在说"未安装(拉取失败/未完成)"。

**根因**：`unified_launcher.py` 里"AI 大脑"这一行的状态，是在
`select_and_start_brain()` **刚返回那一刻**从 `brain._healthy` /
`brain.available_models` 算出来、直接写死进 `phases_state` 的一次性快照。但：

- `start_local_brain()` 内部等 Ollama 就绪的窗口本身可能超时(这次真机就撞上了
  "服务在等待窗口内未响应")；
- `background_pull()` 是故意开在后台线程、不阻塞启动的，这个快照拍下去的那一刻
  它很可能还没跑完。

等到节点系统、L4 模块、Electron、托盘、语音这些阶段都跑完、真正要打总结卡时，
Ollama 和模型大概率都已经真的就绪了，但从来没人把这份最新状态同步回
`phases_state`，导致总结卡永远展示的是那份过期的负面快照——用户看到的是"没装
好"，但实际上已经装好、可以正常对话。

## Changes

- `unified_launcher.py`：新增模块级 `_recheck_ai_brain_phase()`，在打印总结卡
  之前重新探测一次 Ollama(`_ping_ollama` + `_refresh_model_list`)，如果真实
  状态比快照时更好，就地更新 `phases_state` 里"AI 大脑"这一条(只会往好的方向
  纠正，绝不下调，也绝不在没有真实探测证据时凭空放宽判定)。

## Test plan

- [x] `python3 -m py_compile unified_launcher.py`
- [x] 新增 `tests/test_ai_brain_status_recheck.py`(6 个用例):真实好转时
      warn→ok、已经 ok 时不碰、真的还没好时不瞎改、无 brain 实例安全跳过、
      索引越界安全跳过、探测异常被吞掉不致命
- [x] `test_ai_brain_readiness_banner.py`(既有 6 个用例)、
      `test_brain_startup_ordering.py`(前一个 PR 的 2 个用例)全部仍通过
- [ ] 真机复现：确认这次总结卡的"AI 大脑"状态会随后台拉取/Ollama 延迟就绪
      而正确更新为"ok"，不再展示过期的"未安装"

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_