### PR TITLE
根因修复:dotenv 把「空值+行内注释」当值——21 个 env 键被静默投毒(URL 悬案告破)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,8 @@ GALAXY_SYSTEM_MODE=desktop-local          # desktop-local | desktop-cross-device
 # When GALAXY_SYSTEM_MODE=desktop-cross-device this defaults to true.
 # Setting GALAXY_NATS_URL also implicitly enables NATS regardless of mode.
 GALAXY_NATS_ENABLED=false                 # false | true
-GALAXY_NATS_URL=                          # e.g. nats://localhost:4222
+# e.g. nats://localhost:4222
+GALAXY_NATS_URL=
 # Launcher post-start health: if NATS TCP is closed, that is warning-only on
 # desktop-local noop bus; set GALAXY_FABRIC_STRICT=true or GALAXY_NATS_ENABLED=true
 # to treat unreachable NATS as a failed check.
@@ -41,7 +42,8 @@ GALAXY_CROSS_DEVICE_ENABLED=false         # false | true
 
 # Transport priority: comma-separated ordered list.
 # Defaults: lan,internet (desktop-local)  or  tailscale,lan,internet (cross-device).
-GALAXY_TRANSPORT_PRIORITY=                # e.g. tailscale,lan,internet
+# e.g. tailscale,lan,internet
+GALAXY_TRANSPORT_PRIORITY=
 
 # ============================================================================
 # Runtime Mode
@@ -100,7 +102,8 @@ GALAXY_CLIP_MODEL=clip-ViT-B-32          # CLIP 模型(sentence-transformers)
 GALAXY_CLIP_DIR=./data/clip_memory       # CLIP 图像记忆持久化目录
 GALAXY_CLAP_MODEL=laion/clap-htsat-unfused  # CLAP 模型(transformers)
 GALAXY_CLAP_DIR=./data/clap_memory       # CLAP 音频记忆持久化目录
-GALAXY_SIMPLEMEM_API_KEY=               # SimpleMem 用的 OpenAI 兼容 key(留空=该后端不启用)
+# SimpleMem 用的 OpenAI 兼容 key(留空=该后端不启用)
+GALAXY_SIMPLEMEM_API_KEY=
 GALAXY_SIMPLEMEM_MODEL=gpt-4o-mini
 GALAXY_SIMPLEMEM_BASE_URL=
 # 向量后端选择(被 "vector" 使用): auto | local | chroma | qdrant
@@ -146,8 +149,10 @@ GALAXY_REQUIRE_API_TOKEN=false           # true | false — see notes above
 # TLS/HTTPS for the gateway server.
 # Both cert and key must be set to enable HTTPS; otherwise plain HTTP is used.
 # Paths are relative to the working directory or absolute.
-GALAXY_TLS_CERT=                        # e.g. /etc/ssl/certs/galaxy.crt
-GALAXY_TLS_KEY=                         # e.g. /etc/ssl/private/galaxy.key
+# e.g. /etc/ssl/certs/galaxy.crt
+GALAXY_TLS_CERT=
+# e.g. /etc/ssl/private/galaxy.key
+GALAXY_TLS_KEY=
 
 # Pickle serialization secret (external/memos)
 PICKLE_SECRET_KEY=your_secure_random_secret_key_here
@@ -253,17 +258,23 @@ BOCHA_API_KEY=
 # ============================================================================
 # Local LLM (optional)
 # ============================================================================
-OLLAMA_URL=                             # e.g. http://localhost:11434
-VLLM_API_BASE=                          # e.g. http://localhost:8000/v1
+# e.g. http://localhost:11434
+OLLAMA_URL=
+# e.g. http://localhost:8000/v1
+VLLM_API_BASE=
 VLLM_API_KEY=
 
 # ============================================================================
 # LLM Model Selection (optional)
 # ============================================================================
-DEFAULT_MODEL=                          # Default model for general tasks
-CODE_MODEL=                             # Model for code generation
-SIMPLE_MODEL=                           # Model for simple queries
-COMPLEX_MODEL=                          # Model for complex reasoning
+# Default model for general tasks
+DEFAULT_MODEL=
+# Model for code generation
+CODE_MODEL=
+# Model for simple queries
+SIMPLE_MODEL=
+# Model for complex reasoning
+COMPLEX_MODEL=
 
 # ============================================================================
 # Server & Network
@@ -300,8 +311,10 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8085,http://localhos
 # ============================================================================
 # Database URLs
 # ============================================================================
