### PR TITLE
feat(diag): 静默 URL 哨兵 — 定位 "Request URL is missing protocol" 真凶

### DIFF
--- a/core/ollama_url_sentinel.py
+++ b/core/ollama_url_sentinel.py
@@ -1,0 +1,109 @@
+"""core/ollama_url_sentinel.py — 静默 URL 哨兵(缺协议头请求的定位器)
+=================================================================
+
+**它是什么:** 给 ``httpx`` 的 ``send`` 加一层【只观测、不干预】的薄壳。任何
+【缺 ``http://`` / ``https://`` 协议头】的请求 URL —— 也就是那个真机反复出现的
+``Request URL is missing an 'http://' or 'https://' protocol`` 的根源 —— 一旦出现,
+就把**精确的调用栈(file:line)**记进日志,方便一眼定位是哪一处漏网站点。
+
+**设计约束(务必满足):**
+
+- **零行为影响 / 不影响主进程**:安装、检查、日志全部包在 ``try/except`` 里,任何
+  异常都吞掉;请求照常交给原始 ``send`` 执行、原来的异常照常抛出。哨兵只是在旁边
+  记一笔,绝不改变任何请求结果,也绝不让哨兵自身把主流程带崩。
+- **隐蔽 / 平时不显现**:没问题时**零输出**;只有真的抓到缺协议头 URL 才
+  ``logger.warning`` 一次,并且**按调用点去重**——同一处只报一次,不刷屏。
+- **幂等**:重复 :func:`install` 只装一次;不会二次包裹。
+- **可关**:``GALAXY_URL_SENTINEL=0``(或 false/no/off)即禁用,默认开。
+"""
+from __future__ import annotations
+
+import logging
+import os
+import traceback
+from typing import Set
+
+logger = logging.getLogger("Galaxy.UrlSentinel")
+
+_INSTALLED = False
+_seen: Set[str] = set()
+
+
+def _url_missing_scheme(url) -> bool:
+    """URL 是否缺 http(s):// 协议头(任何异常都视为『不是』,绝不误伤主流程)。"""
+    try:
+        s = str(url)
+    except Exception:  # noqa: BLE001
+        return False
+    return bool(s) and not s.startswith(("http://", "https://"))
+
+
+def _report(url) -> None:
+    """把缺协议头 URL 的调用栈记一条日志(按调用点去重、全程静默兜底)。"""
+    try:
+        frames = traceback.format_stack()[:-2]  # 去掉哨兵自身两帧
+        stack = "".join(frames)
+        # 用栈末尾几帧当去重键:同一处只报一次
+        key = "\n".join(stack.strip().splitlines()[-6:])
+        if key in _seen:
+            return
+        _seen.add(key)
+        logger.warning(
+            "[URL-SENTINEL] 抓到缺协议头的请求 URL: %r —— 这正是 "
+            "\"Request URL is missing an 'http://' or 'https://' protocol\" 的根源。"
+            "以下调用栈最下方即罪魁 file:line:\n%s",
+            str(url),
+            stack,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def install() -> None:
+    """幂等安装 httpx.send 观测层。任何异常都静默吞掉,绝不影响主进程。"""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    if os.environ.get("GALAXY_URL_SENTINEL", "1").strip().lower() in (
+        "0", "false", "no", "off",
+    ):
+        _INSTALLED = True  # 明确禁用,记为已处理,后续不再尝试
+        return
+    try:
+        import httpx
+    except Exception:  # noqa: BLE001
+        return  # 没有 httpx 就无从观测,静默退出
+
+    try:
+        _orig_sync = httpx.Client.send
+        _orig_async = httpx.AsyncClient.send
+
+        # 已被包裹过就不再包(幂等,防二次安装叠加)
+        if getattr(_orig_sync, "_galaxy_url_sentinel", False):
+            _INSTALLED = True
+            return
+
+        def _sync_send(self, request, *args, **kwargs):
+            try:
+                if _url_missing_scheme(getattr(request, "url", "")):
+                    _report(request.url)
+            except Exception:  # noqa: BLE001
+                pass
+            return _orig_sync(self, request, *args, **kwargs)
+
+        async def _async_send(self, request, *args, **kwargs):
+            try:
+                if _url_missing_scheme(getattr(request, "url", "")):
+                    _report(request.url)
+            except Exception:  # noqa: BLE001
+                pass
+            return await _orig_async(self, request, *args, **kwargs)
+
+        _sync_send._galaxy_url_sentinel = True  # type: ignore[attr-defined]
+        _async_send._galaxy_url_sentinel = True  # type: ignore[attr-defined]
+        httpx.Client.send = _sync_send  # type: ignore[method-assign]
+        httpx.AsyncClient.send = _async_send  # type: ignore[method-assign]
+        _INSTALLED = True
+    except Exception:  # noqa: BLE001
+        # 装不上也无所谓,主进程照常运行
+        pass

--- a/main.py
+++ b/main.py
@@ -284,6 +284,15 @@ if not logging.getLogger().handlers:
     )
 logger = logging.getLogger("Galaxy")
 
