### PR TITLE
fix(clone-to-use): Windows 克隆到使用全链路排查 + ollama 地址解析收口唯一属主

### DIFF
--- a/core/audio_pipeline.py
+++ b/core/audio_pipeline.py
@@ -106,15 +106,10 @@ class AudioPipeline:
         # 本地 Ollama 音频（MiniCPM-o 4.5 全模态、或最新 Gemma 4 原生音频输入；经 Ollama 的
         # OpenAI 兼容端点 /v1/chat/completions 复用 input_audio content block，纯本地、无需云端
         # key。注意：Ollama 原生 /api/chat 的 audios 字段会被静默忽略，必须走 /v1 这条）。
-        # 兜底补协议头:用户在面板只填 host:port(如 "localhost:11434")时,
-        # 原来的写法(默认值只在 key 不存在时生效)会把这个无协议头的值原样
-        # 传给 httpx,实际请求时炸 InvalidURL(missing protocol)。
-        _ollama_base_raw = self.config.get("ollama_base", os.getenv("OLLAMA_URL", "")).strip()
-        if not _ollama_base_raw:
-            _ollama_base_raw = "http://localhost:11434"
-        elif not _ollama_base_raw.startswith(("http://", "https://")):
-            _ollama_base_raw = f"http://{_ollama_base_raw}"
-        self.ollama_base = _ollama_base_raw.rstrip("/")
+        # ollama 地址解析收口到 core.ollama_endpoint 唯一属主(空值/缺协议头都兜底):
+        # 面板 config 的 ollama_base > 环境变量 OLLAMA_URL > 默认 localhost:11434。
+        from core.ollama_endpoint import resolve_ollama_base_url
+        self.ollama_base = resolve_ollama_base_url(self.config.get("ollama_base"))
         self.local_audio_enabled = os.getenv("GALAXY_LOCAL_AUDIO", "1").strip().lower() in (
             "1", "true", "yes", "on"
         )

--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -112,12 +112,9 @@ class LocalBrainManager:
            'http://'..."(克隆界面探测 Ollama 时那个 HTTP 报错、Ollama 明明在跑却
            判"未响应")。故空值一律回落默认地址,不再放空 URL 出门。
         """
-        raw = (raw or "").strip()
-        if not raw:
-            return LocalBrainManager.OLLAMA_DEFAULT_URL
-        if not raw.startswith(("http://", "https://")):
-            raw = f"http://{raw}"
-        return raw.rstrip("/")
+        # 收口到 core.ollama_endpoint 唯一属主(本方法保留为薄封装:测试与旧调用点仍引用它)。
+        from core.ollama_endpoint import normalize_ollama_url
+        return normalize_ollama_url(raw)
 
     def __init__(self, backend: str = "auto", ollama_url: Optional[str] = None):
         """

--- a/external/memos/memos/memories/activation/kv.py
+++ b/external/memos/memos/memories/activation/kv.py
@@ -157,22 +157,22 @@ class KVCacheMemory(BaseActMemory):
             torch.serialization.add_safe_globals([DynamicCache, KVCacheItem])
 
             # 安全反序列化 - 添加签名验证
-                with open(file_path, "rb") as f:
-                    # 读取签名和数据
-                    signature = f.read(64)  # HMAC-SHA256 签名长度
-                    data_bytes = f.read()
+            with open(file_path, "rb") as f:
+                # 读取签名和数据
+                signature = f.read(64)  # HMAC-SHA256 签名长度
+                data_bytes = f.read()
 
-                    # 验证签名 (如果存在)
-                    if signature:
-                        expected_sig = hmac.new(
-                            os.environ.get('PICKLE_SECRET_KEY', '').encode(),
-                            data_bytes,
-                            hashlib.sha256
-                        ).digest()
-                        if not hmac.compare_digest(signature, expected_sig):
-                            raise ValueError("Invalid pickle file signature - possible tampering detected")
+                # 验证签名 (如果存在)
+                if signature:
+                    expected_sig = hmac.new(
+                        os.environ.get('PICKLE_SECRET_KEY', '').encode(),
+                        data_bytes,
+                        hashlib.sha256
+                    ).digest()
+                    if not hmac.compare_digest(signature, expected_sig):
+                        raise ValueError("Invalid pickle file signature - possible tampering detected")
 
-                    data = pickle.loads(data_bytes)
+                data = pickle.loads(data_bytes)
 
             if isinstance(data, dict):
                 # Load memories, handle both old and new formats