-DATABASE_URL=                           # Main database connection string
-REDIS_URL=                              # Redis connection URL (e.g. redis://localhost:6379)
+# Main database connection string
+DATABASE_URL=
+# Redis connection URL (e.g. redis://localhost:6379)
+REDIS_URL=
 REDIS_HOST=localhost
 REDIS_PORT=6379
 
@@ -316,17 +329,23 @@ POSTGRES_DATABASE=
 # WebRTC / ICE connectivity (optional)
 # ============================================================================
 # Comma-separated STUN server URLs exposed via /api/v1/webrtc/endpoint
-GALAXY_STUN_URLS=                       # e.g. stun:stun.l.google.com:19302
+# e.g. stun:stun.l.google.com:19302
+GALAXY_STUN_URLS=
 
 # Comma-separated TURN server URLs exposed via /api/v1/webrtc/endpoint
-GALAXY_TURN_URLS=                       # e.g. turn:turn.example.com:3478
-GALAXY_TURN_USERNAME=                   # TURN credential username
-GALAXY_TURN_CREDENTIAL=                 # TURN credential password
+# e.g. turn:turn.example.com:3478
+GALAXY_TURN_URLS=
+# TURN credential username
+GALAXY_TURN_USERNAME=
+# TURN credential password
+GALAXY_TURN_CREDENTIAL=
 
 # Tailscale — set to true when this gateway node is on a Tailscale tailnet
 GALAXY_TAILSCALE_ENABLED=false
-GALAXY_TAILSCALE_HOST=                  # e.g. galaxy-gateway.example-tailnet.ts.net
-GALAXY_TAILSCALE_TAG=                   # e.g. tag:galaxy-gateway
+# e.g. galaxy-gateway.example-tailnet.ts.net
+GALAXY_TAILSCALE_HOST=
+# e.g. tag:galaxy-gateway
+GALAXY_TAILSCALE_TAG=
 
 # ============================================================================
 # Node Service URLs (optional — for remote node communication)
@@ -347,7 +366,8 @@ CODE_SERVICE_URL=http://localhost:8101
 # ============================================================================
 FEDERATION_ENABLED=false
 FEDERATION_LOCAL_HOST=
-FEDERATION_PEERS=                       # Comma-separated peer URLs
+# Comma-separated peer URLs
+FEDERATION_PEERS=
 
 # ============================================================================
 # Concurrency & Performance
@@ -359,7 +379,8 @@ RATE_LIMIT_WINDOW_SECONDS=60
 # ============================================================================
 # External Services (optional)
 # ============================================================================
-GITHUB_TOKEN=                           # GitHub personal access token (raises rate limit to 5000/h)
+# GitHub personal access token (raises rate limit to 5000/h)
+GITHUB_TOKEN=
 BRAVE_API_KEY=
 OPENWEATHERMAP_API_KEY=
 

--- a/core/ollama_endpoint.py
+++ b/core/ollama_endpoint.py
@@ -26,14 +26,20 @@ OLLAMA_DEFAULT_URL = "http://localhost:11434"
 
 
 def normalize_ollama_url(raw: Optional[str]) -> str:
-    """把任意 ollama 地址输入归一为合法 URL(空/缺协议头都兜底)。
+    """把任意 ollama 地址输入归一为合法 URL(空/缺协议头/垃圾值都兜底)。
 
     - 空 / None / 纯空白  → ``http://localhost:11434``
     - ``localhost:11434`` → ``http://localhost:11434``(补协议头)
     - ``http(s)://...``   → 原样(去尾部斜杠)
