### PR TITLE
模型列表更新至 2026-07 最新 + 开机自启(基于现有守护进程)

### DIFF
--- a/core/llm/policies.py
+++ b/core/llm/policies.py
@@ -69,7 +69,7 @@ class ProviderSelectionResult:
     provider:
         Selected provider name (e.g. ``"anthropic"``).
     model:
-        Selected model string (e.g. ``"claude-sonnet-4-6-20251022"``).
+        Selected model string (e.g. ``"claude-sonnet-5"``).
     task_type:
         The task type used for selection.
     reason:

--- a/core/llm/route_authority.py
+++ b/core/llm/route_authority.py
@@ -132,7 +132,7 @@ class LLMRouteDecision:
     provider:
         Selected provider identifier (e.g. ``"openai"``, ``"anthropic"``).
     model:
-        Selected model identifier (e.g. ``"gpt-5.5"``, ``"claude-sonnet-4-6-20251022"``).
+        Selected model identifier (e.g. ``"gpt-5.6"``, ``"claude-sonnet-5"``).
     reason:
         Human-readable explanation of why this provider/model was selected.
     alternatives:

--- a/core/model_topology/__init__.py
+++ b/core/model_topology/__init__.py
@@ -23,8 +23,8 @@ Quick start::
     bridge = ConfigBridge()
     snapshot = LegacyLLMProviderSnapshot.from_dict({
         "provider": "openai",
-        "model": "gpt-5.5",
-        "models": ["gpt-5.5", "gpt-5.5-instant", "gpt-4o"],
+        "model": "gpt-5.6",
+        "models": ["gpt-5.6", "gpt-5.6-luna", "gpt-5.6-terra"],
         "speed_score": 8,
         "quality_score": 9,
         "available": True,

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -282,44 +282,48 @@ def _provider_quality_tier(name: str) -> int:
 # 提供商 → 推荐模型 (2026-05-29 全面更新)
 PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
     "openai": {
-        TaskType.REASONING:     "gpt-5.5",
-        TaskType.FAST_RESPONSE: "gpt-5.5-instant",
-        TaskType.CODING:        "gpt-5.5",
-        TaskType.CREATIVE:      "gpt-5.5",
-        TaskType.ANALYSIS:      "gpt-5.5",
-        TaskType.PLANNING:      "gpt-5.5",
-        TaskType.AGENT_CONTROL: "gpt-5.5",
-        TaskType.GENERAL:       "gpt-5.5",
+        # GPT-5.6 家族(2026-07-09 GA):gpt-5.6 = 旗舰 Sol 的别名(1.05M ctx/128K out);
+        # terra=日常均衡($2.5/$15);luna=快而省($1/$6)。
+        TaskType.REASONING:     "gpt-5.6",
+        TaskType.FAST_RESPONSE: "gpt-5.6-luna",
+        TaskType.CODING:        "gpt-5.6",
+        TaskType.CREATIVE:      "gpt-5.6",
+        TaskType.ANALYSIS:      "gpt-5.6",
+        TaskType.PLANNING:      "gpt-5.6",
+        TaskType.AGENT_CONTROL: "gpt-5.6",
+        TaskType.GENERAL:       "gpt-5.6-terra",
     },
     "anthropic": {
         TaskType.REASONING:     "claude-opus-4-8-20250529",
-        TaskType.FAST_RESPONSE: "claude-sonnet-4-6-20251022",
-        TaskType.CODING:        "claude-sonnet-4-6-20251022",
+        TaskType.FAST_RESPONSE: "claude-sonnet-5",
+        TaskType.CODING:        "claude-sonnet-5",
         TaskType.CREATIVE:      "claude-opus-4-8-20250529",
         TaskType.ANALYSIS:      "claude-opus-4-8-20250529",
         TaskType.PLANNING:      "claude-opus-4-8-20250529",
-        TaskType.AGENT_CONTROL: "claude-sonnet-4-6-20251022",
-        TaskType.GENERAL:       "claude-sonnet-4-6-20251022",
+        TaskType.AGENT_CONTROL: "claude-sonnet-5",
+        TaskType.GENERAL:       "claude-sonnet-5",
     },
     "google": {
+        # 注:gemini-3.5-pro 延期到 2026-07-17 才发布——此前表里引用它会 404。
+        # 现全走 GA 的 3.5-flash;Pro 上线后把 CODING/PLANNING/AGENT 升回去。
         TaskType.REASONING:     "gemini-3.5-flash",
         TaskType.FAST_RESPONSE: "gemini-3.5-flash",
-        TaskType.CODING:        "gemini-3.5-pro",
-        TaskType.CREATIVE:      "gemini-3.5-pro",
+        TaskType.CODING:        "gemini-3.5-flash",
+        TaskType.CREATIVE:      "gemini-3.5-flash",
         TaskType.ANALYSIS:      "gemini-3.5-flash",
-        TaskType.PLANNING:      "gemini-3.5-pro",
-        TaskType.AGENT_CONTROL: "gemini-3.5-pro",
+        TaskType.PLANNING:      "gemini-3.5-flash",
+        TaskType.AGENT_CONTROL: "gemini-3.5-flash",
         TaskType.GENERAL:       "gemini-3.5-flash",
     },
     "xai": {
-        TaskType.REASONING:     "grok-4.1",
-        TaskType.FAST_RESPONSE: "grok-4.1",
-        TaskType.CODING:        "grok-4.1",
-        TaskType.CREATIVE:      "grok-4.1",
-        TaskType.ANALYSIS:      "grok-4.1",
-        TaskType.PLANNING:      "grok-4.1",
-        TaskType.AGENT_CONTROL: "grok-4.1",
-        TaskType.GENERAL:       "grok-4.1",
+        TaskType.REASONING:     "grok-4.5",
+        TaskType.FAST_RESPONSE: "grok-4.5",
+        TaskType.CODING:        "grok-4.5",
+        TaskType.CREATIVE:      "grok-4.5",
+        TaskType.ANALYSIS:      "grok-4.5",
+        TaskType.PLANNING:      "grok-4.5",
+        TaskType.AGENT_CONTROL: "grok-4.5",
+        TaskType.GENERAL:       "grok-4.5",
     },
     "mistral": {
         TaskType.REASONING:     "mistral-large-3",
@@ -333,7 +337,7 @@ PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
     },
     "deepseek": {
         TaskType.REASONING:     "deepseek-v4-pro",
-        TaskType.FAST_RESPONSE: "deepseek-v4",
+        TaskType.FAST_RESPONSE: "deepseek-v4-flash",
         TaskType.CODING:        "deepseek-v4-pro",
         TaskType.CREATIVE:      "deepseek-v4-pro",
         TaskType.ANALYSIS:      "deepseek-v4-pro",
@@ -344,7 +348,7 @@ PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
     "qwen": {
         TaskType.REASONING:     "qwen3.7-max",
         TaskType.CODING:        "qwen3.7-coder",
-        TaskType.FAST_RESPONSE: "qwen3.7-max",
+        TaskType.FAST_RESPONSE: "qwen-flash",
         TaskType.GENERAL:       "qwen3.7-max",
         TaskType.ANALYSIS:      "qwen3.7-max",
         TaskType.PLANNING:      "qwen3.7-max",
@@ -390,9 +394,12 @@ PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
         TaskType.GENERAL:       "mimo-v2.5-pro",
     },
     "moonshot": {
-        TaskType.GENERAL:       "moonshot-v1-128k",
-        TaskType.ANALYSIS:      "moonshot-v1-256k",
-        TaskType.FAST_RESPONSE: "moonshot-v1-32k",
+        # Kimi K2 系取代老 moonshot-v1-*:k2.6=最新最强(代码/agent);
+        # k2.5=原生多模态 256K 长上下文(2026-01 开源权重)。
+        TaskType.GENERAL:       "kimi-k2.6",
+        TaskType.CODING:        "kimi-k2.6",
+        TaskType.ANALYSIS:      "kimi-k2.5",
+        TaskType.FAST_RESPONSE: "kimi-k2.5",
     },
     "perplexity": {
         TaskType.REASONING:     "sonar-deep-research",
@@ -995,8 +1002,8 @@ class MultiLLMRouter:
             base = self._get_key("openai_base") or os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
             cfg = ProviderConfig(
                 name="openai", api_key=key, base_url=base,
-                models=["gpt-5.5", "gpt-5.5-instant", "gpt-4.1", "gpt-4o", "gpt-4o-mini"],
-                default_model="gpt-5.5",
+                models=["gpt-5.6", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-4o"],
+                default_model="gpt-5.6",
                 cost_per_1k_input=0.005, cost_per_1k_output=0.015,
                 multimodal=True, env_key="OPENAI_API_KEY",
             )
@@ -1011,8 +1018,8 @@ class MultiLLMRouter:
             cfg = ProviderConfig(
                 name="anthropic", api_key=key,
                 base_url="https://api.anthropic.com/v1",
-                models=["claude-opus-4-8-20250529", "claude-sonnet-4-6-20251022", "claude-haiku-4-5-20251001"],
-                default_model="claude-sonnet-4-6-20251022",
+                models=["claude-opus-4-8-20250529", "claude-sonnet-5", "claude-haiku-4-5-20251001"],
+                default_model="claude-sonnet-5",
                 cost_per_1k_input=0.003, cost_per_1k_output=0.015,
                 multimodal=True, env_key="ANTHROPIC_API_KEY",
             )
@@ -1043,8 +1050,8 @@ class MultiLLMRouter:
             cfg = ProviderConfig(
                 name="xai", api_key=key,
                 base_url="https://api.x.ai/v1",
-                models=["grok-4.1", "grok-4.1-beta"],
-                default_model="grok-4.1",
+                models=["grok-4.5", "grok-4.3"],
+                default_model="grok-4.5",
                 cost_per_1k_input=0.005, cost_per_1k_output=0.015,
                 multimodal=True, env_key="XAI_API_KEY",
             )
@@ -1075,7 +1082,7 @@ class MultiLLMRouter:
             cfg = ProviderConfig(
                 name="deepseek", api_key=key,
                 base_url="https://api.deepseek.com/v1",
-                models=["deepseek-v4-pro", "deepseek-v4", "deepseek-chat", "deepseek-reasoner"],
+                models=["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"],
                 default_model="deepseek-v4-pro",
                 cost_per_1k_input=0.000025, cost_per_1k_output=0.00006,
                 multimodal=False, env_key="DEEPSEEK_API_KEY",
@@ -1174,8 +1181,8 @@ class MultiLLMRouter:
             cfg = ProviderConfig(
                 name="moonshot", api_key=key,
                 base_url="https://api.moonshot.cn/v1",
-                models=["moonshot-v1-128k", "moonshot-v1-32k", "moonshot-v1-256k"],
-                default_model="moonshot-v1-128k",
+                models=["kimi-k2.6", "kimi-k2.5", "moonshot-v1-128k"],
+                default_model="kimi-k2.6",
                 cost_per_1k_input=0.002, cost_per_1k_output=0.002,
                 multimodal=False, env_key="MOONSHOT_API_KEY",
             )

--- a/daemon/autostart.py
+++ b/daemon/autostart.py
@@ -1,0 +1,232 @@
+"""daemon/autostart.py — 开机自启(唯一属主)
+==================================================
+
+把【现有守护进程 galaxy_daemon.py】注册为开机自启,三平台同一入口:
+
+- Windows: 计划任务(schtasks ONLOGON,优先 pythonw.exe 无黑窗)
+- Linux:   systemd 用户单元 ~/.config/systemd/user/galaxy-daemon.service
+- macOS:   LaunchAgent ~/Library/LaunchAgents/com.galaxy.daemon.plist
+
+守护进程自身已带 24/7 监督(拉起 unified_launcher + 健康/硬件监控,崩溃自动重启),
+所以系统层只负责"开机把守护进程带起来",不重复做保活(Restart=on-failure 仅兜
+守护进程本体崩溃)。
+
+用法(经 galaxy_daemon CLI)::
+
+    python daemon/galaxy_daemon.py --install-autostart     # 注册开机自启
+    python daemon/galaxy_daemon.py --uninstall-autostart   # 取消
+    python daemon/galaxy_daemon.py --autostart-status      # 查看
+
+纯逻辑与系统调用分离:内容生成为纯函数(可单测),落地经 _run()(测试可 mock)。
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Galaxy.Autostart")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DAEMON_SCRIPT = REPO_ROOT / "daemon" / "galaxy_daemon.py"
+DAEMON_CONFIG = REPO_ROOT / "daemon" / "config.json"
+
+TASK_NAME = "GalaxyDaemon"                       # Windows 计划任务名
+UNIT_NAME = "galaxy-daemon.service"              # systemd 用户单元名
+PLIST_LABEL = "com.galaxy.daemon"                # macOS LaunchAgent 标签
+
+
+def detect_platform() -> str:
+    """windows / macos / linux。"""
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform == "darwin":
+        return "macos"
+    return "linux"
+
+
+def _python_executable(prefer_windowless: bool = True) -> str:
+    """守护进程用的 Python 解释器。
+
+    Windows 上优先 pythonw.exe(无控制台黑窗,开机静默);找不到退回 python.exe。
+    """
+    exe = sys.executable or "python"
+    if detect_platform() == "windows" and prefer_windowless:
+        cand = Path(exe).with_name("pythonw.exe")
+        if cand.exists():
+            return str(cand)
+    return exe
+
+
+def daemon_command() -> List[str]:
+    """开机要执行的完整命令(基于现有守护进程,不另起炉灶)。"""
+    return [
+        _python_executable(),
+        str(DAEMON_SCRIPT),
+        "--config",
+        str(DAEMON_CONFIG),
+    ]
+
+
+# ── 内容生成(纯函数,单测覆盖)──────────────────────────────────────────────────
+
+def systemd_unit_content() -> str:
+    cmd = " ".join(_quote(c) for c in daemon_command())
+    return f"""[Unit]
+Description=Galaxy 24/7 Daemon (desktop AI supervisor)
+After=network-online.target graphical-session.target
+
+[Service]
+Type=simple
+WorkingDirectory={REPO_ROOT}
+ExecStart={cmd}
+# 守护进程自带 24/7 监督与子进程重启;这里只兜它本体崩溃。
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def launchd_plist_content() -> str:
+    args = "\n".join(f"        <string>{c}</string>" for c in daemon_command())
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{PLIST_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+{args}
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{REPO_ROOT}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>
+"""
+
+
+def schtasks_create_command() -> List[str]:
+    """Windows 计划任务:用户登录时启动守护进程(工作目录经 cmd /c cd 保证)。"""
+    inner = " ".join(_quote(c) for c in daemon_command())
+    # schtasks 不支持设工作目录 → 经 cmd /c 先 cd 到仓库根,守护进程内的相对
+    # 路径(unified_launcher.py / .env 等)才解析正确。
+    tr = f'cmd /c "cd /d {_quote(str(REPO_ROOT))} && {inner}"'
+    return [
+        "schtasks", "/Create",
+        "/TN", TASK_NAME,
+        "/SC", "ONLOGON",
+        "/TR", tr,
+        "/RL", "LIMITED",
+        "/F",
+    ]
+
+
+def _quote(s: str) -> str:
+    return f'"{s}"' if " " in s and not s.startswith('"') else s
+
+
+def systemd_unit_path(home: Optional[Path] = None) -> Path:
+    return (home or Path.home()) / ".config" / "systemd" / "user" / UNIT_NAME
+
+
+def launchd_plist_path(home: Optional[Path] = None) -> Path:
+    return (home or Path.home()) / "Library" / "LaunchAgents" / f"{PLIST_LABEL}.plist"
+
+
+# ── 落地(系统调用集中经 _run,测试可 mock)────────────────────────────────────
+
+def _run(cmd: List[str]) -> Tuple[int, str]:
+    """跑一条系统命令,返回 (returncode, 合并输出)。绝不抛。"""
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        out = (p.stdout or "") + (p.stderr or "")
+        return p.returncode, out.strip()
+    except Exception as exc:  # noqa: BLE001
+        return 1, str(exc)
+
+
+def install(home: Optional[Path] = None) -> Dict[str, str]:
+    """注册开机自启(幂等:重复安装即覆盖更新)。返回 {platform, method, detail}。"""
+    plat = detect_platform()
+    if plat == "windows":
+        rc, out = _run(schtasks_create_command())
+        ok = rc == 0
+        return {
+            "platform": plat, "method": f"schtasks ONLOGON ({TASK_NAME})",
+            "ok": str(ok), "detail": out[:300],
+        }
+    if plat == "macos":
+        path = launchd_plist_path(home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(launchd_plist_content(), encoding="utf-8")
+        rc, out = _run(["launchctl", "load", "-w", str(path)])
+        return {
+            "platform": plat, "method": f"LaunchAgent ({path})",
+            "ok": str(rc == 0), "detail": out[:300],
+        }
+    # linux
+    path = systemd_unit_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(systemd_unit_content(), encoding="utf-8")
+    _run(["systemctl", "--user", "daemon-reload"])
+    rc, out = _run(["systemctl", "--user", "enable", UNIT_NAME])
+    return {
+        "platform": plat, "method": f"systemd user unit ({path})",
+        "ok": str(rc == 0),
+        "detail": (out[:250] + " | 提示: 无图形会话的机器需 `loginctl enable-linger $USER`"),
+    }
+
+
+def uninstall(home: Optional[Path] = None) -> Dict[str, str]:
+    """取消开机自启(幂等:未安装时也安全)。"""
+    plat = detect_platform()
+    if plat == "windows":
+        rc, out = _run(["schtasks", "/Delete", "/TN", TASK_NAME, "/F"])
+        return {"platform": plat, "ok": str(rc == 0), "detail": out[:300]}
+    if plat == "macos":
+        path = launchd_plist_path(home)
+        detail = ""
+        if path.exists():
+            _, detail = _run(["launchctl", "unload", "-w", str(path)])
+            try:
+                path.unlink()
+            except OSError as exc:
+                detail += f" | unlink: {exc}"
+        return {"platform": plat, "ok": str(not path.exists()), "detail": detail[:300]}
+    path = systemd_unit_path(home)
+    _run(["systemctl", "--user", "disable", UNIT_NAME])
+    detail = ""
+    if path.exists():
+        try:
+            path.unlink()
+        except OSError as exc:
+            detail = f"unlink: {exc}"
+    _run(["systemctl", "--user", "daemon-reload"])
+    return {"platform": plat, "ok": str(not path.exists()), "detail": detail[:300]}
+
+
+def status(home: Optional[Path] = None) -> Dict[str, str]:
+    """当前开机自启状态。"""
+    plat = detect_platform()
+    if plat == "windows":
+        rc, out = _run(["schtasks", "/Query", "/TN", TASK_NAME])
+        return {"platform": plat, "installed": str(rc == 0), "detail": out[:300]}
+    if plat == "macos":
+        path = launchd_plist_path(home)
+        return {"platform": plat, "installed": str(path.exists()), "detail": str(path)}
+    path = systemd_unit_path(home)
+    rc, out = _run(["systemctl", "--user", "is-enabled", UNIT_NAME])
+    return {
+        "platform": plat,
+        "installed": str(path.exists() and rc == 0),
+        "detail": f"{path} | is-enabled: {out[:100]}",
+    }

--- a/daemon/galaxy_daemon.py
+++ b/daemon/galaxy_daemon.py
@@ -256,13 +256,18 @@ class GalaxyDaemon:
         self._signal_pending: int = 0  # 0=none, SIGTERM/SIGINT=shutdown, SIGHUP=reload
 
         # Setup signal handlers — use a simple atomic flag approach for thread safety
+        # Windows 兼容(开机自启的前提):SIGHUP 与 siginterrupt 在 Windows 上不存在,
+        # 此前无条件调用 → 守护进程在 Windows 一启动就 AttributeError 崩掉。
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
-        signal.signal(signal.SIGHUP, self._signal_handler)
-        # Prevent signals from interrupting system calls (retry instead)
-        signal.siginterrupt(signal.SIGTERM, False)
-        signal.siginterrupt(signal.SIGINT, False)
-        signal.siginterrupt(signal.SIGHUP, False)
+        if hasattr(signal, "SIGHUP"):
+            signal.signal(signal.SIGHUP, self._signal_handler)
+        if hasattr(signal, "siginterrupt"):
+            # Prevent signals from interrupting system calls (retry instead)
+            signal.siginterrupt(signal.SIGTERM, False)
+            signal.siginterrupt(signal.SIGINT, False)
+            if hasattr(signal, "SIGHUP"):
+                signal.siginterrupt(signal.SIGHUP, False)
 
         logger.info("GalaxyDaemon initialized")
     
@@ -535,9 +540,29 @@ if __name__ == "__main__":
     parser.add_argument("--config", "-c", help="Configuration file path")
     parser.add_argument("--status", "-s", action="store_true", help="Show status")
     parser.add_argument("--stop", action="store_true", help="Stop daemon")
-    
+    parser.add_argument("--install-autostart", action="store_true",
+                        help="注册开机自启(Windows 计划任务 / systemd user / LaunchAgent)")
+    parser.add_argument("--uninstall-autostart", action="store_true", help="取消开机自启")
+    parser.add_argument("--autostart-status", action="store_true", help="查看开机自启状态")
+
     args = parser.parse_args()
-    
+
+    if args.install_autostart or args.uninstall_autostart or args.autostart_status:
+        try:
+            from daemon.autostart import install, status, uninstall
+        except ImportError:
+            # 直接 `python daemon/galaxy_daemon.py` 运行时 sys.path[0] 是 daemon/
+            # 目录本身,包名不可见 → 退回同目录导入。
+            from autostart import install, status, uninstall
+        if args.install_autostart:
+            result = install()
+        elif args.uninstall_autostart:
+            result = uninstall()
+        else:
+            result = status()
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        sys.exit(0 if result.get("ok", result.get("installed")) != "False" else 1)
+
     if args.stop:
         # Send stop signal
         # Find and stop running daemon

--- a/tests/test_daemon_autostart.py
+++ b/tests/test_daemon_autostart.py
@@ -1,0 +1,143 @@
+"""tests/test_daemon_autostart.py
+=====================================
+
+开机自启(daemon/autostart.py,基于现有守护进程)+ 守护进程 Windows 兼容修复。
+系统调用经 _run 抽象,测试全部 mock,不碰真实 systemctl/schtasks/launchctl。
+"""
+from __future__ import annotations
+
+import signal
+
+import pytest
+
+import daemon.autostart as au
+
+
+@pytest.fixture()
+def calls(monkeypatch):
+    """mock 掉系统调用,记录命令。"""
+    recorded = []
+
+    def _fake_run(cmd):
+        recorded.append(cmd)
+        return 0, "ok"
+    monkeypatch.setattr(au, "_run", _fake_run)
+    return recorded
+
+
+# ── 内容生成(纯函数)──
+
+class TestContent:
+    def test_daemon_command_uses_existing_daemon(self):
+        cmd = au.daemon_command()
+        assert cmd[1].endswith("galaxy_daemon.py")          # 基于现有守护进程
+        assert "--config" in cmd and cmd[-1].endswith("config.json")
+
+    def test_systemd_unit_shape(self):
+        unit = au.systemd_unit_content()
+        assert "galaxy_daemon.py" in unit
+        assert f"WorkingDirectory={au.REPO_ROOT}" in unit
+        assert "Restart=on-failure" in unit                 # 只兜守护进程本体
+        assert "WantedBy=default.target" in unit
+
+    def test_launchd_plist_shape(self):
+        plist = au.launchd_plist_content()
+        assert au.PLIST_LABEL in plist
+        assert "galaxy_daemon.py" in plist
+        assert "<key>RunAtLoad</key>" in plist and "<true/>" in plist
+
+    def test_schtasks_command_shape(self):
+        cmd = au.schtasks_create_command()
+        assert cmd[:2] == ["schtasks", "/Create"]
+        assert "/SC" in cmd and cmd[cmd.index("/SC") + 1] == "ONLOGON"
+        tr = cmd[cmd.index("/TR") + 1]
+        assert "galaxy_daemon.py" in tr and "cd /d" in tr    # 工作目录经 cmd /c cd 保证
+        assert "/F" in cmd                                    # 幂等覆盖
+
+
+# ── 平台分派 + 安装/卸载/状态(mock 落地)──
+
+class TestLinux:
+    @pytest.fixture(autouse=True)
+    def _linux(self, monkeypatch):
+        monkeypatch.setattr(au.sys, "platform", "linux")
+
+    def test_install_writes_unit_and_enables(self, tmp_path, calls):
+        r = au.install(home=tmp_path)
+        unit = au.systemd_unit_path(tmp_path)
+        assert unit.exists() and "galaxy_daemon.py" in unit.read_text(encoding="utf-8")
+        assert ["systemctl", "--user", "daemon-reload"] in calls
+        assert ["systemctl", "--user", "enable", au.UNIT_NAME] in calls
+        assert r["ok"] == "True"
+
+    def test_install_idempotent(self, tmp_path, calls):
+        au.install(home=tmp_path)
+        au.install(home=tmp_path)  # 重复安装 = 覆盖更新,不抛
+        assert au.systemd_unit_path(tmp_path).exists()
+
+    def test_uninstall_removes_unit(self, tmp_path, calls):
+        au.install(home=tmp_path)
+        r = au.uninstall(home=tmp_path)
+        assert not au.systemd_unit_path(tmp_path).exists()
+        assert ["systemctl", "--user", "disable", au.UNIT_NAME] in calls
+        assert r["ok"] == "True"
+
+    def test_uninstall_when_never_installed_is_safe(self, tmp_path, calls):
+        r = au.uninstall(home=tmp_path)
+        assert r["ok"] == "True"
+
+    def test_status(self, tmp_path, calls):
+        assert au.status(home=tmp_path)["installed"] == "False"
+        au.install(home=tmp_path)
+        assert au.status(home=tmp_path)["installed"] == "True"
+
+
+class TestMacos:
+    @pytest.fixture(autouse=True)
+    def _mac(self, monkeypatch):
+        monkeypatch.setattr(au.sys, "platform", "darwin")
+
+    def test_install_writes_plist_and_loads(self, tmp_path, calls):
+        r = au.install(home=tmp_path)
+        plist = au.launchd_plist_path(tmp_path)
+        assert plist.exists()
+        assert any(c[:2] == ["launchctl", "load"] for c in calls)
+        assert r["ok"] == "True"
+
+    def test_uninstall_unloads_and_removes(self, tmp_path, calls):
+        au.install(home=tmp_path)
+        r = au.uninstall(home=tmp_path)
+        assert not au.launchd_plist_path(tmp_path).exists()
+        assert r["ok"] == "True"
+
+
+class TestWindows:
+    @pytest.fixture(autouse=True)
+    def _win(self, monkeypatch):
+        monkeypatch.setattr(au.sys, "platform", "win32")
+
+    def test_install_calls_schtasks_create(self, tmp_path, calls):
+        r = au.install(home=tmp_path)
+        assert calls and calls[0][:2] == ["schtasks", "/Create"]
+        assert r["ok"] == "True"
+
+    def test_uninstall_calls_schtasks_delete(self, tmp_path, calls):
+        au.uninstall(home=tmp_path)
+        assert ["schtasks", "/Delete", "/TN", au.TASK_NAME, "/F"] in calls
+
+    def test_status_queries_task(self, tmp_path, calls):
+        r = au.status(home=tmp_path)
+        assert calls[-1][:2] == ["schtasks", "/Query"]
+        assert r["installed"] == "True"  # mock rc=0 → 已安装
+
+
+# ── 守护进程 Windows 兼容(SIGHUP 守卫)──
+
+class TestDaemonWindowsCompat:
+    def test_daemon_init_survives_missing_sighup(self, monkeypatch):
+        """Windows 无 SIGHUP/siginterrupt——守卫后 __init__ 不再崩。"""
+        monkeypatch.delattr(signal, "SIGHUP", raising=False)
+        monkeypatch.delattr(signal, "siginterrupt", raising=False)
+        from daemon.galaxy_daemon import GalaxyDaemon
+        d = GalaxyDaemon()  # 此前在这里 AttributeError
+        assert d.state is not None


### PR DESCRIPTION
## 概要

两个批次:

### 批次 1:模型列表更新(2026-07 联网核实)

`core/multi_llm_router.py` PROVIDER_MODEL_MAP 全量对齐最新一代:

| Provider | 变化 |
|---|---|
| OpenAI | gpt-5.1 系 → **gpt-5.6**(GENERAL: gpt-5.6-terra,FAST: gpt-5.6-luna) |
| Anthropic | sonnet → **claude-sonnet-5**(opus-4-8 保留) |
| Google | 全部 → **gemini-3.5-flash**(3.5-pro 官方延期至 07-17,发布后可再升) |
| xAI | → **grok-4.5** |
| DeepSeek | FAST → **deepseek-v4-flash** |
| Qwen | FAST → **qwen-flash**;GENERAL/CODING → qwen3.7-max 系 |
| Moonshot | → **kimi-k2.6**(GENERAL/CODING)/ kimi-k2.5(ANALYSIS/FAST) |

无发布证据的 provider(zhipu/minimax/step/mimo/groq/perplexity/本地 ollama)不动。ProviderConfig 的 models/default 同步;相关 docstring 更新。215 测试全绿。

### 批次 2:开机自启(用户请求:基于已有守护进程)

新增 `daemon/autostart.py`(唯一属主),把**现有** `galaxy_daemon.py` 注册为开机自启,不另起炉灶:

- **Windows**:schtasks ONLOGON 计划任务 `GalaxyDaemon`,优先 pythonw 静默启动,经 `cmd /c cd` 保证工作目录
- **Linux**:systemd 用户单元 `~/.config/systemd/user/galaxy-daemon.service`(`Restart=on-failure` 只兜守护进程本体崩溃,子进程保活仍由守护进程自身监督)
- **macOS**:LaunchAgent `com.galaxy.daemon.plist`(RunAtLoad)

CLI(接在守护进程上):

```
python daemon/galaxy_daemon.py --install-autostart     # 注册
python daemon/galaxy_daemon.py --uninstall-autostart   # 取消
python daemon/galaxy_daemon.py --autostart-status      # 查看(未安装退出码 1,同 systemctl is-enabled)
```

顺带修复真实 Windows 崩溃:`signal.SIGHUP` / `signal.siginterrupt` 此前无守卫,Windows 上 `GalaxyDaemon.__init__` 直接 AttributeError → hasattr 守卫。

## 验证

- 新增 `tests/test_daemon_autostart.py` 15 测全绿(内容形状、三平台安装/卸载/状态 mock 落地、幂等、SIGHUP 缺失兼容)
- CLI 冒烟通过(JSON 状态输出正常)
- flake8:新文件 0 告警,`galaxy_daemon.py` 存量告警 64→62(零新增)
- stash 基线对比:零新增失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b