--- a/external/memos/memos/memories/activation/vllmkv.py
+++ b/external/memos/memos/memories/activation/vllmkv.py
@@ -163,22 +163,22 @@ class VLLMKVCacheMemory(BaseActMemory):
             torch.serialization.add_safe_globals([VLLMKVCacheItem])
 
             # 安全反序列化 - 添加签名验证
-                with open(file_path, "rb") as f:
-                    # 读取签名和数据
-                    signature = f.read(64)  # HMAC-SHA256 签名长度
-                    data_bytes = f.read()
+            with open(file_path, "rb") as f:
+                # 读取签名和数据
+                signature = f.read(64)  # HMAC-SHA256 签名长度
+                data_bytes = f.read()
 
-                    # 验证签名 (如果存在)
-                    if signature:
-                        expected_sig = hmac.new(
-                            os.environ.get('PICKLE_SECRET_KEY', '').encode(),
-                            data_bytes,
-                            hashlib.sha256
-                        ).digest()
-                        if not hmac.compare_digest(signature, expected_sig):
-                            raise ValueError("Invalid pickle file signature - possible tampering detected")
+                # 验证签名 (如果存在)
+                if signature:
+                    expected_sig = hmac.new(
+                        os.environ.get('PICKLE_SECRET_KEY', '').encode(),
+                        data_bytes,
+                        hashlib.sha256
+                    ).digest()
+                    if not hmac.compare_digest(signature, expected_sig):
+                        raise ValueError("Invalid pickle file signature - possible tampering detected")
 
-                    data = pickle.loads(data_bytes)
+                data = pickle.loads(data_bytes)
 
             if isinstance(data, dict):
                 # Load memories, handle both old and new formats


### PR DESCRIPTION
## 背景

真机(Windows)从克隆到使用全程复现的报错反复出现,尤其是 ollama「Request URL is missing an 'http://' or 'https://' protocol」——即便面板/克隆界面里 Ollama 明明在跑,却被判"未响应"。本 PR 把这一类问题从**根**上收口,并做了一次完整的克隆到使用链路复验。

## 改动

**ollama 地址解析收口成"一扇门"** —— 新增 `core/ollama_endpoint.py` 作为唯一属主:
- `normalize_ollama_url()`:空/None/纯空白 → `http://localhost:11434`;缺协议头(`localhost:11434`)→ 补 `http://`;去尾斜杠。
- `resolve_ollama_base_url()`:显式传入(面板值)> 环境变量 `OLLAMA_URL` > 默认,任一层为空都继续兜底,绝不放空 URL 出门。
- 消费端全部改为委派该模块:`hardware_aware_multimodal_router`、`model_selection`、`routes/models`、`audio_pipeline`、`local_brain_manager`(`_normalize_ollama_url` 保留为薄封装,兼容测试与旧调用点)、`multi_llm_router`(`ProviderConfig.__post_init__` + `OllamaAdapter` 调用点)。

> 根因:`.env.example` 生成 `OLLAMA_URL=`(空串),`os.environ.get("OLLAMA_URL", 默认)` 在**键存在但为空**时返回 `""` 而非默认值。此前十几处各写各的兜底,只要一处漏掉就复活报错。现在只有一套标准。

**Windows 崩溃类续排查(保持已修状态)**:
- 启动器 `loop.add_signal_handler` 在 ProactorEventLoop 上 `NotImplementedError` → try/except 回退到 `signal.signal`。
- daemon 主循环 `signum == signal.SIGHUP` 在无 SIGHUP 平台崩溃 → `getattr(signal, "SIGHUP", None)` 守卫。
- sandbox `preexec_fn` 仅在 `_RESOURCE_AVAILABLE` 时传入(Windows `ValueError`)。
- 7 个节点 `subprocess text=True` 捕获补 `encoding="utf-8"`(cp1252 解码 UTF-8 中文崩溃)。

## 验证(克隆到使用全链路)

以 `OLLAMA_URL=""` 精确复现 `.env.example` 场景:
- 所有 ollama 消费端(hardware_aware / local_brain / ProviderConfig / audio_pipeline / 唯一属主)均返回合法带协议头 URL,含 `localhost:11434` 无协议头输入。
- 启动导入链 `import main; import unified_launcher` 干净无报错。
- 22 项 ollama 回归测试全绿(`test_ollama_url_empty_guard` / `test_env_empty_values_and_electron_intact` / `test_local_brain_ollama_readiness`)。

## 备注

若真机拉取最新代码后仍报同一 ollama URL 错误,请在项目根目录执行以下自检——报 `ModuleNotFoundError` 即说明运行的仍是旧代码(镜像未同步),而非本 PR 未修复:

```
python -c "from core.ollama_endpoint import resolve_ollama_base_url; print('OK:', resolve_ollama_base_url())"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_