+    - **垃圾值**(含空白符、或以 ``#`` 开头)→ 默认地址。真机根因:python-dotenv
+      会把「``OLLAMA_URL=   # e.g. http://...``」这种【空值+行内注释】整段注释当成
+      值('# e.g. http://localhost:11434'),此前本函数给它补协议头后变成
+      ``http://# e.g. ...``——以 http:// 开头骗过全部 startswith 检查,httpx 却把
+      # 后全解析成 fragment、host 为空,最终发出缺协议头请求。URL 里不可能有
+      裸空格、也不可能以 # 开头,一律判垃圾回落默认。
     """
     val = (raw or "").strip()
-    if not val:
+    if not val or val.startswith("#") or any(ch.isspace() for ch in val):
         return OLLAMA_DEFAULT_URL
     if not val.startswith(("http://", "https://")):
         val = f"http://{val}"

--- a/core/ollama_url_sentinel.py
+++ b/core/ollama_url_sentinel.py
@@ -39,7 +39,9 @@ def _culprit_frame(frames: List[str]) -> str:
     里的应用代码帧(也就是真正拿着坏 URL 去发请求的那处)。取不到就返回空串。"""
     try:
         for line in reversed(frames):
-            low = line.lower()
+            # 统一分隔符再匹配:Windows 栈里是 site-packages\httpx\_client.py,
+            # 只查 "/httpx/" 会漏排 → 界面上"罪魁"显示成 httpx 内部帧(真机复现)。
+            low = line.lower().replace("\\", "/")
             if "/httpx/" in low or "ollama_url_sentinel" in low:
                 continue
             # traceback.format_stack 的帧首行形如:  File "xxx.py", line N, in fn

--- a/main.py
+++ b/main.py
@@ -22,8 +22,12 @@ try:
     # missing an 'http://' or 'https://' protocol"、Ollama 明明在跑却判"服务
     # 未响应/模型未就绪")、Redis "must specify scheme"、NATS "invalid
     # hostname"。这里改为只加载【非空】值,空值视同未配置,让代码默认值生效。
+    # 另一类毒值:python-dotenv 会把「KEY=   # 注释」这种【空值+行内注释】整段
+    # 注释当成值(实测 1.2.2:OLLAMA_URL= # e.g. http://... → '# e.g. http://...'),
+    # 经 normalize 补协议头后变成 http://#... 的怪 URL,骗过全部 startswith 检查。
+    # 值以 # 开头一律视同未配置(合法配置值不可能以 # 开头)。
     for _k, _v in (dotenv_values(_env_path) or {}).items():
-        if _v and _k not in os.environ:
+        if _v and not _v.lstrip().startswith("#") and _k not in os.environ:
             os.environ[_k] = _v
 except Exception:
     pass

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -31,7 +31,8 @@ try:
     for _k, _v in (_dotenv_values(
         _os.path.join(_os.path.dirname(_os.path.abspath(__file__)), ".env")
     ) or {}).items():
-        if _v and _k not in _os.environ:
+        # 值以 # 开头 = dotenv 把「空值+行内注释」整段当值(毒值),视同未配置
+        if _v and not _v.lstrip().startswith("#") and _k not in _os.environ:
             _os.environ[_k] = _v
 except Exception:
     pass


### PR DESCRIPTION
## 悬案告破(100% 复现)

真机(Windows 全新克隆)哨兵抓到的 `request.url='/'` 缺协议头请求,根因锁定:

**python-dotenv(实测 1.2.2)对「`KEY=   # 注释`」这种【空值+行内注释】行,会把整段注释当成值。**

`.env` 从 `.env.example` 生成后:
```
OLLAMA_URL = '# e.g. http://localhost:11434'
```
`normalize` 见它非空、无协议头 → 补成 `'http://# e.g. ...'` —— **以 `http://` 开头,骗过 property/钢板/哨兵调用点的全部 startswith 检查**(所以 #1473 的取证日志一声不吭);httpx 解析时 `#` 后全成 fragment、host 为空,最终发出缺协议头请求。

**`.env.example` 里共 21 个键中此毒**(OLLAMA_URL / DATABASE_URL / REDIS_URL / GALAXY_NATS_URL / GITHUB_TOKEN / TLS 路径 / STUN / TURN / 模型名等)——每次全新安装都在被静默投毒。

## 四层修复

1. **`.env.example`**:21 行行内注释全部上移为独立注释行,值行干净收尾;dotenv 复检全部解析为 `''`;
2. **`main.py` / `unified_launcher.py` 加载环解毒**:值以 `#` 开头视同未配置——医治用户机上**已生成的中毒 `.env`**(它不会被重建,只改模板救不了存量);
3. **`normalize_ollama_url` 垃圾值判定**:含空白符或以 `#` 开头 → 默认地址(URL 不可能含裸空格/以 # 开头);正常值不受影响;
4. **哨兵 `_culprit_frame`** 统一路径分隔符再匹配——Windows 栈是 `site-packages\httpx\`,只查 `/httpx/` 漏排,界面"罪魁"错显 httpx 内部帧(真机复现)。

## 验证
- 毒值全链复现(env→property→钢板→ping):修复后 URL 恢复默认、哨兵零告警;
- normalize 垃圾/正常值 4 例;加载环解毒;罪魁帧 Windows 路径压缩;
- ollama/local_brain/env 相关套件 61 过,唯一失败与干净 main 逐条一致(既有)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_