+# 静默 URL 哨兵:给 httpx 加一层【只观测、不干预】的薄壳,任何缺 http(s):// 协议头的
+# 请求 URL(那个 "Request URL is missing protocol" 的根源)一出现就把精确调用栈记进日志。
+# 平时零输出、零行为影响;装不上也静默兜底,绝不影响主进程。
+try:
+    from core.ollama_url_sentinel import install as _install_url_sentinel
+    _install_url_sentinel()
+except Exception:  # noqa: BLE001
+    pass
+
 # Health / validation tracking (non-strict mode diagnostics)
 _health_status: str = "unknown"
 _failed_validations: list = []

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -127,6 +127,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger("Galaxy")
 
+# 静默 URL 哨兵(见 core/ollama_url_sentinel):只观测不干预,缺协议头请求 URL 一出现
+# 就记精确调用栈;平时零输出、零行为影响,装不上也静默兜底。桌面壳走 unified_launcher
+# 入口时同样武装,不依赖 main.py 是否被导入。
+try:
+    from core.ollama_url_sentinel import install as _install_url_sentinel
+    _install_url_sentinel()
+except Exception:  # noqa: BLE001
+    pass
+
 
 # ============================================================================
 # 终端颜色和打印工具 — 从 core/ascii_art 导入规范实现


### PR DESCRIPTION
## 背景

真机反复出现 ollama 的 `Request URL is missing an 'http://' or 'https://' protocol` 警告。但对**合并后的当前 main** 用 httpx 拦截器实测:在 `OLLAMA_URL` 取【空 / 无协议头 `localhost:11434` / 纯空格 / 带尾斜杠 IP】等各种配置下,所有 ollama 探测入口(`routes/models`、`local_brain`、`hardware_aware`、`audio_pipeline`、`model_selection`、路由 discovery)构造出的 URL **无一缺协议头**(0 处)。即:警告并非当前后端代码所发,真凶在别处(旧镜像进程 / 某 node 服务 / 前端缓存 / 我未覆盖的站点)。

为在**真机上一次性钉死真凶**,加一个静默 URL 哨兵,把这个偶发、难复现的警告变成一条**精确到 file:line** 的日志。

## 改动

**`core/ollama_url_sentinel.py`(新增)** — 给 `httpx.Client/AsyncClient.send` 加一层【只观测、不干预】的薄壳:任何缺 `http(s)://` 协议头的请求 URL 一出现,就把完整调用栈(最下方即罪魁 file:line)记一条 `logger.warning`。硬约束:

- **零行为影响 / 不影响主进程**:请求照常交原始 `send` 执行、原异常照常抛出;安装 / 检查 / 日志全程 `try/except` 兜底,任何异常都吞掉,绝不把主流程带崩。
- **隐蔽 / 平时不显现**:没问题时**零输出**;只有真抓到才记一次,并**按调用点去重**,不刷屏。
- **幂等**:重复 `install()` 只装一次、不二次包裹。
- **可关**:`GALAXY_URL_SENTINEL=0` 即禁用(默认开)。

**`main.py` / `unified_launcher.py`** — 在各自 logger 就绪后静默 `install()`,两个入口(`python main.py` 与桌面壳)都武装。

## 自测

- 好 URL(`http://…`)→ 哨兵不误报,行为不变;
- 坏 URL(`localhost:11434/…` 无协议头)→ 记录精确调用栈,且原 `UnsupportedProtocol` 异常照常抛出;
- 重复 `install()` 幂等;`import main` / `import unified_launcher` 干净、哨兵已武装、零输出。

## 用法

平时无感。若真机再冒出那条 ollama 警告,日志里会同时出现一条 `[URL-SENTINEL] 抓到缺协议头的请求 URL: …` + 调用栈——把那段发出来即可精准定位并收口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_