### PR TITLE
本地脑 URL 拼接点消费端钢板 + 自取证日志(真机哨兵二次实证跟进)

### DIFF
--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -297,7 +297,8 @@ class LocalBrainManager:
                 import httpx
 
                 resp = httpx.get(
-                    f"{self.ollama_url}/api/tags", timeout=3.0
+                    f"{self._hardened_base_url('_auto_select_backend')}/api/tags",
+                    timeout=3.0,
                 )
                 if resp.status_code == 200:
                     logger.info(
@@ -482,7 +483,10 @@ class LocalBrainManager:
             try:
                 import httpx
                 async with httpx.AsyncClient(timeout=10.0) as client:
-                    await client.delete(f"{self.ollama_url}/api/delete", json={"name": ""}, timeout=5.0)
+                    await client.delete(
+                        f"{self._hardened_base_url('_probe_delete')}/api/delete",
+                        json={"name": ""}, timeout=5.0,
+                    )
             except Exception as exc:
                 logger.debug("Ollama cleanup delete failed: %s", exc)
 
@@ -612,7 +616,7 @@ class LocalBrainManager:
             import httpx
             async with httpx.AsyncClient(timeout=60.0) as client:
                 resp = await client.delete(
-                    f"{self.ollama_url}/api/delete",
+                    f"{self._hardened_base_url('_delete_model')}/api/delete",
                     json={"name": model_name},
                     timeout=30.0,
                 )
@@ -715,12 +719,37 @@ class LocalBrainManager:
 
     # ───────── 内部方法 ─────────
 
+    def _hardened_base_url(self, call_site: str) -> str:
+        """调用点级钢板 + 自取证:真机哨兵仍抓到本类发出缺协议头请求(镜像版本
+        与主干在兜底层可能不一致/或环境注入怪值),而调用栈照不到 property 内部。
+        这里在【消费端】再归一一次;若发现归一前后不一致,把原始值 repr + 环境
+        变量 repr 打进日志——下次复现时罪魁真值自己现形,不再靠猜。"""
+        raw = ""
+        try:
+            raw = self.ollama_url  # property(读时归一)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[URL-取证:%s] 读 ollama_url 属性即异常: %r", call_site, exc)
+        try:
+            from core.ollama_endpoint import normalize_ollama_url
+            base = normalize_ollama_url(raw)
+        except Exception:  # noqa: BLE001
+            base = raw if str(raw).startswith(("http://", "https://")) else "http://localhost:11434"
+        if base != raw:
+            logger.warning(
+                "[URL-取证:%s] ollama_url 读出异常值 raw=%r(归一后=%r);"
+                "os.environ['OLLAMA_URL']=%r, _ollama_url=%r —— 请把本行日志发回排查。",
+                call_site, raw, base,
+                os.environ.get("OLLAMA_URL"), getattr(self, "_ollama_url", None),
+            )
+        return base
+
     async def _ping_ollama(self) -> bool:
         """Ping Ollama 服务"""
         try:
             import httpx
+            base = self._hardened_base_url("_ping_ollama")
             async with httpx.AsyncClient(timeout=3.0) as client:
-                resp = await client.get(f"{self.ollama_url}/api/tags")
+                resp = await client.get(f"{base}/api/tags")
                 return resp.status_code == 200
         except Exception as exc:
             logger.debug("Ollama health check failed: %s", exc)
@@ -831,7 +860,7 @@ class LocalBrainManager:
         try:
             import httpx
             async with httpx.AsyncClient(timeout=5.0) as client:
-                resp = await client.get(f"{self.ollama_url}/api/tags")
+                resp = await client.get(f"{self._hardened_base_url('_list_models')}/api/tags")
                 if resp.status_code == 200:
                     data = resp.json()
                     self.available_models = [
@@ -847,7 +876,7 @@ class LocalBrainManager:
             import httpx
             async with httpx.AsyncClient(timeout=300.0) as client:
                 resp = await client.post(
-                    f"{self.ollama_url}/api/pull",
+                    f"{self._hardened_base_url('_pull_model')}/api/pull",
                     json={"name": model_name, "stream": False},
                 )
                 if resp.status_code == 200:


### PR DESCRIPTION
## 背景

真机(Windows,gitee 镜像克隆)URL 哨兵再次抓到 `local_brain_manager` 发出 `request.url='/'` 的缺协议头请求(`_auto_select_backend:299` / `_ping_ollama:723`)。但三重实证表明**当前主干代码不可能产生该现象**:

1. `ollama_url` property 读时归一(空→默认)——容器实测正确;
2. `normalize_ollama_url` 空值路径实测正确;
3. httpx 0.28.1(与真机**逐帧行号核对**同版)下 `f"{X}/api/tags"` 无论 X 为何值都渲染不出 `'/'`(穷举实测)。

矛盾指向:镜像文件与主干在**栈照不到的区域**(property/normalize 层)不一致,或运行环境注入怪值。gitee 对本环境 403,无法远程取证。

## 对策(治标 + 取证一体)

- **`_hardened_base_url(call_site)`**:消费端再归一一次,任何来源的坏值都出不了门;若归一前后不一致,把 `raw` repr + `os.environ['OLLAMA_URL']` repr + `_ollama_url` repr 打进 WARNING——**下次真机复现时罪魁真值自己现形,不再靠猜**。
- 本文件全部 **5 处** `f"{self.ollama_url}/..."` 直拼站点统一改走钢板(`_auto_select_backend` / `_ping_ollama` / `_probe_delete` / `_delete_model` / `_list_models` / `_pull_model`)。
- 正常路径零行为差异、零日志。

## 测试
- 自测:正常路径钢板透明;模拟坏 property(空串)→ 归一为默认 + 取证日志含全部三个 repr;
- local_brain/ollama 相关 42 测全过;
- lint 违规数与 main 持平(零新增)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_