### PR TITLE
feat: Ollama 原生工具打通 + 延迟优化 + IndexTTS2 + 三态一致性根修 + 任务成本账本

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -470,6 +470,13 @@ GALAXY_TOOLS_SLIM=auto
 # 瘦身阈值(同时也是挑选上限);核心工具(记忆召回/问人)永不裁
 GALAXY_TOOLS_MAX=24
 
+# ── 任务成本账本(北极星=任务总消耗,不是单次 TPS)──────────────────
+# 每次请求聚合一张账单(LLM 次数/总 token/工具数/轮数/墙钟),日志一行可读,
+# 并追加到 JSONL(长期积累,亦是将来微调专属小模型的原料);off 关闭落盘
+GALAXY_TASK_LEDGER_PATH=data/task_cost_ledger.jsonl
+# ReAct 每轮生成的输出 token 预算(本地 CPU 上输出 token≈等待秒数)
+GALAXY_MAX_TOKENS_ANSWER=4096
+
 # ── IndexTTS2 质量档(零样本音色克隆+情绪控制;B站 IndexSpeech 开源)────
 # 注意: 自回归大模型,CPU 合成一句需数秒到数十秒——适合旁白/有声内容/情绪
 # 演绎,实时对话请留在 edge/kokoro。启用: pip install indextts + 下载权重

--- a/.env.example
+++ b/.env.example
@@ -447,14 +447,48 @@ CUSTOM_LOGGER_TOKEN=
 # 语音输出(TTS)与延迟优化(2026-07 A→C→B 批次)
 # ============================================================================
 # TTS 引擎: edge(默认,联网音质好) | kokoro(离线82M·纯CPU快于实时·中文) |
-# melo | piper | sapi(Windows自带零依赖) | auto。运行期失败自动降级换引擎。
+# melo | piper | sapi(Windows自带零依赖) | indextts(质量档,见下) | auto。
+# 运行期失败自动降级换引擎。
 GALAXY_TTS_ENGINE=edge
 # Kokoro 模型自动拉取(约310MB,经 huggingface_hub,支持 HF_ENDPOINT 镜像);0 关闭
 GALAXY_KOKORO_AUTOFETCH=1
 # Ollama 模型常驻(-1=不卸载,根治冷启动;可设 30m 等时长)
 GALAXY_OLLAMA_KEEP_ALIVE=-1
+# Ollama 上下文窗口: 显式设置避免超默认 4096 后滑窗截断→前缀缓存全废→
+# 每轮全量重预填(CPU 机"越聊越慢"的元凶之一)。0=不传(用模型默认)
+GALAXY_OLLAMA_NUM_CTX=8192
 # 高性能事件循环(Windows: winloop / 其它: uvloop);0 用系统默认
 GALAXY_FAST_LOOP=1
+
+# ── 上下文修剪(对话层延迟优化,零 LLM 成本)──────────────────────────
+# 单条工具结果注入上限(头+尾保留式截断,结论不丢)
+GALAXY_TOOL_RESULT_MAX_CHARS=4000
+# ReAct 保留最近 N 轮完整工具结果,更早的大结果换短存根;0 关闭
+GALAXY_TOOL_PRUNE_KEEP_ROUNDS=3
+# 工具定义瘦身: auto(默认)=数量超阈值才按相关性挑选,阈值内原样不动; off 关闭
+GALAXY_TOOLS_SLIM=auto
+# 瘦身阈值(同时也是挑选上限);核心工具(记忆召回/问人)永不裁
+GALAXY_TOOLS_MAX=24
+
+# ── IndexTTS2 质量档(零样本音色克隆+情绪控制;B站 IndexSpeech 开源)────
+# 注意: 自回归大模型,CPU 合成一句需数秒到数十秒——适合旁白/有声内容/情绪
+# 演绎,实时对话请留在 edge/kokoro。启用: pip install indextts + 下载权重
+# (数 GB: hf download IndexTeam/IndexTTS-2 --local-dir=models/indextts2,
+# 支持 HF_ENDPOINT 镜像) + 设 GALAXY_TTS_ENGINE=indextts。
+# 参考音频(必填): 一段目标音色的 wav,零样本克隆的音色来源
+# GALAXY_INDEXTTS_REF_AUDIO=C:\path\to\voice.wav
+# 模型目录(默认 models/indextts2)
+# GALAXY_INDEXTTS_DIR=models/indextts2
+# 后台自动拉取权重(数 GB,默认关;1 开启)
+GALAXY_INDEXTTS_AUTOFETCH=0
+# 情绪控制(README 官方四种方式,均可选):
+# GALAXY_INDEXTTS_EMO_AUDIO=   情绪参考音频(方式A)
+# GALAXY_INDEXTTS_EMO_TEXT=    独立情绪文本描述,与台词解耦(方式D)
+# GALAXY_INDEXTTS_USE_EMO_TEXT=1  由台词语义自动推断情绪(方式C)
+# 情绪强度(官方建议 0.6)
+GALAXY_INDEXTTS_EMO_ALPHA=0.6
+# 显存紧张时启用 fp16(GPU 场景)
+GALAXY_INDEXTTS_FP16=0
 
 # ============================================================================
 # 阈限态预演(Gecko 借鉴: 真实执行前在状态化模拟环境中试错)

--- a/core/context_trim.py
+++ b/core/context_trim.py
@@ -1,0 +1,141 @@
+"""core/context_trim.py — 对话上下文修剪(延迟优化·对话层)
+================================================================
+
+CPU 本地模型的延迟大头是 prompt 预填(prefill)。本模块提供三个纯函数,
+把每轮喂给模型的字节数压到"刚好够用":
+
+  1. :func:`clip_tool_result` — 工具结果**插入时**截断(头+尾保留,中段
+     打标记丢弃)。只在插入时截,之后不再动它——事中改写历史会作废 Ollama
+     的前缀 KV 缓存,省的不如重预填花的多。
+  2. :func:`prune_stale_tool_results` — ReAct 长任务里,早期轮次的工具结果
+     模型早已消化(结论体现在其后的推理里),第 N 轮还全文携带纯属浪费。
+     保最近 K 轮完整,更早的大结果换成短存根(OpenClaw 的 TTL/Claude Code
+     的 snip 思路)。只剪"够大"的,小结果不值得为它破坏前缀缓存。
+  3. :func:`slim_tools` — 工具定义瘦身(auto 档):工具数超阈值才按与本次
+     请求的词法相关性挑 top-K,核心工具(记忆召回/问人)始终保留。
+     阈值内**原样返回**(零行为变化)——质量优先,只防御病态膨胀。
+
+全部零 LLM 成本、零 IO;开关与阈值均可 env 调。
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, List
+
+# 始终保留的核心工具(与具体任务无关的"元能力")
+_CORE_TOOL_MARKERS = ("memory__", "ask_human__")
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# 1. 工具结果插入截断
+# ---------------------------------------------------------------------------
+
+def clip_tool_result(text: str, max_chars: int = 0) -> str:
+    """头+尾保留式截断:长工具输出的结论常在末尾(exit code/汇总行),
+    纯 ``[:N]`` 会把它切没。默认上限 GALAXY_TOOL_RESULT_MAX_CHARS=4000。"""
+    limit = max_chars or _env_int("GALAXY_TOOL_RESULT_MAX_CHARS", 4000)
+    if limit <= 0 or len(text) <= limit:
+        return text
+    head = int(limit * 0.75)
+    tail = limit - head
+    return (
+        f"{text[:head]}\n…[中段已修剪,原文共 {len(text)} 字]…\n{text[-tail:]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. ReAct 老轮次工具结果修剪
+# ---------------------------------------------------------------------------
+
+def prune_stale_tool_results(
+    messages: List[Dict[str, Any]],
+    keep_rounds: int = 0,
+    min_chars: int = 500,
+) -> int:
+    """原地把"最近 keep_rounds 轮之外"的大工具结果换成短存根,返回修剪条数。
+
+    轮次边界 = 带 tool_calls 的 assistant 消息。GALAXY_TOOL_PRUNE_KEEP_ROUNDS
+    默认 3;设 0 关闭。只剪 >min_chars 的(小结果不值得作废前缀缓存);
+    存根保留开头片段,模型仍知道"当时拿到过什么",需要时可重新调用。
+    """
+    keep = keep_rounds or _env_int("GALAXY_TOOL_PRUNE_KEEP_ROUNDS", 3)
+    if keep <= 0:
+        return 0
+    round_starts = [
+        i for i, m in enumerate(messages)
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    if len(round_starts) <= keep:
+        return 0
+    cutoff = round_starts[-keep]  # 此下标之前的轮次为"老轮次"
+    pruned = 0
+    for m in messages[:cutoff]:
+        if not (isinstance(m, dict) and m.get("role") == "tool"):
+            continue
+        content = m.get("content")
+        if not isinstance(content, str) or len(content) <= min_chars:
+            continue
+        m["content"] = (
+            f"[早期工具结果已修剪·原 {len(content)} 字,要点见其后推理;"
+            f"如需原文请重新调用] {content[:200]}…"
+        )
+        pruned += 1
+    return pruned
+
+
+# ---------------------------------------------------------------------------
+# 3. 工具定义瘦身(auto 档)
+# ---------------------------------------------------------------------------
+
+def _terms_of(text: str) -> set:
+    """查询/工具描述 → 词项集合:ASCII 词 + CJK 双字滑窗(零依赖轻量分词)。"""
+    text = (text or "").lower()
+    terms = set(re.findall(r"[a-z0-9_]{2,}", text))
+    cjk = re.findall(r"[一-鿿]", text)
+    terms.update("".join(p) for p in zip(cjk, cjk[1:]))
+    terms.update(cjk)
+    return terms
+
+
+def slim_tools(
+    tools: List[Dict[str, Any]],
+    query: str,
+    max_tools: int = 0,
+) -> List[Dict[str, Any]]:
+    """工具数 ≤ 阈值时原样返回(零行为变化);超了才按词法相关性挑 top-K。
+
+    GALAXY_TOOLS_SLIM=auto(默认)|off;阈值 GALAXY_TOOLS_MAX=24。
+    核心工具(memory__/ask_human__)始终入选;排序稳定(同分保持原序),
+    不破坏前缀缓存的字节稳定性。
+    """
+    mode = os.environ.get("GALAXY_TOOLS_SLIM", "auto").strip().lower()
+    if mode in ("0", "off", "false", "no"):
+        return tools
+    limit = max_tools or _env_int("GALAXY_TOOLS_MAX", 24)
+    if limit <= 0 or len(tools) <= limit:
+        return tools
+
+    q_terms = _terms_of(query)
+
+    def _score(t: Dict[str, Any]) -> float:
+        fn = t.get("function") or {}
+        name = str(fn.get("name", ""))
+        if any(marker in name for marker in _CORE_TOOL_MARKERS):
+            return float("inf")  # 核心元能力永不裁
+        blob = _terms_of(f"{name} {fn.get('description', '')}")
+        if not q_terms or not blob:
+            return 0.0
+        return len(q_terms & blob) / (len(q_terms) ** 0.5)
+
+    scored = [(_score(t), i, t) for i, t in enumerate(tools)]
+    picked = sorted(scored, key=lambda x: (-x[0], x[1]))[:limit]
+    picked.sort(key=lambda x: x[1])  # 恢复原始相对顺序(前缀字节稳定)
+    return [t for _, _, t in picked]

--- a/core/desktop_presence_runtime.py
+++ b/core/desktop_presence_runtime.py
@@ -93,6 +93,7 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
 import time
 import uuid
 from enum import Enum
@@ -785,6 +786,37 @@ class DesktopPresenceRuntime:
         except Exception as _ph_err:
             logger.debug("policy hint resolution failed (non-fatal): %s", _ph_err)
 
+        # LIMINAL → MANIFEST 的触发点(三态语义对齐):
+        # MANIFEST = 主体开始【真实落手/对外表达】。此前拿到执行车道就立刻
+        # advance——LLM 的整段思考(CPU 机上可达数十秒)全被标成 manifest,
+        # 阈限态几毫秒就被跳过,推演/认知期(含 Gecko 预演)在视觉上不存在。
+        # 现在:流式请求在**第一个 token 流出**的瞬间才进 MANIFEST,思考期
+        # 停留在 LIMINAL(continuum tick 的意图呼吸映射正好驱动"思考中"动画);
+        # 非流式调用保持原时序(advance 后派发)。GALAXY_MANIFEST_ON_FIRST_TOKEN=0
+        # 可整体回退旧行为。
+        def _enter_manifest() -> None:
+            if rsession.tristate is not TriState.LIMINAL:
+                return
+            rsession.advance(TriState.MANIFEST)
+            self._update_presence_mode(
+                tri_state=rsession.tristate.value,
+                task_active=True,
+                sensing_active=bool(multimodal_context) or stream_sensing_active,
+                execution_active=True,
+                user_interaction=source in {"chat", "voice", "operator"},
+            )
+
+        _manifest_sink = None
+        _manifest_orig_on_delta = None
+        if os.environ.get("GALAXY_MANIFEST_ON_FIRST_TOKEN", "1").strip().lower() not in (
+            "0", "false", "no", "off",
+        ):
+            try:
+                from core.llm_stream import current_stream as _current_token_stream
+                _manifest_sink = _current_token_stream()
+            except Exception:  # noqa: BLE001
+                _manifest_sink = None
+
         lane_snapshot = None
         try:
             lane_manager = get_session_execution_lane_manager()
@@ -792,15 +824,19 @@ class DesktopPresenceRuntime:
                 conversation_session_id,
                 control_session_id=control_session_id,
             ) as lane:
-                # LIMINAL → MANIFEST: OpenClawd has branched; subject enters manifest
-                rsession.advance(TriState.MANIFEST)
-                self._update_presence_mode(
-                    tri_state=rsession.tristate.value,
-                    task_active=True,
-                    sensing_active=bool(multimodal_context) or stream_sensing_active,
-                    execution_active=True,
-                    user_interaction=source in {"chat", "voice", "operator"},
-                )
+                if _manifest_sink is not None:
+                    # 首输出驱动:包装 sink 的 on_delta,第一段文本流出即进 MANIFEST。
+                    # 请求结束(下面 finally)恢复原回调,绝不泄漏到请求之外。
+                    _manifest_orig_on_delta = _manifest_sink._on_delta
+
+                    def _hooked_on_delta(text: str, _orig=_manifest_orig_on_delta) -> None:
+                        _enter_manifest()
+                        _orig(text)
+
+                    _manifest_sink._on_delta = _hooked_on_delta
+                else:
+                    # 非流式:保持原时序(LIMINAL → MANIFEST → 派发)
+                    _enter_manifest()
                 _dispatch_presence_runtime_hint = self._current_presence_runtime_hint()
                 _presence_mode = _dispatch_presence_runtime_hint["presence_mode"]
                 _stream_runtime_status = (
@@ -852,6 +888,18 @@ class DesktopPresenceRuntime:
                 "error": str(exc),
             }
         finally:
+            # 恢复被首输出钩子包装的 sink 回调(请求结束后 sink 可能还被
+            # 消费端复用于伪流式兜底,绝不让钩子在死会话上触发)
+            if _manifest_sink is not None and _manifest_orig_on_delta is not None:
+                try:
+                    _manifest_sink._on_delta = _manifest_orig_on_delta
+                except Exception:  # noqa: BLE001
+                    pass
+            # 整个请求零输出(异常/空响应):补齐 canonical 相位序
+            # LIMINAL→MANIFEST→SILENT,下游消费者(审计/跨设备同步)的
+            # 三段轨迹不变——与旧行为等价,不多不少。
+            if rsession.tristate is TriState.LIMINAL:
+                _enter_manifest()
             # MANIFEST → SILENT: subject returns to rest (even on error)
             rsession.advance(TriState.SILENT)
             self._update_presence_mode(

--- a/core/desktop_presence_runtime.py
+++ b/core/desktop_presence_runtime.py
@@ -299,11 +299,24 @@ class RuntimeSession:
         while self._tick_running and self.tristate in (TriState.LIMINAL, TriState.MANIFEST):
             try:
                 cs = self._continuum_state or {}
+                intensity = float(cs.get("presence_intensity", 0.0) or 0.0)
+                # 哲学对齐:_continuum_state 由 dispatch 返回后才回填——LIMINAL
+                # 思考期它还是空的,强度恒 0,"认知强度驱动外壳"只是空转。
+                # 思考期改读【活的】持续认知场(activation/intent_strength 随
+                # notify_request 注入并自然衰减),阈限态的呼吸才有真数据。
+                if intensity <= 0.0:
+                    try:
+                        from core.cognitive.continuous_state import get_cognitive_state
+                        _snap = get_cognitive_state().snapshot()
+                        intensity = float(_snap.get("activation", 0.0) or 0.0)
+                        cs = {**cs, "intent_strength": _snap.get("intent_strength", 0.0)}
+                    except Exception:  # noqa: BLE001
+                        pass
                 _emit(
                     "continuum.state",
                     source="desktop_presence_runtime",
                     payload={
-                        "presence_intensity": round(cs.get("presence_intensity", 0.0), 4),
+                        "presence_intensity": round(intensity, 4),
                         "coherence": round(cs.get("coherence", 0.0), 4),
                         "phase": self.tristate.value,
                         "collapse_tendency": round(cs.get("collapse_tendency", 0.0), 4),
@@ -312,6 +325,20 @@ class RuntimeSession:
                     },
                     runtime_session_id=self.runtime_session_id,
                 )
+                # 哲学对齐:面板桥一直订阅着 intent.update(阈限 0.15-0.85 呼吸
+                # 映射),但全仓库【从未有人发射过它】——设计的两半从没接上。
+                # LIMINAL 期由本 tick 发射,意图强度取认知场与 continuum 的较大者。
+                if self.tristate is TriState.LIMINAL:
+                    _emit(
+                        "intent.update",
+                        source="desktop_presence_runtime",
+                        payload={
+                            "intent_strength": round(
+                                max(intensity,
+                                    float(cs.get("intent_strength", 0.0) or 0.0)), 4),
+                        },
+                        runtime_session_id=self.runtime_session_id,
+                    )
             except Exception:
                 pass
             await asyncio.sleep(0.2)
@@ -728,6 +755,16 @@ class DesktopPresenceRuntime:
         except Exception as _cfe_err:
             logger.debug("cognitive_field_engine.notify_request failed (non-fatal): %s", _cfe_err)
 
+        # 任务成本账本(北极星=任务总消耗,不是单次 TPS):开账挂上下文,
+        # 深链各层(router 记账漏斗/ReAct 轮次/工具派发)自动记账;下面 finally
+        # 结账落盘并挂进响应。账本任何故障绝不影响请求路径。
+        _bill_token = None
+        try:
+            from core.task_cost_ledger import open_task_bill
+            _bill_token = open_task_bill(rsession.runtime_session_id, source=source)
+        except Exception as _tcl_err:  # noqa: BLE001
+            logger.debug("task_cost_ledger open failed (non-fatal): %s", _tcl_err)
+
         # PR-18: Derive the cognitive execution-policy hint from live signals.
         # This is done BEFORE dispatch so the hint can be forwarded to OpenClawd
         # as an advisory signal for execution-path and delegation biasing.
@@ -912,6 +949,19 @@ class DesktopPresenceRuntime:
             )
             self._log_request_end(rsession)
             self._active_sessions.pop(rsession.runtime_session_id, None)
+
+            # 任务成本账本:结账(定格墙钟→内存环形+JSONL+一行日志),
+            # 账单挂进响应供面板/调用方直读本次任务的总消耗。
+            if _bill_token is not None:
+                try:
+                    from core.task_cost_ledger import close_task_bill
+                    _task_bill = close_task_bill(
+                        _bill_token, success=bool(result.get("success", True)),
+                    )
+                    if _task_bill:
+                        result["task_cost"] = _task_bill
+                except Exception as _tcl_err:  # noqa: BLE001
+                    logger.debug("task_cost_ledger close failed (non-fatal): %s", _tcl_err)
 
             # Block-3: Notify decay controller that execution completed so the
             # cognitive field begins its manifest→liminal→passive reabsorption.

--- a/core/lumiv_websocket_bridge.py
+++ b/core/lumiv_websocket_bridge.py
@@ -131,11 +131,15 @@ class GalaxyPresenceBridge:
 
     # ── StateEventBus 回调 ──
 
+    # 注:speaking 的生命周期由 core.speech_output 的 set_ai_speaking(播放起止)
+    # 全权管理——相位切换【绝不】把它踩掉。此前 phase.silent/manifest 一到就强制
+    # _speaking=False:响应文本一好 runtime 就回 SILENT,而 TTS 还在播,结果
+    # "嘴在动、动画已灭"。相位事件只管相位。
+
     def _on_phase_silent(self, payload: Dict[str, Any]) -> None:
         self._current_mode = "static"
         self._current_depth = MODE_DEPTH_MAP["static"]
         self._intent = 0.0
-        self._speaking = False
         asyncio.create_task(self._broadcast_state())
 
     def _on_phase_liminal(self, event: Any) -> None:
@@ -144,14 +148,13 @@ class GalaxyPresenceBridge:
         self._current_depth = MODE_DEPTH_MAP["liminal"]
         # intent 从 payload 中提取，如果没有则默认 0.5
         self._intent = p.get("intent_strength", 0.5)
-        self._speaking = p.get("speaking", False)
+        self._speaking = p.get("speaking", self._speaking)
         asyncio.create_task(self._broadcast_state())
 
     def _on_phase_manifest(self, payload: Dict[str, Any]) -> None:
         self._current_mode = "manifest"
         self._current_depth = MODE_DEPTH_MAP["manifest"]
         self._intent = 1.0
-        self._speaking = False
         asyncio.create_task(self._broadcast_state())
 
     def _on_intent_update(self, event: Any) -> None:
@@ -350,12 +353,18 @@ class GalaxyPresenceBridge:
 
     def _build_message(self) -> Dict[str, Any]:
         """构建与前端兼容的 state_event 消息。"""
+        # 说话地板:TTS 还在播时即使相位已回 SILENT(depth 0.05),也维持一个
+        # 可见的在场深度——说完(set_ai_speaking(False) 广播)才落回相位深度,
+        # 由渲染端弹簧自然缓落。消除"话没说完、画面先睡"的割裂。
+        _depth = self._current_depth
+        if self._speaking:
+            _depth = max(_depth, MODE_DEPTH_MAP["liminal"])
         return {
             "type": "state_event",
             "event_category": "ambient_tick",
             "payload": {
                 "phase": self._current_mode,
-                "depth_factor": round(self._current_depth, 4),
+                "depth_factor": round(_depth, 4),
                 "intent": round(self._intent, 4),
                 "speaking": self._speaking,
                 "mode": self._current_mode,

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -892,6 +892,42 @@ class OllamaAdapter(BaseProviderAdapter):
             out.append(new_m)
         return out
 
+    @staticmethod
+    def _normalize_tool_calls(raw_calls: Any) -> Optional[List[Dict]]:
+        """Ollama 原生 tool_calls → OpenAI 形状(下游 ReAct 统一按此消费)。
+
+        差异:Ollama 的 function.arguments 是 **dict**(OpenAI 是 JSON 字符串),
+        且不带 id。这里统一转字符串 + 合成 id,让 openclawd 的
+        ``json.loads(fn["arguments"])`` 两家通吃。
+        """
+        if not raw_calls:
+            return None
+        out: List[Dict] = []
+        for i, tc in enumerate(raw_calls):
+            fn = (tc or {}).get("function") or {}
+            args = fn.get("arguments")
+            if isinstance(args, (dict, list)):
+                args = json.dumps(args, ensure_ascii=False)
+            elif not isinstance(args, str):
+                args = "{}"
+            out.append({
+                "id": tc.get("id") or f"ollama_call_{i}_{fn.get('name', '')}",
+                "type": "function",
+                "function": {"name": fn.get("name", ""), "arguments": args},
+            })
+        return out or None
+
+    @staticmethod
+    def _is_tools_unsupported_error(exc: Exception) -> bool:
+        """Ollama 对无工具模板的模型(如 gemma 系)回 400 'does not support tools'。"""
+        try:
+            if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+                return (exc.response.status_code == 400
+                        and "tool" in exc.response.text.lower())
+        except Exception:  # noqa: BLE001
+            pass
+        return False
+
     async def chat(self, messages, model, tools=None,
                    temperature=0.7, max_tokens=4096,
                    response_format=None, **kwargs) -> LLMResponse:
@@ -905,13 +941,29 @@ class OllamaAdapter(BaseProviderAdapter):
             _keep_alive = int(_keep_alive)
         except (TypeError, ValueError):
             pass
+        _options: Dict[str, Any] = {"temperature": temperature, "num_predict": max_tokens}
+        # num_ctx 显式设置:系统提示+工具定义+记忆+历史很容易超过模型默认上下文
+        # (常为 4096),一旦溢出 Ollama 滑窗截断 → 前缀 KV 缓存每轮全废 → 每轮
+        # ReAct 全量重预填,CPU 机上就是"越聊越慢"。默认 8192;设 0/空 则不传
+        # (回到模型默认)。
+        try:
+            _num_ctx = int(os.environ.get("GALAXY_OLLAMA_NUM_CTX", "8192"))
+            if _num_ctx > 0:
+                _options["num_ctx"] = _num_ctx
+        except (TypeError, ValueError):
+            _options["num_ctx"] = 8192
         body = {
             "model": model,
             "messages": self._to_ollama_messages(messages),
             "stream": False,
-            "options": {"temperature": temperature, "num_predict": max_tokens},
+            "options": _options,
             "keep_alive": _keep_alive,
         }
+        # 原生 function calling:Ollama /api/chat 支持 OpenAI 形状的 tools
+        # (qwen/minicpm/llama3.1 等带工具模板的模型)。此前适配器收了 tools
+        # 却不发——本地主脑从来"看不到"工具,整个 ReAct 工具层对 Ollama 是哑的。
+        if tools:
+            body["tools"] = tools
 
         # 调用点兜底:即使 config.base_url 因某条边缘路径被置空/缺协议头,
         # 也在此归一,绝不把坏 URL 交给 httpx(否则炸 "Request URL is missing
@@ -930,6 +982,20 @@ class OllamaAdapter(BaseProviderAdapter):
                     base=_base, body=body, model=model, sink=_sink,
                 )
             except Exception as exc:  # noqa: BLE001
+                if self._is_tools_unsupported_error(exc) and "tools" in body:
+                    # 模型无工具模板(gemma 系):去工具重试流式——宁可这轮没有
+                    # 工具,也不能整个请求 400 哑掉。上层日志可见,便于用户换模型。
+                    logger.warning(
+                        "Ollama 模型 %s 不支持原生工具,本轮去工具重试"
+                        "(需要工具请换 qwen/minicpm 等带工具模板的模型)", model,
+                    )
+                    body = {k: v for k, v in body.items() if k != "tools"}
+                    try:
+                        return await self._chat_streaming(
+                            base=_base, body=body, model=model, sink=_sink,
+                        )
+                    except Exception as exc2:  # noqa: BLE001
+                        exc = exc2
                 logger.info("Ollama 流式失败,退回非流式: %s", exc)
                 try:
                     _sink.reset()
@@ -937,21 +1003,37 @@ class OllamaAdapter(BaseProviderAdapter):
                     pass
 
         t0 = time.monotonic()
-        resp = await self._post_with_retry(
-            f"{_base}/api/chat",
-            headers={"Content-Type": "application/json"},
-            body=body,
-        )
+        try:
+            resp = await self._post_with_retry(
+                f"{_base}/api/chat",
+                headers={"Content-Type": "application/json"},
+                body=body,
+            )
+        except httpx.HTTPStatusError as exc:
+            if not (self._is_tools_unsupported_error(exc) and "tools" in body):
+                raise
+            logger.warning(
+                "Ollama 模型 %s 不支持原生工具,本轮去工具重试"
+                "(需要工具请换 qwen/minicpm 等带工具模板的模型)", model,
+            )
+            body = {k: v for k, v in body.items() if k != "tools"}
+            resp = await self._post_with_retry(
+                f"{_base}/api/chat",
+                headers={"Content-Type": "application/json"},
+                body=body,
+            )
         latency = (time.monotonic() - t0) * 1000
         data = resp.json()
 
+        _msg = data.get("message", {}) or {}
         return LLMResponse(
-            content=data.get("message", {}).get("content", ""),
+            content=_msg.get("content", ""),
             provider=self.config.name,
             model=model,
             input_tokens=data.get("prompt_eval_count", 0),
             output_tokens=data.get("eval_count", 0),
             latency_ms=latency,
+            tool_calls=self._normalize_tool_calls(_msg.get("tool_calls")),
             raw_response=data,
         )
 
@@ -962,11 +1044,15 @@ class OllamaAdapter(BaseProviderAdapter):
         client = await self._get_client()
         t0 = time.monotonic()
         content_parts: List[str] = []
+        raw_tool_calls: List[Dict] = []
         final: Dict[str, Any] = {}
         async with client.stream(
             "POST", f"{base}/api/chat",
             headers={"Content-Type": "application/json"}, json=stream_body,
         ) as resp:
+            if getattr(resp, "status_code", 200) >= 400:
+                # 让 chat() 的"模型不支持工具 → 去工具重试"能拿到响应体判因
+                await resp.aread()
             resp.raise_for_status()
             async for line in resp.aiter_lines():
                 line = (line or "").strip()
@@ -976,10 +1062,16 @@ class OllamaAdapter(BaseProviderAdapter):
                     chunk = json.loads(line)
                 except (ValueError, TypeError):
                     continue
-                piece = (chunk.get("message") or {}).get("content", "")
+                _cmsg = chunk.get("message") or {}
+                piece = _cmsg.get("content", "")
                 if piece:
                     content_parts.append(piece)
                     sink.feed(piece)
+                # 工具调用块:Ollama 流式在(通常是末尾的)块上整只给出
+                # message.tool_calls,不是 OpenAI 式碎片增量——直接收集,
+                # 绝不喂 sink(工具调用不是正文)。
+                if _cmsg.get("tool_calls"):
+                    raw_tool_calls.extend(_cmsg["tool_calls"])
                 if chunk.get("done"):
                     final = chunk
         latency = (time.monotonic() - t0) * 1000
@@ -990,6 +1082,7 @@ class OllamaAdapter(BaseProviderAdapter):
             input_tokens=int(final.get("prompt_eval_count", 0) or 0),
             output_tokens=int(final.get("eval_count", 0) or 0),
             latency_ms=latency,
+            tool_calls=self._normalize_tool_calls(raw_tool_calls),
             raw_response=final or None,
         )
 

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -2479,7 +2479,7 @@ class MultiLLMRouter:
                 "provider": provider, "model": model,
                 "task_type": task_type.value if hasattr(task_type, "value") else str(task_type),
                 "latency_ms": float(getattr(response, "latency_ms", 0.0) or 0.0),
-                "tokens": itok + otok, "cost": round(cost, 6),
+                "tokens": itok + otok, "tokens_out": otok, "cost": round(cost, 6),
                 "timestamp": time.time(), "success": bool(success),
             })
             if len(self.call_history) > 500:
@@ -2490,6 +2490,13 @@ class MultiLLMRouter:
                     cfg.last_used = time.time()
                 else:
                     cfg.error_count += 1
+            # 任务成本账本:所有 LLM 调用都经此漏斗,顺手记进当前任务账单
+            # (无在途账单时静默无操作;账本故障绝不反噬)。
+            try:
+                from core.task_cost_ledger import add_llm_usage
+                add_llm_usage(provider, itok, otok, cost)
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:  # noqa: BLE001
             pass
 
@@ -2507,20 +2514,26 @@ class MultiLLMRouter:
             if not p:
                 continue
             s = stats.setdefault(p, {"calls": 0.0, "successes": 0.0,
-                                     "latency_sum": 0.0, "cost_sum": 0.0})
+                                     "latency_sum": 0.0, "cost_sum": 0.0,
+                                     "tokens_out_sum": 0.0})
             s["calls"] += 1
             if rec.get("success"):
                 s["successes"] += 1
             s["latency_sum"] += float(rec.get("latency_ms", 0.0) or 0.0)
             s["cost_sum"] += float(rec.get("cost", 0.0) or 0.0)
+            s["tokens_out_sum"] += float(rec.get("tokens_out", 0.0) or 0.0)
         return stats
 
     def _bandit_score(self, name: str, stats: Dict[str, Dict[str, float]], total: int,
                       *, latency_weight: float = 0.2, cost_weight: float = 0.1,
-                      explore_c: float = 1.4) -> float:
-        """UCB1 式打分:利用项(成功率 − 延迟/成本惩罚)＋ 探索项。未试过的 provider 返回
-        +inf(乐观初始化,保证每个都至少被探索一次)。惩罚做相对归一化,避免延迟/成本的
-        绝对量级压过成功率主信号。"""
+                      verbosity_weight: float = 0.1, explore_c: float = 1.4) -> float:
+        """UCB1 式打分:利用项(成功率 − 延迟/成本/啰嗦惩罚)＋ 探索项。未试过的 provider
+        返回 +inf(乐观初始化,保证每个都至少被探索一次)。惩罚做相对归一化,避免任何
+        单项的绝对量级压过成功率主信号。
+
+        啰嗦惩罚(token 效率,Grok 4.5 的核心洞见):同样把事办成,平均输出 token
+        越多的 provider 越吃亏——本地 CPU 上输出 token ≈ 等待秒数,云端 ≈ 账单。
+        北极星是"任务总消耗",不是单次速度。"""
         s = stats.get(name)
         if not s or s["calls"] == 0:
             return float("inf")
@@ -2528,9 +2541,11 @@ class MultiLLMRouter:
         success_rate = s["successes"] / n
         avg_latency = s["latency_sum"] / n
         avg_cost = s["cost_sum"] / n
+        avg_tokens_out = s.get("tokens_out_sum", 0.0) / n
         lat_pen = latency_weight * min(1.0, avg_latency / 5000.0)   # 5s 封顶
         cost_pen = cost_weight * min(1.0, avg_cost / 0.05)          # 0.05/次 封顶
-        exploit = max(0.0, success_rate - lat_pen - cost_pen)
+        verb_pen = verbosity_weight * min(1.0, avg_tokens_out / 2000.0)  # 2k tok/次 封顶
+        exploit = max(0.0, success_rate - lat_pen - cost_pen - verb_pen)
         explore = explore_c * math.sqrt(math.log(max(total, 1) + 1.0) / n)
         return exploit + explore
 

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -7910,6 +7910,13 @@ class OpenClawd:
             nonlocal _total_tool_calls, _last_tool_name
 
             for iteration in range(max_iterations):
+                # 任务成本账本:记一轮 ReAct(账本故障绝不反噬)
+                try:
+                    from core.task_cost_ledger import add_react_round
+                    add_react_round()
+                except Exception:  # noqa: BLE001
+                    pass
+
                 # 延迟优化(对话层):长任务里早期轮次的大工具结果模型早已消化,
                 # 继续全文携带只是白白加重每轮 prefill(CPU 机的延迟大头)。
                 # 保最近 K 轮完整,更早的大结果换短存根;小结果不动
@@ -7925,11 +7932,18 @@ class OpenClawd:
                 # PR-3: Use chat_with_tools() which is defined on both UnifiedLLMRouter
                 # and MultiLLMRouter, ensuring the unified policy layer is applied
                 # regardless of which router type _get_router() returns.
+                # 输出预算:本地 CPU 上"输出 token 数 ≈ 等待秒数"——上限可调
+                # (GALAXY_MAX_TOKENS_ANSWER,默认 4096 保持原行为)。
+                import os as _os_budget
+                try:
+                    _answer_budget = int(_os_budget.getenv("GALAXY_MAX_TOKENS_ANSWER", "4096"))
+                except (TypeError, ValueError):
+                    _answer_budget = 4096
                 response = await router.chat_with_tools(
                     messages=messages,
                     tools=tools if tools else None,
                     task_type=task_type,
-                    max_tokens=4096,
+                    max_tokens=_answer_budget,
                     **({"stream": _token_sink} if _token_sink is not None else {}),
                 )
                 last_response = response
@@ -8017,6 +8031,13 @@ class OpenClawd:
                     else:
                         _consecutive_same.clear()
                     _last_tool_name = tc_name
+
+                    # 任务成本账本:记一次工具调用(账本故障绝不反噬)
+                    try:
+                        from core.task_cost_ledger import add_tool_call
+                        add_tool_call()
+                    except Exception:  # noqa: BLE001
+                        pass
 
                     # 执行工具 (带计时 + 单工具超时)
                     t0 = _time.time()
@@ -8118,7 +8139,9 @@ class OpenClawd:
                         "你是 Galaxy 智能助手 (OpenClawd)，一个桌面级超级 AI 智能体。\n"
                         "你可以帮助用户进行对话、任务管理、设备控制、代码执行等操作。\n"
                         "当你需要执行操作时，请使用提供的工具。\n"
-                        "如果没有合适的工具，直接用文字回答。"
+                        "如果没有合适的工具，直接用文字回答。\n"
+                        "表达原则：直接、简洁，不复述问题、不加客套铺垫；"
+                        "要调用工具就直接调用，不要先输出长段解释。"
                     ),
                 },
             ]

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -7910,6 +7910,18 @@ class OpenClawd:
             nonlocal _total_tool_calls, _last_tool_name
 
             for iteration in range(max_iterations):
+                # 延迟优化(对话层):长任务里早期轮次的大工具结果模型早已消化,
+                # 继续全文携带只是白白加重每轮 prefill(CPU 机的延迟大头)。
+                # 保最近 K 轮完整,更早的大结果换短存根;小结果不动
+                # (不值得为它作废 Ollama 前缀 KV 缓存)。
+                try:
+                    from core.context_trim import prune_stale_tool_results
+                    _n_pruned = prune_stale_tool_results(messages)
+                    if _n_pruned:
+                        logger.debug("ReAct 上下文修剪: %d 条早期工具结果换存根", _n_pruned)
+                except Exception:  # noqa: BLE001 — 修剪失败绝不影响主流程
+                    pass
+
                 # PR-3: Use chat_with_tools() which is defined on both UnifiedLLMRouter
                 # and MultiLLMRouter, ensuring the unified policy layer is applied
                 # regardless of which router type _get_router() returns.
@@ -8033,12 +8045,18 @@ class OpenClawd:
                         )
                     )
 
-                    # 追加 tool result 到 messages
+                    # 追加 tool result 到 messages(头+尾保留式截断:长输出的
+                    # 结论常在末尾,纯 [:N] 会把它切没;上限 env 可调)
+                    try:
+                        from core.context_trim import clip_tool_result
+                        _clipped = clip_tool_result(result_str)
+                    except Exception:  # noqa: BLE001
+                        _clipped = result_str[:4000]
                     messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": tc_id,
-                            "content": result_str[:4000],
+                            "content": _clipped,
                         }
                     )
 
@@ -8160,6 +8178,21 @@ class OpenClawd:
 
             # 收集可用工具
             tools = self._collect_tools()
+
+            # 延迟优化(auto 档):工具定义是 prompt 预填的大头(实测 22 个
+            # ≈3.2k tokens)。数量在阈值(默认 24)内**原样不动**——质量优先;
+            # 超了才按与本次请求的词法相关性挑 top-K,核心工具永不裁。
+            try:
+                from core.context_trim import slim_tools
+                _n_before = len(tools)
+                tools = slim_tools(tools, message)
+                if len(tools) != _n_before:
+                    logger.info(
+                        "工具定义瘦身: %d → %d(GALAXY_TOOLS_SLIM=off 可关闭)",
+                        _n_before, len(tools),
+                    )
+            except Exception:  # noqa: BLE001 — 瘦身失败用全量,绝不影响主流程
+                pass
 
             # PR-3: 计算复杂度向量 — 通过统一入口代理 compute_complexity_vector()，
             # 避免直接访问 _backend._compute_complexity_vector()。

--- a/core/routing_explanation/live_decision.py
+++ b/core/routing_explanation/live_decision.py
@@ -213,6 +213,54 @@ class LiveRoutingDecisionBuilder:
             )
             self._decision_bases.append(basis_rej)
 
+    def record_v3_slot_gate(
+        self,
+        approved: List[str],
+        blocked: List[str],
+        block_reason: str = "",
+    ) -> None:
+        """Record the V3 canonical dispatch-slot authority verdict.
+
+        PR-H 的调用点(command_router.route_envelope)一直在调本方法,但它
+        此前从未被实现——每次派发都在日志里吞一条 AttributeError,V3 槽门
+        (设备级派发合法性的最终权威)在活路由解释里整体缺失。补齐后,
+        路由解释与实际决策链一致:槽门放行/拦截与原因均可回溯。
+
+        Args:
+            approved:     通过 canonical 槽评估的设备 ID。
+            blocked:      被槽权威拦下的设备 ID。
+            block_reason: 拦截原因(全拦时的聚合说明)。
+        """
+        if approved:
+            self._decision_bases.append(make_decision_basis(
+                factor=DecisionFactor.AVAILABILITY,
+                signal_value=list(approved),
+                description=(
+                    f"{len(approved)} target(s) approved by V3 canonical "
+                    f"dispatch-slot authority: {list(approved)}"
+                ),
+                accepted=True,
+                weight=0.2,
+            ))
+        for dev_id in (blocked or []):
+            reason_str = block_reason or "blocked by V3 canonical dispatch-slot authority"
+            self._rejected_candidates.append(
+                RejectedCandidate(
+                    candidate_id=str(dev_id),
+                    rejection_reason=reason_str,
+                    was_available=False,
+                )
+            )
+            self._decision_bases.append(make_decision_basis(
+                factor=DecisionFactor.AVAILABILITY,
+                signal_value=False,
+                description=(
+                    f"Target '{dev_id}' blocked by V3 slot gate: {reason_str}"
+                ),
+                accepted=False,
+                weight=0.2,
+            ))
+
     def record_capability_enforcement(
         self,
         confirmed: List[str],

--- a/core/speech_output.py
+++ b/core/speech_output.py
@@ -147,7 +147,24 @@ def _get_engine() -> Optional[Any]:
             logger.info("SAPI TTS 不可用: %s", exc)
             return None
 
-    if choice == "melo":
+    def _try_indextts():
+        if "IndexTTSEngine" in _failed_engine_types:
+            return None
+        try:
+            from core.tts.indextts_engine import IndexTTSEngine
+            eng = IndexTTSEngine()
+            return eng if eng.available() else None
+        except Exception as exc:  # noqa: BLE001
+            logger.info("IndexTTS 不可用: %s", exc)
+            return None
+
+    if choice == "indextts":
+        # 质量档(零样本克隆+情绪,自回归大模型):仅显式选择才启用,不进
+        # 任何默认回退链——CPU 合成一句数秒到数十秒,拿它当日常对话嗓音会
+        # 显著加重延迟。不可用/运行期失败仍落回默认链,绝不整段静默。
+        _engine = (_try_indextts() or _try_edge() or _try_melo()
+                   or _try_piper() or _try_kokoro() or _try_sapi())
+    elif choice == "melo":
         _engine = (_try_melo() or _try_piper() or _try_edge()
                    or _try_kokoro() or _try_sapi())
     elif choice == "piper":

--- a/core/task_cost_ledger.py
+++ b/core/task_cost_ledger.py
@@ -1,0 +1,197 @@
+"""core/task_cost_ledger.py — 任务成本账本(北极星:任务总消耗,不是单次 TPS)
+================================================================================
+
+哲学对齐:问题导向 + 解决质量为主、兼顾效率——优化的是「把一个任务真正办成
+所花的总资源」这个比值的分母,而不是任何单点指标(TPS/单次延迟)。
+不能优化你没度量的东西:本模块把散落的度量零件(router.call_history 记单次
+LLM 调用、ToolCallRecord 记单次工具调用、runtime_session_id 串生命周期)
+按【任务】聚合成一张账单:
+
+    一个 runtime session(= 用户的一次请求)结束时,聚合:
+    LLM 调了几次、总输入/输出 token、工具调了几次、ReAct 几轮、总墙钟。
+
+用法(与 llm_stream 同款 contextvars 模式,零签名侵入):
+
+    bill = open_task_bill(trace_id, source)      # runtime.handle_request 进入时
+    ... 深链内任意层: add_llm_usage(...) / add_tool_call(...) / add_react_round()
+    bill = close_task_bill()                     # 结束时:落账 + 返回账单
+
+落账三路:内存环形账本(面板/诊断即查)、JSONL 追加(跨进程/长期积累,
+将来微调专属小模型的原料)、INFO 一行日志(真机肉眼可读)。
+全程 try/except,账本任何故障绝不影响主流程。
+"""
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.TaskCostLedger")
+
+_LEDGER_PATH_DEFAULT = "data/task_cost_ledger.jsonl"
+
+
+@dataclass
+class TaskBill:
+    """一个任务(一次 runtime 请求)的成本账单。"""
+    trace_id: str
+    source: str = "unknown"
+    started_monotonic: float = field(default_factory=time.monotonic)
+    started_at: float = field(default_factory=time.time)
+    llm_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    tool_calls: int = 0
+    react_rounds: int = 0
+    providers: Dict[str, int] = field(default_factory=dict)  # provider → 调用次数
+    cost_usd: float = 0.0
+    success: Optional[bool] = None
+    wall_ms: float = 0.0
+
+    def add_llm(self, provider: str, input_tokens: int, output_tokens: int,
+                cost: float = 0.0) -> None:
+        self.llm_calls += 1
+        self.input_tokens += max(0, int(input_tokens or 0))
+        self.output_tokens += max(0, int(output_tokens or 0))
+        self.cost_usd += float(cost or 0.0)
+        if provider:
+            self.providers[provider] = self.providers.get(provider, 0) + 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "trace_id": self.trace_id,
+            "source": self.source,
+            "started_at": round(self.started_at, 3),
+            "wall_ms": round(self.wall_ms, 1),
+            "llm_calls": self.llm_calls,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.input_tokens + self.output_tokens,
+            "tool_calls": self.tool_calls,
+            "react_rounds": self.react_rounds,
+            "providers": dict(self.providers),
+            "cost_usd": round(self.cost_usd, 6),
+            "success": self.success,
+        }
+
+
+# 请求级上下文:runtime 开账,深链各层记账,互不串扰(同 llm_stream 模式)。
+_current_bill: contextvars.ContextVar[Optional[TaskBill]] = contextvars.ContextVar(
+    "galaxy_task_bill", default=None,
+)
+
+
+class TaskCostLedger:
+    """进程级账本:内存环形 + JSONL 追加。"""
+
+    _instance: Optional["TaskCostLedger"] = None
+    _lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._recent: deque = deque(maxlen=200)
+
+    @classmethod
+    def get_instance(cls) -> "TaskCostLedger":
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    def commit(self, bill: TaskBill) -> None:
+        record = bill.to_dict()
+        self._recent.append(record)
+        # 真机一行可读:这就是"任务总消耗"北极星的日常观测面
+        logger.info(
+            "任务账单 | %s | LLM×%d tokens(in %d/out %d) 工具×%d 轮×%d %.1fs%s",
+            bill.trace_id[:12], bill.llm_calls, bill.input_tokens,
+            bill.output_tokens, bill.tool_calls, bill.react_rounds,
+            bill.wall_ms / 1000.0,
+            "" if bill.success is None else (" ✓" if bill.success else " ✗"),
+        )
+        try:
+            path = os.environ.get("GALAXY_TASK_LEDGER_PATH", _LEDGER_PATH_DEFAULT)
+            if path and path.strip().lower() not in ("0", "off", "none"):
+                os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+                with open(path, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception as exc:  # noqa: BLE001 — 落盘失败不影响主流程
+            logger.debug("任务账本落盘失败(忽略): %s", exc)
+
+    def recent(self, n: int = 20) -> List[Dict[str, Any]]:
+        return list(self._recent)[-n:]
+
+    def summary(self) -> Dict[str, Any]:
+        """聚合观测:近期任务的平均总 token / 工具数 / 墙钟(优化 before/after 的标尺)。"""
+        bills = list(self._recent)
+        if not bills:
+            return {"tasks": 0}
+        n = len(bills)
+        return {
+            "tasks": n,
+            "avg_total_tokens": round(sum(b["total_tokens"] for b in bills) / n, 1),
+            "avg_output_tokens": round(sum(b["output_tokens"] for b in bills) / n, 1),
+            "avg_llm_calls": round(sum(b["llm_calls"] for b in bills) / n, 2),
+            "avg_tool_calls": round(sum(b["tool_calls"] for b in bills) / n, 2),
+            "avg_wall_ms": round(sum(b["wall_ms"] for b in bills) / n, 1),
+            "success_rate": round(
+                sum(1 for b in bills if b.get("success")) / n, 3),
+        }
+
+
+def get_task_cost_ledger() -> TaskCostLedger:
+    return TaskCostLedger.get_instance()
+
+
+# ---------------------------------------------------------------------------
+# 深链记账入口(任何层都可安全调用;无在途账单时静默无操作)
+# ---------------------------------------------------------------------------
+
+def open_task_bill(trace_id: str, source: str = "unknown") -> contextvars.Token:
+    """开账并挂到当前上下文;返回 token 供 close 时复位。"""
+    bill = TaskBill(trace_id=trace_id, source=source)
+    return _current_bill.set(bill)
+
+
+def close_task_bill(token: contextvars.Token,
+                    success: Optional[bool] = None) -> Optional[Dict[str, Any]]:
+    """结账:定格墙钟、落账、复位上下文;返回账单 dict(供挂进响应 metadata)。"""
+    bill = _current_bill.get()
+    _current_bill.reset(token)
+    if bill is None:
+        return None
+    bill.wall_ms = (time.monotonic() - bill.started_monotonic) * 1000.0
+    bill.success = success
+    try:
+        get_task_cost_ledger().commit(bill)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("任务账本 commit 失败(忽略): %s", exc)
+    return bill.to_dict()
+
+
+def add_llm_usage(provider: str, input_tokens: int, output_tokens: int,
+                  cost: float = 0.0) -> None:
+    bill = _current_bill.get()
+    if bill is not None:
+        bill.add_llm(provider, input_tokens, output_tokens, cost)
+
+
+def add_tool_call() -> None:
+    bill = _current_bill.get()
+    if bill is not None:
+        bill.tool_calls += 1
+
+
+def add_react_round() -> None:
+    bill = _current_bill.get()
+    if bill is not None:
+        bill.react_rounds += 1
+
+
+def current_task_bill() -> Optional[TaskBill]:
+    return _current_bill.get()

--- a/core/tts/indextts_engine.py
+++ b/core/tts/indextts_engine.py
@@ -1,0 +1,199 @@
+"""core.tts.indextts_engine — IndexTTS2 零样本克隆 + 情绪控制(可选引擎)
+==========================================================================
+
+**定位:** B 站 IndexSpeech 开源的工业级零样本 TTS(github.com/index-tts/index-tts)。
+给一段参考音频即可复刻音色,且音色与情绪解耦(可"这个人的声音+另一种情绪")。
+**质量/表现力档,不是低延迟档**:自回归大模型,纯 CPU 合成一句要数秒到数十秒,
+远慢于 kokoro/edge——所以它**不进默认回退链**,只在用户显式
+``GALAXY_TTS_ENGINE=indextts`` 时启用(运行期失败仍会 demote 回默认链,
+绝不整段静默)。适合:旁白/有声内容/情绪演绎;实时对话请留在 edge/kokoro。
+
+依赖与模型(都不随仓库分发,按需自装):
+  - ``pip install indextts``(或按官方 README: git clone + uv sync)
+  - 模型权重 ~几 GB:HuggingFace ``IndexTeam/IndexTTS-2``(支持 HF_ENDPOINT 镜像)
+    存放 models/indextts2/(GALAXY_INDEXTTS_DIR 可改)。体积大,后台自动拉取
+    **默认关闭**(GALAXY_INDEXTTS_AUTOFETCH=1 显式打开)。
+
+音色/情绪(README 官方口径):
+  - GALAXY_INDEXTTS_REF_AUDIO   参考音频 wav 路径(必填——零样本克隆的音色来源)
+  - GALAXY_INDEXTTS_EMO_AUDIO   可选:情绪参考音频(方式 A)
+  - GALAXY_INDEXTTS_EMO_TEXT    可选:独立情绪文本描述(方式 D,与台词解耦)
+  - GALAXY_INDEXTTS_EMO_ALPHA   情绪强度(默认 0.6,官方建议值)
+  - GALAXY_INDEXTTS_USE_EMO_TEXT=1  由台词语义自动推断情绪(方式 C)
+  - GALAXY_INDEXTTS_FP16=1      显存紧张时启用 fp16(GPU 场景)
+
+合成放 asyncio.to_thread(重推理,不占事件循环);播放/打断继承 EdgeTTSEngine。
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+from .edge_tts_engine import EdgeTTSEngine
+
+logger = logging.getLogger("Galaxy.TTS.IndexTTS")
+
+_HF_REPO = "IndexTeam/IndexTTS-2"
+
+_fetch_lock = threading.Lock()
+_fetch_started = False
+
+
+def _model_dir() -> Path:
+    return Path(os.environ.get("GALAXY_INDEXTTS_DIR", "models/indextts2"))
+
+
+def _ref_audio() -> str:
+    return os.environ.get("GALAXY_INDEXTTS_REF_AUDIO", "").strip()
+
+
+def model_files_present() -> bool:
+    """以 config.yaml 为就绪哨兵(官方 checkpoints 布局的锚点文件)。"""
+    return (_model_dir() / "config.yaml").exists()
+
+
+def kick_background_fetch() -> None:
+    """后台拉取模型(幂等,至多一次)。**默认关闭**——权重数 GB,不做静默大下载;
+    GALAXY_INDEXTTS_AUTOFETCH=1 显式开启(支持 HF_ENDPOINT 国内镜像)。"""
+    global _fetch_started
+    if os.environ.get("GALAXY_INDEXTTS_AUTOFETCH", "0").strip().lower() not in (
+        "1", "true", "yes", "on",
+    ):
+        return
+    with _fetch_lock:
+        if _fetch_started or model_files_present():
+            return
+        _fetch_started = True
+
+    def _fetch() -> None:
+        try:
+            from huggingface_hub import snapshot_download
+            d = _model_dir()
+            d.mkdir(parents=True, exist_ok=True)
+            logger.info("IndexTTS-2 模型后台拉取中(数 GB,首次较久): %s", _HF_REPO)
+            snapshot_download(repo_id=_HF_REPO, local_dir=str(d))
+            logger.info("IndexTTS-2 模型就绪(%s)——下次语音引擎选择/重启后启用", d)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("IndexTTS-2 模型拉取失败(下次启动再试): %s", exc)
+
+    threading.Thread(target=_fetch, name="indextts-fetch", daemon=True).start()
+
+
+class IndexTTSEngine(EdgeTTSEngine):
+    """IndexTTS2 零样本克隆引擎(播放/打断继承 EdgeTTSEngine)。"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._tts: Optional[Any] = None
+
+    def available(self) -> bool:
+        """包可导入 + 模型就位 + 参考音频已配置且存在,三者齐备才可用。"""
+        try:
+            import indextts  # noqa: F401
+        except Exception:
+            logger.info("IndexTTS 包未安装(pip install indextts / 官方 uv sync)")
+            return False
+        if not model_files_present():
+            kick_background_fetch()
+            logger.info(
+                "IndexTTS-2 模型未就位(%s);设 GALAXY_INDEXTTS_AUTOFETCH=1 "
+                "可后台拉取,或手动 hf download %s --local-dir=%s",
+                _model_dir(), _HF_REPO, _model_dir(),
+            )
+            return False
+        ref = _ref_audio()
+        if not ref or not os.path.exists(ref):
+            logger.warning(
+                "IndexTTS 需要参考音频做零样本克隆:请设 GALAXY_INDEXTTS_REF_AUDIO "
+                "指向一段目标音色的 wav(当前: %r)", ref,
+            )
+            return False
+        return True
+
+    def _ensure_loaded(self) -> Any:
+        if self._tts is None:
+            d = str(_model_dir())
+            use_fp16 = os.environ.get("GALAXY_INDEXTTS_FP16", "0").strip().lower() in (
+                "1", "true", "yes", "on",
+            )
+            try:
+                # IndexTTS2(主线,情感+时长控制)
+                from indextts.infer_v2 import IndexTTS2
+                self._tts = IndexTTS2(
+                    cfg_path=os.path.join(d, "config.yaml"),
+                    model_dir=d,
+                    use_fp16=use_fp16,
+                )
+                logger.info("IndexTTS2 引擎已加载(model_dir=%s, fp16=%s)", d, use_fp16)
+            except ImportError:
+                # 旧版包只有 v1 入口——降级加载,不带情绪参数
+                from indextts.infer import IndexTTS
+                self._tts = IndexTTS(cfg_path=os.path.join(d, "config.yaml"), model_dir=d)
+                logger.info("IndexTTS(v1) 引擎已加载——情绪控制参数将被忽略")
+        return self._tts
+
+    def _emotion_kwargs(self) -> dict:
+        """按 README 四种方式组装情绪参数;未配置则空(纯克隆)。"""
+        kw: dict = {}
+        emo_audio = os.environ.get("GALAXY_INDEXTTS_EMO_AUDIO", "").strip()
+        if emo_audio and os.path.exists(emo_audio):
+            kw["emo_audio_prompt"] = emo_audio
+        emo_text = os.environ.get("GALAXY_INDEXTTS_EMO_TEXT", "").strip()
+        if emo_text:
+            kw["emo_text"] = emo_text
+            kw["use_emo_text"] = True
+        elif os.environ.get("GALAXY_INDEXTTS_USE_EMO_TEXT", "").strip().lower() in (
+            "1", "true", "yes", "on",
+        ):
+            kw["use_emo_text"] = True  # 由台词语义自动推断
+        try:
+            kw["emo_alpha"] = float(os.environ.get("GALAXY_INDEXTTS_EMO_ALPHA", "0.6"))
+        except (TypeError, ValueError):
+            kw["emo_alpha"] = 0.6
+        return kw
+
+    async def synthesize(
+        self,
+        text: str,
+        output_path: Optional[str] = None,
+        voice: Optional[str] = None,   # 接口兼容;IndexTTS 的"音色"来自参考音频
+        rate: Optional[str] = None,    # 接口兼容
+    ) -> str:
+        def _run() -> str:
+            tts = self._ensure_loaded()
+            path = output_path
+            if not path:
+                tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+                tmp.close()
+                path = tmp.name
+            kwargs = {
+                "spk_audio_prompt": _ref_audio(),
+                "text": text,
+                "output_path": path,
+                "verbose": False,
+                **self._emotion_kwargs(),
+            }
+            try:
+                tts.infer(**kwargs)
+            except TypeError:
+                # 版本间签名漂移(v1 无情绪参数/字段更名):退到最小参数集,
+                # 宁可丢情绪也要出声。
+                logger.debug("IndexTTS infer 签名不匹配,退最小参数集重试")
+                try:
+                    tts.infer(
+                        spk_audio_prompt=_ref_audio(), text=text, output_path=path,
+                    )
+                except TypeError:
+                    # v1 位置参数形态: infer(voice, text, output_path)
+                    tts.infer(_ref_audio(), text, path)
+            return path
+
+        # 自回归大模型推理,重 CPU/GPU,放线程,绝不占事件循环。
+        path = await asyncio.to_thread(_run)
+        logger.debug("IndexTTS synthesized: '%s...' → %s", text[:30], path)
+        return path

--- a/electron/renderer/app.js
+++ b/electron/renderer/app.js
@@ -277,7 +277,7 @@ class GalaxyRenderer {
         text = 'Galaxy';
       } else if (this.currentDepth < 0.65) {
         progress = 1;
-        text = this.speaking ? '倾听中...' : 'Galaxy';
+        text = this.speaking ? '说话中...' : 'Galaxy';
       } else {
         progress = Math.max(0, 1 - (this.currentDepth - 0.65) / 0.18);
         text = '执行中...';

--- a/tests/test_agent_predeploy_flow.py
+++ b/tests/test_agent_predeploy_flow.py
@@ -37,6 +37,51 @@ from core.unified.models import UnifiedDevice, UnifiedDeviceType  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
+# 门豁免夹具:本套件钉的是【预部署顺序契约】(物理设备先 deploy 后 execute),
+# 不是设备级准入策略。后来加入的 PR-CAP-DEFAULT 能力推断 + V3 canonical 槽
+# 权威会把假设备全部拦下(Transport is not alive)——按既定的 sanctioned
+# bypass 模式(test_pr2_task_envelope_pipeline)豁免两道门,专门的门策略
+# 契约由其各自的守卫套件钉。
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _bypass_dispatch_gates(monkeypatch):
+    from core.canonical_dispatch_slot_authority import (
+        CanonicalDispatchSlot,
+        CanonicalDispatchSlotStatus,
+        CanonicalDispatchSlotsResult,
+    )
+
+    def _approve_all(device_ids, execution_mode, **kwargs):
+        slots = [
+            CanonicalDispatchSlot(
+                device_id=d,
+                execution_mode=execution_mode,
+                slot_approved=True,
+                status=CanonicalDispatchSlotStatus.SLOT_APPROVED.value,
+                reason="test override — predeploy-flow suite",
+            )
+            for d in device_ids
+        ]
+        return CanonicalDispatchSlotsResult(
+            execution_mode=execution_mode,
+            approved_slots=slots,
+            blocked_slots=[],
+            can_proceed=True,
+            block_reason="",
+        )
+
+    monkeypatch.setattr(
+        "core.canonical_dispatch_slot_authority.get_canonical_dispatch_slots",
+        _approve_all,
+    )
+    monkeypatch.setattr(
+        "core.capability_aware_routing_default.infer_dispatch_capabilities",
+        lambda tool_name: [],
+    )
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -106,6 +151,8 @@ class TestDispatchAgentRemotePhysicalDevice:
         }
         router._queue_depth = 0
         router._cb = MagicMock(is_open=MagicMock(return_value=True))
+        # __new__ 骨架随 CommandRouter 演进补齐:执行器兜底路径会查 _executor
+        router._executor = None
         return router
 
     @pytest.mark.asyncio
@@ -141,7 +188,7 @@ class TestDispatchAgentRemotePhysicalDevice:
         fake_cm.active_devices = {device_id}
         fake_cm.send_to_device = AsyncMock(side_effect=fake_send_to_device)
 
-        with patch("core.command_router.CommandRouter.route_command", new=AsyncMock(return_value=fake_route_result)) as mock_route, \
+        with patch("core.command_router.CommandRouter.route_envelope", new=AsyncMock(return_value=fake_route_result)) as mock_route, \
              patch("core.routes._shared.connection_manager", fake_cm):
             result = await router.dispatch_agent_remote(
                 device_id=device_id,
@@ -160,15 +207,15 @@ class TestDispatchAgentRemotePhysicalDevice:
         assert call_order[0] == "agent_deploy", (
             f"agent_deploy was not the first message sent (order={call_order})"
         )
-        # agent_execute must follow
+        # agent_execute must follow — PR-7 起 execute 经 route_envelope
+        # (统一基底根)承载,route_command 为有意绕开的 compat shim。
         mock_route.assert_called_once()
-        call_kwargs = mock_route.call_args
-        actual_command = call_kwargs.kwargs.get("command") or (
-            call_kwargs.args[1] if call_kwargs.args and len(call_kwargs.args) > 1 else None
+        _envelope = mock_route.call_args.args[0] if mock_route.call_args.args \
+            else mock_route.call_args.kwargs.get("envelope")
+        assert getattr(_envelope, "tool_name", None) == "agent_execute", (
+            f"route_envelope 未携带 agent_execute(got {getattr(_envelope, 'tool_name', None)!r})"
         )
-        assert actual_command == "agent_execute", (
-            f"route_command was not called with command='agent_execute' (got {actual_command!r})"
-        )
+        assert getattr(_envelope, "targets", None) == [device_id]
 
         assert result["success"] is True
         assert result["agent_id"] == agent_id
@@ -189,9 +236,12 @@ class TestDispatchAgentRemotePhysicalDevice:
 
         fake_cm = MagicMock()
         fake_cm.active_devices = {}  # device offline
+        # 离线判定已收口到 connection_manager.is_online()(不再看 active_devices
+        # 成员关系);MagicMock 默认返回真值会被当"在线",必须显式置 False。
+        fake_cm.is_online = MagicMock(return_value=False)
         fake_cm.send_to_device = AsyncMock(return_value=True)
 
-        with patch("core.command_router.CommandRouter.route_command", new=AsyncMock()) as mock_route, \
+        with patch("core.command_router.CommandRouter.route_envelope", new=AsyncMock()) as mock_route, \
              patch("core.routes._shared.connection_manager", fake_cm):
             result = await router.dispatch_agent_remote(
                 device_id=device_id,
@@ -225,7 +275,7 @@ class TestDispatchAgentRemotePhysicalDevice:
         fake_cm.active_devices = {device_id}
         fake_cm.send_to_device = AsyncMock(return_value=False)  # send fails
 
-        with patch("core.command_router.CommandRouter.route_command", new=AsyncMock()) as mock_route, \
+        with patch("core.command_router.CommandRouter.route_envelope", new=AsyncMock()) as mock_route, \
              patch("core.routes._shared.connection_manager", fake_cm):
             result = await router.dispatch_agent_remote(
                 device_id=device_id,
@@ -257,6 +307,8 @@ class TestDispatchAgentRemoteNonPhysical:
         }
         router._queue_depth = 0
         router._cb = MagicMock(is_open=MagicMock(return_value=True))
+        # __new__ 骨架随 CommandRouter 演进补齐:执行器兜底路径会查 _executor
+        router._executor = None
         return router
 
     @pytest.mark.asyncio
@@ -292,7 +344,7 @@ class TestDispatchAgentRemoteNonPhysical:
         fake_cm.active_devices = {device_id}
         fake_cm.send_to_device = AsyncMock(return_value=True)
 
-        with patch("core.command_router.CommandRouter.route_command", new=AsyncMock(return_value=fake_route_result)) as mock_route, \
+        with patch("core.command_router.CommandRouter.route_envelope", new=AsyncMock(return_value=fake_route_result)) as mock_route, \
              patch("core.routes._shared.connection_manager", fake_cm):
             result = await router.dispatch_agent_remote(
                 device_id=device_id,
@@ -306,8 +358,9 @@ class TestDispatchAgentRemoteNonPhysical:
 
         # deploy must NOT have been sent via connection_manager.send_to_device
         fake_cm.send_to_device.assert_not_called()
-        # route_command must have been called with agent_execute
+        # PR-7:直连 execute 同样经 route_envelope 承载
         mock_route.assert_called_once()
-        result_kw = mock_route.call_args.kwargs
-        assert result_kw.get("command") == "agent_execute"
+        _envelope = mock_route.call_args.args[0] if mock_route.call_args.args \
+            else mock_route.call_args.kwargs.get("envelope")
+        assert getattr(_envelope, "tool_name", None) == "agent_execute"
         assert result["success"] is True

--- a/tests/test_android_takeover_protocol.py
+++ b/tests/test_android_takeover_protocol.py
@@ -236,12 +236,16 @@ class TestTrackingOnAccept:
         tid = f"tkv_{uuid.uuid4().hex[:10]}"
         msg = _make_accept_message(takeover_id=tid)
 
+        # PR-11-V2:tracking/审计收口生命周期协调器,直挂 _record_takeover_response
+        # 钩子已退役——改钉协调器绑定(与审计族既定改钉方向一致)。
+        coordinator = MagicMock()
         with patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response"
-        ) as mock_record:
+            "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
+            return_value=coordinator,
+        ):
             _run(handle_takeover_response(MagicMock(), None, msg))
-            mock_record.assert_called_once()
-            call_kwargs = mock_record.call_args[1]
+            coordinator.on_takeover_response.assert_called_once()
+            call_kwargs = coordinator.on_takeover_response.call_args.kwargs
             assert call_kwargs["accepted"] is True
             assert call_kwargs["takeover_id"] == tid
 
@@ -249,11 +253,13 @@ class TestTrackingOnAccept:
         from galaxy_gateway.android.handlers.takeover_response import handle_takeover_response
         msg = _make_accept_message(device_id="my-android-device")
 
+        coordinator = MagicMock()
         with patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response"
-        ) as mock_record:
+            "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
+            return_value=coordinator,
+        ):
             _run(handle_takeover_response(MagicMock(), None, msg))
-            call_kwargs = mock_record.call_args[1]
+            call_kwargs = coordinator.on_takeover_response.call_args.kwargs
             assert call_kwargs["device_id"] == "my-android-device"
 
 
@@ -268,12 +274,14 @@ class TestTrackingOnReject:
         tid = f"tkv_{uuid.uuid4().hex[:10]}"
         msg = _make_reject_message(takeover_id=tid)
 
+        coordinator = MagicMock()
         with patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response"
-        ) as mock_record:
+            "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
+            return_value=coordinator,
+        ):
             _run(handle_takeover_response(MagicMock(), None, msg))
-            mock_record.assert_called_once()
-            call_kwargs = mock_record.call_args[1]
+            coordinator.on_takeover_response.assert_called_once()
+            call_kwargs = coordinator.on_takeover_response.call_args.kwargs
             assert call_kwargs["accepted"] is False
             assert call_kwargs["takeover_id"] == tid
 
@@ -282,11 +290,13 @@ class TestTrackingOnReject:
         msg = _make_reject_message()
         msg["reason"] = "screen locked"
 
+        coordinator = MagicMock()
         with patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response"
-        ) as mock_record:
+            "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
+            return_value=coordinator,
+        ):
             _run(handle_takeover_response(MagicMock(), None, msg))
-            call_kwargs = mock_record.call_args[1]
+            call_kwargs = coordinator.on_takeover_response.call_args.kwargs
             assert call_kwargs["reason"] == "screen locked"
 
 
@@ -309,15 +319,12 @@ class TestTakeoverResponseSessionRecovery:
             "galaxy_gateway.android.handlers.takeover_response._lookup_session_by_device",
             return_value=SimpleNamespace(runtime_session_id=expected_session_id),
         ) as mock_lookup, patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response",
-        ) as mock_record, patch(
             "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
             return_value=coordinator,
         ):
             _run(handle_takeover_response(MagicMock(), None, msg))
 
         mock_lookup.assert_called_once_with(msg["device_id"])
-        assert mock_record.call_args.kwargs["session_id"] == expected_session_id
         assert coordinator.on_takeover_response.call_args.kwargs["session_id"] == expected_session_id
 
     def test_I02_missing_session_id_without_registry_entry_degrades_gracefully(self):
@@ -332,16 +339,11 @@ class TestTakeoverResponseSessionRecovery:
             "galaxy_gateway.android.handlers.takeover_response._lookup_session_by_device",
             return_value=None,
         ), patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response",
-        ) as mock_record, patch(
             "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
             return_value=coordinator,
         ):
             _run(handle_takeover_response(MagicMock(), None, msg))
 
-        assert mock_record.call_args.kwargs["session_id"] is None, (
-            "Tracking API normalizes missing session_id to None"
-        )
         assert coordinator.on_takeover_response.call_args.kwargs["session_id"] == "", (
             "Coordinator API preserves empty-string session_id when lookup cannot recover it"
         )
@@ -358,7 +360,7 @@ class TestTrackingDegradeGracefully:
         msg = _make_accept_message()
 
         with patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response",
+            "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
             None,
         ):
             resp = _run(handle_takeover_response(MagicMock(), None, msg))
@@ -368,9 +370,11 @@ class TestTrackingDegradeGracefully:
         from galaxy_gateway.android.handlers.takeover_response import handle_takeover_response
         msg = _make_reject_message()
 
+        coordinator = MagicMock()
+        coordinator.on_takeover_response.side_effect = RuntimeError("tracking failure")
         with patch(
-            "galaxy_gateway.android.handlers.takeover_response._record_takeover_response",
-            side_effect=RuntimeError("tracking failure"),
+            "galaxy_gateway.android.handlers.takeover_response._get_lifecycle_coordinator",
+            return_value=coordinator,
         ):
             # Handler must not propagate the exception
             resp = _run(handle_takeover_response(MagicMock(), None, msg))

--- a/tests/test_cp_phase3.py
+++ b/tests/test_cp_phase3.py
@@ -689,13 +689,15 @@ class TestWindowsAIPClientSwarmManifestFields:
             },
         }
 
+        # 执行收口 WindowsExecutionArbiter(_get_manager 直连已退役);
+        # 仲裁器不可用 = 诚实失败(不再伪装 success),关联 ID/manifest 照透传。
         with patch(
-            "windows_client.windows_aip_client._get_manager",
-            return_value=None,  # no autonomy manager
+            "windows_client.windows_aip_client._get_arbiter",
+            return_value=None,
         ):
             result = _execute_agent_task(payload)
 
-        assert result["success"] is True
+        assert result["success"] is False
         assert result["agent_id"] == "a_sys"
         assert result["trace_id"] == "tr_sys"
         assert result["manifest_id"] == "swm_abc123"
@@ -712,7 +714,7 @@ class TestWindowsAIPClientSwarmManifestFields:
             "context": {"manifest_id": "swm_deadbeef"},
         }
 
-        with patch("windows_client.windows_aip_client._get_manager", return_value=None):
+        with patch("windows_client.windows_aip_client._get_arbiter", return_value=None):
             result = _execute_agent_task(payload)
 
         assert result.get("manifest_id") == "swm_deadbeef"
@@ -729,7 +731,7 @@ class TestWindowsAIPClientSwarmManifestFields:
             "context": {},
         }
 
-        with patch("windows_client.windows_aip_client._get_manager", return_value=None):
+        with patch("windows_client.windows_aip_client._get_arbiter", return_value=None):
             result = _execute_agent_task(payload)
 
         assert "manifest_id" not in result
@@ -737,9 +739,9 @@ class TestWindowsAIPClientSwarmManifestFields:
     def test_passes_enriched_request_to_autonomy_manager(self):
         from windows_client.windows_aip_client import _execute_agent_task
 
-        mock_mgr = MagicMock()
-        mock_mgr.execute_agent_task.return_value = {
-            "success": True, "output": "manager result"
+        mock_arbiter = MagicMock()
+        mock_arbiter.route_command.return_value = {
+            "success": True, "result": {"output": "arbiter result"}
         }
 
         payload = {
@@ -757,15 +759,16 @@ class TestWindowsAIPClientSwarmManifestFields:
             },
         }
 
-        with patch("windows_client.windows_aip_client._get_manager", return_value=mock_mgr):
+        with patch("windows_client.windows_aip_client._get_arbiter", return_value=mock_arbiter):
             result = _execute_agent_task(payload)
 
-        mock_mgr.execute_agent_task.assert_called_once()
-        call_arg = mock_mgr.execute_agent_task.call_args[0][0]
-        assert call_arg["system_prompt"] == "Analyse carefully"
-        assert call_arg["tool_schemas"] == [{"name": "analyse"}]
-        assert call_arg["memory_snapshot"] == {"prev": "data"}
-        assert call_arg["manifest_id"] == "swm_mgr_001"
+        mock_arbiter.route_command.assert_called_once()
+        params = mock_arbiter.route_command.call_args.kwargs["params"]
+        # PR158 扩展键经 params.context 抵达执行仲裁器(信息一条不丢)
+        assert params["context"]["system_prompt"] == "Analyse carefully"
+        assert params["context"]["tool_schemas"] == [{"name": "analyse"}]
+        assert params["context"]["memory_snapshot"] == {"prev": "data"}
+        assert params["context"]["manifest_id"] == "swm_mgr_001"
         assert result["manifest_id"] == "swm_mgr_001"
 
 

--- a/tests/test_desktop_existence_surface.py
+++ b/tests/test_desktop_existence_surface.py
@@ -425,7 +425,8 @@ class TestStateFamilyGrounding(unittest.TestCase):
                 get_desktop_presence_runtime,
             )
             runtime = get_desktop_presence_runtime()
-            summary = runtime.presence_summary
+            # presence_summary 已从属性演进为方法
+            summary = runtime.presence_summary()
             self.assertIsInstance(summary, dict)
             self.assertIn("dominant_tristate", summary)
         except ModuleNotFoundError as exc:

--- a/tests/test_e2e_flow.py
+++ b/tests/test_e2e_flow.py
@@ -66,13 +66,18 @@ class TestE2EOrchestrator:
 
             assert result["success"] is True
             assert result["reply"] == "Hello!"
-            mock_pipeline.execute.assert_called_once_with(
-                message="你好",
-                user_id="user_001",
-                source_device_id="phone_01",
-                session_id=None,
-                context=None,
-            )
+            # PR-UNIFIED-CONTEXT(一条会话主线):编排器有意自动供给
+            # canonical session_id,并在 context 里携带会话身份块
+            # (runtime_session_id/trace_id/control_session_id)——
+            # "session_id=None, context=None" 是收口前的退役契约。
+            mock_pipeline.execute.assert_called_once()
+            kw = mock_pipeline.execute.call_args.kwargs
+            assert kw["message"] == "你好"
+            assert kw["user_id"] == "user_001"
+            assert kw["source_device_id"] == "phone_01"
+            assert isinstance(kw["session_id"], str) and kw["session_id"]
+            assert kw["context"] and "runtime_session_id" in kw["context"][0]
+            assert kw["context"][0].get("trace_id")
 
     @pytest.mark.asyncio
     async def test_process_user_input_default_uses_constellation(self):
@@ -176,9 +181,18 @@ class TestSessionRoaming:
         assert mgr.get_session_by_device("device_B") is not None
         assert mgr.get_session_by_device("device_A") is None
 
-    def test_list_sessions(self):
+    def test_list_sessions(self, tmp_path, monkeypatch):
+        import importlib
+        import sys
         from galaxy_gateway.session_roaming import SessionRoamingManager
 
+        # 管理器构造时会从 PERSISTENCE_FILE 载入历史会话(跨进程持久化是
+        # 特性),计数断言必须在隔离的空存储上做,否则数的是磁盘残留。
+        # 注:包属性 session_roaming 被同名单例实例遮蔽,须经 sys.modules
+        # 取真模块再打补丁。
+        importlib.import_module("galaxy_gateway.session_roaming")
+        sr_mod = sys.modules["galaxy_gateway.session_roaming"]
+        monkeypatch.setattr(sr_mod, "PERSISTENCE_FILE", tmp_path / "sessions.json")
         mgr = SessionRoamingManager()
         mgr.create_session("dev_1", wake_word="hello")
         mgr.create_session("dev_2", wake_word="hey")
@@ -278,59 +292,59 @@ class TestWebSocketHandlerWiring:
 class TestSessionManager:
     """Test the unified session manager."""
 
-    def test_get_or_create_session(self):
+    async def test_get_or_create_session(self):
         from core.session_manager import SessionManager
 
         sm = SessionManager()
         sm._sessions.clear()
         sm._user_active_session.clear()
 
-        session = sm.get_or_create_session("user_001", "phone_01")
+        session = await sm.get_or_create_session("user_001", "phone_01")
         assert session.user_id == "user_001"
         assert "phone_01" in session.devices
 
         # Same user, different device → same session
-        session2 = sm.get_or_create_session("user_001", "pc_01")
+        session2 = await sm.get_or_create_session("user_001", "pc_01")
         assert session2.id == session.id
         assert "pc_01" in session2.devices
 
-    def test_add_message_and_history(self):
+    async def test_add_message_and_history(self):
         from core.session_manager import SessionManager
 
         sm = SessionManager()
         sm._sessions.clear()
         sm._user_active_session.clear()
 
-        session = sm.create_session("user_001", "phone_01")
-        sm.add_message(session.id, "user", "Hello", "phone_01")
-        sm.add_message(session.id, "assistant", "Hi!", "")
+        session = await sm.create_session("user_001", "phone_01")
+        await sm.add_message(session.id, "user", "Hello", "phone_01")
+        await sm.add_message(session.id, "assistant", "Hi!", "")
 
         history = sm.get_history(session.id)
         assert len(history) == 2
         assert history[0]["role"] == "user"
         assert history[1]["content"] == "Hi!"
 
-    def test_join_session(self):
+    async def test_join_session(self):
         from core.session_manager import SessionManager
 
         sm = SessionManager()
         sm._sessions.clear()
         sm._user_active_session.clear()
 
-        session = sm.create_session("user_001", "phone_01")
-        assert sm.join_session(session.id, "tablet_01") is True
+        session = await sm.create_session("user_001", "phone_01")
+        assert await sm.join_session(session.id, "tablet_01") is True
         assert "tablet_01" in sm.get_session(session.id).devices
 
-    def test_list_device_sessions(self):
+    async def test_list_device_sessions(self):
         from core.session_manager import SessionManager
 
         sm = SessionManager()
         sm._sessions.clear()
         sm._user_active_session.clear()
 
-        s1 = sm.create_session("user_001", "phone_01")
-        sm.join_session(s1.id, "pc_01")
-        s2 = sm.create_session("user_002", "pc_01")
+        s1 = await sm.create_session("user_001", "phone_01")
+        await sm.join_session(s1.id, "pc_01")
+        s2 = await sm.create_session("user_002", "pc_01")
 
         # pc_01 should appear in 2 sessions
         device_sessions = sm.list_device_sessions("pc_01")

--- a/tests/test_latency_ollama_tools_indextts.py
+++ b/tests/test_latency_ollama_tools_indextts.py
@@ -1,0 +1,331 @@
+"""延迟优化批次 + Ollama 原生工具 + IndexTTS 质量档 测试
+============================================================
+
+覆盖:
+  1. OllamaAdapter 原生 function calling:tools 进请求体、tool_calls 归一
+     (dict 参数→JSON 字符串、合成 id)、模型不支持工具时去工具重试。
+  2. num_ctx 显式设置(默认 8192,env 可调,0 不传)。
+  3. context_trim:工具结果头尾截断、ReAct 老轮次修剪、工具定义 auto 瘦身。
+  4. IndexTTS 质量档:默认不自动拉取权重、缺参考音频不可用、
+     GALAXY_TTS_ENGINE=indextts 不可用时落回默认链。
+"""
+import json
+from types import SimpleNamespace
+import httpx
+import pytest
+
+
+def _mk_ollama_adapter():
+    from core.multi_llm_router import OllamaAdapter, ProviderConfig
+    cfg = ProviderConfig(
+        name="ollama", api_key="", base_url="http://localhost:11434",
+        models=["qwen3:4b"], default_model="qwen3:4b",
+    )
+    return OllamaAdapter(cfg)
+
+
+def _ok_response(payload: dict) -> httpx.Response:
+    return httpx.Response(
+        200, json=payload, request=httpx.Request("POST", "http://t/api/chat"),
+    )
+
+
+TOOLS = [{"type": "function",
+          "function": {"name": "node__06__list",
+                       "parameters": {"type": "object", "properties": {}}}}]
+
+
+# ---------------------------------------------------------------------------
+# 1/2. Ollama 原生工具 + num_ctx
+# ---------------------------------------------------------------------------
+
+class TestOllamaNativeTools:
+    @pytest.mark.asyncio
+    async def test_tools_and_num_ctx_enter_body(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_OLLAMA_NUM_CTX", "8192")
+        ad = _mk_ollama_adapter()
+        seen = {}
+
+        async def _fake_post(url, headers, body):
+            seen.update(body)
+            return _ok_response({"message": {"content": "好"},
+                                 "prompt_eval_count": 1, "eval_count": 1})
+
+        ad._post_with_retry = _fake_post
+        resp = await ad.chat([{"role": "user", "content": "q"}],
+                             model="qwen3:4b", tools=TOOLS)
+        assert seen.get("tools") == TOOLS, "tools 必须随请求体发给 Ollama"
+        assert seen["options"]["num_ctx"] == 8192
+        assert resp.content == "好"
+
+    @pytest.mark.asyncio
+    async def test_num_ctx_zero_means_model_default(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_OLLAMA_NUM_CTX", "0")
+        ad = _mk_ollama_adapter()
+        seen = {}
+
+        async def _fake_post(url, headers, body):
+            seen.update(body)
+            return _ok_response({"message": {"content": "ok"}})
+
+        ad._post_with_retry = _fake_post
+        await ad.chat([{"role": "user", "content": "q"}], model="m")
+        assert "num_ctx" not in seen["options"]
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_normalized_to_openai_shape(self):
+        """Ollama 的 arguments 是 dict 且无 id → 归一成 JSON 字符串 + 合成 id,
+        下游 ReAct 的 json.loads(arguments) 两家通吃。"""
+        ad = _mk_ollama_adapter()
+
+        async def _fake_post(url, headers, body):
+            return _ok_response({"message": {
+                "content": "",
+                "tool_calls": [{"function": {"name": "node__06__list",
+                                             "arguments": {"path": "/a"}}}],
+            }})
+
+        ad._post_with_retry = _fake_post
+        resp = await ad.chat([{"role": "user", "content": "q"}],
+                             model="m", tools=TOOLS)
+        assert resp.tool_calls and len(resp.tool_calls) == 1
+        tc = resp.tool_calls[0]
+        assert tc["id"]
+        assert tc["type"] == "function"
+        assert json.loads(tc["function"]["arguments"]) == {"path": "/a"}
+
+    @pytest.mark.asyncio
+    async def test_tools_unsupported_model_retries_without_tools(self):
+        """gemma 系无工具模板 → 400 'does not support tools':去工具重试,
+        宁可本轮无工具也不整个请求哑掉。"""
+        ad = _mk_ollama_adapter()
+        bodies = []
+
+        async def _fake_post(url, headers, body):
+            bodies.append(body)
+            if "tools" in body:
+                req = httpx.Request("POST", url)
+                resp = httpx.Response(
+                    400, text='{"error":"gemma3 does not support tools"}',
+                    request=req)
+                raise httpx.HTTPStatusError("400", request=req, response=resp)
+            return _ok_response({"message": {"content": "无工具回答"}})
+
+        ad._post_with_retry = _fake_post
+        resp = await ad.chat([{"role": "user", "content": "q"}],
+                             model="gemma3:4b", tools=TOOLS)
+        assert len(bodies) == 2
+        assert "tools" in bodies[0] and "tools" not in bodies[1]
+        assert resp.content == "无工具回答"
+
+    @pytest.mark.asyncio
+    async def test_unrelated_400_still_raises(self):
+        ad = _mk_ollama_adapter()
+
+        async def _fake_post(url, headers, body):
+            req = httpx.Request("POST", url)
+            resp = httpx.Response(400, text='{"error":"invalid model"}', request=req)
+            raise httpx.HTTPStatusError("400", request=req, response=resp)
+
+        ad._post_with_retry = _fake_post
+        with pytest.raises(httpx.HTTPStatusError):
+            await ad.chat([{"role": "user", "content": "q"}], model="m", tools=TOOLS)
+
+    def test_normalize_tool_calls_edge_shapes(self):
+        from core.multi_llm_router import OllamaAdapter
+        norm = OllamaAdapter._normalize_tool_calls
+        assert norm(None) is None
+        assert norm([]) is None
+        out = norm([{"function": {"name": "t", "arguments": "已是字符串"}}])
+        assert out[0]["function"]["arguments"] == "已是字符串"
+        out = norm([{"function": {"name": "t"}}])  # 无 arguments
+        assert out[0]["function"]["arguments"] == "{}"
+
+
+# ---------------------------------------------------------------------------
+# 3. context_trim
+# ---------------------------------------------------------------------------
+
+class TestContextTrim:
+    def test_clip_short_passthrough(self):
+        from core.context_trim import clip_tool_result
+        assert clip_tool_result("短结果", max_chars=100) == "短结果"
+
+    def test_clip_keeps_head_and_tail(self):
+        from core.context_trim import clip_tool_result
+        text = "开头" + "x" * 5000 + "结尾成功exit0"
+        out = clip_tool_result(text, max_chars=1000)
+        assert len(out) < len(text)
+        assert out.startswith("开头")
+        assert out.endswith("结尾成功exit0")
+        assert "已修剪" in out and str(len(text)) in out
+
+    def _mk_round(self, i, tool_len):
+        return [
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": f"c{i}", "type": "function",
+                             "function": {"name": "t", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": f"c{i}", "content": "R" * tool_len},
+        ]
+
+    def test_prune_keeps_recent_rounds_and_small_results(self):
+        from core.context_trim import prune_stale_tool_results
+        messages = [{"role": "system", "content": "s"},
+                    {"role": "user", "content": "u"}]
+        for i in range(5):  # 5 轮:前 2 轮该剪(大),第 3 轮小不剪,后 2 轮保留
+            messages += self._mk_round(i, 2000 if i < 2 else (100 if i == 2 else 2000))
+
+        n = prune_stale_tool_results(messages, keep_rounds=2, min_chars=500)
+        assert n == 2  # 只有前两轮的大结果被剪(第 3 轮太小,最后 2 轮受保护)
+        tool_msgs = [m for m in messages if m["role"] == "tool"]
+        assert "已修剪" in tool_msgs[0]["content"]
+        assert "已修剪" in tool_msgs[1]["content"]
+        assert tool_msgs[2]["content"] == "R" * 100        # 小结果原样
+        assert tool_msgs[3]["content"] == "R" * 2000       # 最近轮完整
+        assert tool_msgs[4]["content"] == "R" * 2000
+
+    def test_prune_disabled_or_few_rounds_noop(self):
+        from core.context_trim import prune_stale_tool_results
+        messages = self._mk_round(0, 9000)
+        assert prune_stale_tool_results(messages, keep_rounds=0) == 0
+        assert prune_stale_tool_results(messages, keep_rounds=3) == 0
+        assert messages[1]["content"] == "R" * 9000
+
+    def _mk_tools(self, n):
+        return [{"type": "function",
+                 "function": {"name": f"node__{i:02d}__act{i}",
+                              "description": f"desc {i}"}} for i in range(n)]
+
+    def test_slim_under_threshold_returns_unchanged(self, monkeypatch):
+        from core.context_trim import slim_tools
+        monkeypatch.setenv("GALAXY_TOOLS_SLIM", "auto")
+        tools = self._mk_tools(10)
+        assert slim_tools(tools, "随便问问", max_tools=24) is tools
+
+    def test_slim_over_threshold_prefers_relevant_and_core(self, monkeypatch):
+        from core.context_trim import slim_tools
+        monkeypatch.setenv("GALAXY_TOOLS_SLIM", "auto")
+        tools = self._mk_tools(30)
+        tools.append({"type": "function", "function": {
+            "name": "node__fs__截图屏幕", "description": "截取当前屏幕画面"}})
+        tools.append({"type": "function", "function": {
+            "name": "memory__recall", "description": "记忆召回"}})
+        out = slim_tools(tools, "帮我截图屏幕看看", max_tools=5)
+        names = [t["function"]["name"] for t in out]
+        assert len(out) == 5
+        assert "node__fs__截图屏幕" in names   # 相关工具入选
+        assert "memory__recall" in names       # 核心工具永不裁
+
+    def test_slim_off_switch(self, monkeypatch):
+        from core.context_trim import slim_tools
+        monkeypatch.setenv("GALAXY_TOOLS_SLIM", "off")
+        tools = self._mk_tools(50)
+        assert slim_tools(tools, "q", max_tools=5) is tools
+
+
+# ---------------------------------------------------------------------------
+# 4. IndexTTS 质量档
+# ---------------------------------------------------------------------------
+
+class TestIndexTTSEngine:
+    def test_autofetch_default_off(self, monkeypatch):
+        """数 GB 权重绝不静默下载:默认关,显式 =1 才拉。"""
+        import core.tts.indextts_engine as ie
+        monkeypatch.delenv("GALAXY_INDEXTTS_AUTOFETCH", raising=False)
+        monkeypatch.setattr(ie, "_fetch_started", False)
+        started = []
+        monkeypatch.setattr(ie.threading, "Thread",
+                            lambda **kw: started.append(kw) or SimpleNamespace(start=lambda: None))
+        ie.kick_background_fetch()
+        assert not started
+
+    def test_unavailable_without_ref_audio(self, monkeypatch, tmp_path):
+        """包在、模型在、但没配参考音频 → 不可用(零样本克隆必须有音色来源)。"""
+        import sys
+        import core.tts.indextts_engine as ie
+        monkeypatch.setitem(sys.modules, "indextts", SimpleNamespace())
+        monkeypatch.setenv("GALAXY_INDEXTTS_DIR", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("ok")
+        monkeypatch.delenv("GALAXY_INDEXTTS_REF_AUDIO", raising=False)
+        eng = ie.IndexTTSEngine()
+        assert eng.available() is False
+
+    def test_available_when_all_present(self, monkeypatch, tmp_path):
+        import sys
+        import core.tts.indextts_engine as ie
+        monkeypatch.setitem(sys.modules, "indextts", SimpleNamespace())
+        monkeypatch.setenv("GALAXY_INDEXTTS_DIR", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("ok")
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"RIFF")
+        monkeypatch.setenv("GALAXY_INDEXTTS_REF_AUDIO", str(ref))
+        eng = ie.IndexTTSEngine()
+        assert eng.available() is True
+
+    @pytest.mark.asyncio
+    async def test_synthesize_passes_clone_and_emotion(self, monkeypatch, tmp_path):
+        import core.tts.indextts_engine as ie
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"RIFF")
+        monkeypatch.setenv("GALAXY_INDEXTTS_REF_AUDIO", str(ref))
+        monkeypatch.setenv("GALAXY_INDEXTTS_EMO_TEXT", "平静而温柔")
+        monkeypatch.setenv("GALAXY_INDEXTTS_EMO_ALPHA", "0.7")
+
+        calls = {}
+
+        class _FakeTTS:
+            def infer(self, **kw):
+                calls.update(kw)
+
+        eng = ie.IndexTTSEngine()
+        eng._tts = _FakeTTS()
+        out = await eng.synthesize("你好世界")
+        assert calls["spk_audio_prompt"] == str(ref)
+        assert calls["text"] == "你好世界"
+        assert calls["emo_text"] == "平静而温柔"
+        assert calls["use_emo_text"] is True
+        assert calls["emo_alpha"] == 0.7
+        assert out  # 产出路径
+
+    @pytest.mark.asyncio
+    async def test_signature_drift_falls_back_to_minimal(self, monkeypatch, tmp_path):
+        """v1 无情绪参数:TypeError → 最小参数集重试,宁丢情绪也要出声。"""
+        import core.tts.indextts_engine as ie
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"RIFF")
+        monkeypatch.setenv("GALAXY_INDEXTTS_REF_AUDIO", str(ref))
+        monkeypatch.setenv("GALAXY_INDEXTTS_EMO_TEXT", "开心")
+
+        calls = []
+
+        class _V1TTS:
+            def infer(self, spk_audio_prompt=None, text=None, output_path=None, **extra):
+                if extra:
+                    raise TypeError("unexpected keyword")
+                calls.append((spk_audio_prompt, text, output_path))
+
+        eng = ie.IndexTTSEngine()
+        eng._tts = _V1TTS()
+        await eng.synthesize("测试")
+        assert calls and calls[0][1] == "测试"
+
+    def test_engine_choice_falls_back_when_unavailable(self, monkeypatch):
+        """GALAXY_TTS_ENGINE=indextts 但引擎不可用 → 落回默认链,绝不整段哑。"""
+        import core.speech_output as so
+        monkeypatch.setenv("GALAXY_TTS_ENGINE", "indextts")
+        monkeypatch.setattr(so, "_engine", None)
+        monkeypatch.setattr(so, "_engine_failed", False)
+        monkeypatch.setattr(so, "_failed_engine_types", set())
+
+        sentinel = object()
+        import core.tts.indextts_engine as ie
+        monkeypatch.setattr(ie.IndexTTSEngine, "available", lambda self: False)
+        # 默认链第一站 edge 直接给假引擎,证明链条接上了
+        import core.tts as tts_pkg
+        monkeypatch.setattr(tts_pkg, "EdgeTTSEngine",
+                            lambda voice=None: sentinel, raising=False)
+        import sys
+        monkeypatch.setitem(sys.modules, "edge_tts", SimpleNamespace())
+
+        eng = so._get_engine()
+        assert eng is sentinel

--- a/tests/test_oneapi_system_position.py
+++ b/tests/test_oneapi_system_position.py
@@ -368,12 +368,19 @@ def test_35_entry_to_dict_canonical_doc_key():
 def _import_provider_category():
     """Import ProviderCategory directly from the submodule to avoid pydantic chain."""
     import importlib.util
+    import sys
     spec = importlib.util.spec_from_file_location(
         "topology_types_direct",
         os.path.join(_REPO_ROOT, "core", "model_topology", "topology_types.py"),
     )
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    # 标准 importlib 配方:exec 前必须登记 sys.modules——Python 3.11 起
+    # dataclass 处理会查 sys.modules[cls.__module__],缺登记直接炸。
+    sys.modules[spec.name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.modules.pop(spec.name, None)
     return mod.ProviderCategory
 
 

--- a/tests/test_openclawd_execution_integration.py
+++ b/tests/test_openclawd_execution_integration.py
@@ -88,6 +88,8 @@ class TestRunExecution:
         mock_executor = MagicMock(spec=DecisionExecutor)
         mock_executor.execute.return_value = ExecutionResult(action_taken="noop", success=True)
         oc._decision_executor = mock_executor
+        # PR-23 就绪门在执行器前——本组钉"执行器被咨询/入参转发",通门桩
+        oc._check_readiness = lambda *a, **k: None
         oc._run_execution({"decision": {"action_level": "observe"}})
         mock_executor.execute.assert_called_once()
 
@@ -100,6 +102,8 @@ class TestRunExecution:
             action_taken="launch_app", target="notepad.exe", success=True
         )
         oc._decision_executor = mock_executor
+        # PR-23 就绪门在执行器前——本组钉"执行器被咨询/入参转发",通门桩
+        oc._check_readiness = lambda *a, **k: None
         with caplog.at_level(logging.DEBUG, logger="core.openclawd"):
             oc._run_execution({"decision": {"action_level": "execute"}})
         # No exception — log check is optional as level may be filtered
@@ -110,6 +114,8 @@ class TestRunExecution:
         mock_executor = MagicMock(spec=DecisionExecutor)
         mock_executor.execute.side_effect = RuntimeError("executor exploded")
         oc._decision_executor = mock_executor
+        # PR-23 就绪门在执行器前——本组钉"执行器被咨询/入参转发",通门桩
+        oc._check_readiness = lambda *a, **k: None
         # Should not raise
         oc._run_execution({"decision": {"action_level": "execute"}})
 
@@ -119,6 +125,8 @@ class TestRunExecution:
         mock_executor = MagicMock(spec=DecisionExecutor)
         mock_executor.execute.return_value = ExecutionResult(action_taken="noop", success=True)
         oc._decision_executor = mock_executor
+        # PR-23 就绪门在执行器前——本组钉"执行器被咨询/入参转发",通门桩
+        oc._check_readiness = lambda *a, **k: None
         oc._run_execution(None)
         # Verify None was passed as the state_continuum positional argument
         call_args = mock_executor.execute.call_args
@@ -273,6 +281,8 @@ class TestRunExecutionEntryMode:
         mock_executor = MagicMock(spec=DecisionExecutor)
         mock_executor.execute.return_value = ExecutionResult(action_taken="noop", success=True)
         oc._decision_executor = mock_executor
+        # PR-23 就绪门在执行器前——本组钉"执行器被咨询/入参转发",通门桩
+        oc._check_readiness = lambda *a, **k: None
         state = {"decision": {"action_level": "observe"}}
         oc._run_execution(state, entry_mode="local")
         call_kwargs = mock_executor.execute.call_args
@@ -305,6 +315,8 @@ class TestRunExecutionEntryMode:
         mock_executor = MagicMock(spec=DecisionExecutor)
         mock_executor.execute.return_value = ExecutionResult(action_taken="noop", success=True)
         oc._decision_executor = mock_executor
+        # PR-23 就绪门在执行器前——本组钉"执行器被咨询/入参转发",通门桩
+        oc._check_readiness = lambda *a, **k: None
         state = {"decision": {"action_level": "observe"}}
         oc._run_execution(state)  # no entry_mode
         call_kwargs = mock_executor.execute.call_args

--- a/tests/test_phase5_self_healing.py
+++ b/tests/test_phase5_self_healing.py
@@ -306,6 +306,47 @@ class TestScoringWithHealth:
 # ===========================================================================
 # C) CommandRouter — retry routing on simulated device failure
 # ===========================================================================
+# 门豁免夹具:本组钉的是【失败重试/隔离/审计事件】自愈语义,不是设备准入
+# 策略。后加入的 V3 canonical 槽权威会把假设备拦下(not registered in UDM)
+# ——按既定 sanctioned bypass 模式豁免,门策略由其守卫套件专钉。
+
+
+@pytest.fixture()
+def _bypass_dispatch_gates(monkeypatch):
+    from core.canonical_dispatch_slot_authority import (
+        CanonicalDispatchSlot,
+        CanonicalDispatchSlotStatus,
+        CanonicalDispatchSlotsResult,
+    )
+
+    def _approve_all(device_ids, execution_mode, **kwargs):
+        slots = [
+            CanonicalDispatchSlot(
+                device_id=d,
+                execution_mode=execution_mode,
+                slot_approved=True,
+                status=CanonicalDispatchSlotStatus.SLOT_APPROVED.value,
+                reason="test override — self-healing retry suite",
+            )
+            for d in device_ids
+        ]
+        return CanonicalDispatchSlotsResult(
+            execution_mode=execution_mode,
+            approved_slots=slots,
+            blocked_slots=[],
+            can_proceed=True,
+            block_reason="",
+        )
+
+    monkeypatch.setattr(
+        "core.canonical_dispatch_slot_authority.get_canonical_dispatch_slots",
+        _approve_all,
+    )
+    monkeypatch.setattr(
+        "core.capability_aware_routing_default.infer_dispatch_capabilities",
+        lambda tool_name: [],
+    )
+
 
 class TestCommandRouterRetry:
     """Integration tests for retry-routing when a device fails."""
@@ -326,7 +367,7 @@ class TestCommandRouterRetry:
         )
 
     @pytest.mark.asyncio
-    async def test_retry_succeeds_on_second_device(self):
+    async def test_retry_succeeds_on_second_device(self, _bypass_dispatch_gates):
         """When device_1 fails, the router retries on device_2 and succeeds."""
         router = self._router()
         calls = []
@@ -399,7 +440,7 @@ class TestCommandRouterRetry:
         assert len(attempted) <= 3
 
     @pytest.mark.asyncio
-    async def test_retry_emits_audit_events(self):
+    async def test_retry_emits_audit_events(self, _bypass_dispatch_gates):
         """TASK_RETRY_SCHEDULED and TASK_RETRY_SUCCEEDED are emitted."""
         from core.control_plane.audit_ledger import AuditLedger, EventType
         from core.control_plane._globals import get_audit_ledger
@@ -438,7 +479,7 @@ class TestCommandRouterRetry:
         assert len(succeeded) >= 1
 
     @pytest.mark.asyncio
-    async def test_all_retries_fail_emits_task_retry_failed(self):
+    async def test_all_retries_fail_emits_task_retry_failed(self, _bypass_dispatch_gates):
         """TASK_RETRY_FAILED is emitted when all retries are exhausted."""
         from core.control_plane.audit_ledger import AuditLedger, EventType
 
@@ -470,7 +511,7 @@ class TestCommandRouterRetry:
         assert len(failed) >= 1
 
     @pytest.mark.asyncio
-    async def test_quarantined_device_skipped_in_retry(self):
+    async def test_quarantined_device_skipped_in_retry(self, _bypass_dispatch_gates):
         """A quarantined device is not tried even when listed as a candidate."""
         from core.control_plane.device_health_registry import DeviceHealthRegistry
 

--- a/tests/test_pr530_runtime_acceptance_and_spine_hardening.py
+++ b/tests/test_pr530_runtime_acceptance_and_spine_hardening.py
@@ -483,11 +483,12 @@ class TestNodeLayerRegression:
             "module": None,
         }
 
-        with patch("core.routes._helpers._load_node", return_value=fake_node_info), \
-             patch("core.routes._helpers._execute_node",
-                   new_callable=AsyncMock, return_value=sentinel), \
-             patch("core.routes._helpers.nodes_root", "/fake"), \
-             patch("os.path.exists", return_value=True):
+        # 节点执行已收口 core.node_invocation.invoke_node(canonical),
+        # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
+        from types import SimpleNamespace as _SN
+        _mock_invoke = AsyncMock(return_value=_SN(
+            success=True, result=sentinel, error=None))
+        with patch("core.node_invocation.invoke_node", _mock_invoke):
             result = await oc._dispatch_tool_call("node__node_reg_ok__run", {})
 
         assert result.get("success") is True
@@ -506,11 +507,12 @@ class TestNodeLayerRegression:
             "module": None,
         }
 
-        with patch("core.routes._helpers._load_node", return_value=fake_node_info), \
-             patch("core.routes._helpers._execute_node",
-                   new_callable=AsyncMock, return_value=sentinel), \
-             patch("core.routes._helpers.nodes_root", "/fake"), \
-             patch("os.path.exists", return_value=True):
+        # 节点执行已收口 core.node_invocation.invoke_node(canonical),
+        # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
+        from types import SimpleNamespace as _SN
+        _mock_invoke = AsyncMock(return_value=_SN(
+            success=True, result=sentinel, error=None))
+        with patch("core.node_invocation.invoke_node", _mock_invoke):
             result = await oc._dispatch_tool_call("node__node_inline_ok__run", {})
 
         assert result.get("success") is True
@@ -739,11 +741,12 @@ class TestMCPLayerRegression:
             "module": None,
         }
 
-        with patch("core.routes._helpers._load_node", return_value=fake_node_info), \
-             patch("core.routes._helpers._execute_node",
-                   new_callable=AsyncMock, return_value=sentinel), \
-             patch("core.routes._helpers.nodes_root", "/fake"), \
-             patch("os.path.exists", return_value=True):
+        # 节点执行已收口 core.node_invocation.invoke_node(canonical),
+        # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
+        from types import SimpleNamespace as _SN
+        _mock_invoke = AsyncMock(return_value=_SN(
+            success=True, result=sentinel, error=None))
+        with patch("core.node_invocation.invoke_node", _mock_invoke):
             node_result = await oc._dispatch_tool_call("node__after_mcp_node__run", {})
 
         assert node_result.get("success") is True
@@ -1126,11 +1129,12 @@ class TestFailurePaths:
             "execute": AsyncMock(return_value=sentinel),
             "module": None,
         }
-        with patch("core.routes._helpers._load_node", return_value=fake_node_info), \
-             patch("core.routes._helpers._execute_node",
-                   new_callable=AsyncMock, return_value=sentinel), \
-             patch("core.routes._helpers.nodes_root", "/fake"), \
-             patch("os.path.exists", return_value=True):
+        # 节点执行已收口 core.node_invocation.invoke_node(canonical),
+        # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
+        from types import SimpleNamespace as _SN
+        _mock_invoke = AsyncMock(return_value=_SN(
+            success=True, result=sentinel, error=None))
+        with patch("core.node_invocation.invoke_node", _mock_invoke):
             r3 = await oc._dispatch_tool_call("node__degrade_node__run", {})
         assert r3.get("success") is True
         assert r3.get("result") == sentinel

--- a/tests/test_pr530_runtime_acceptance_and_spine_hardening.py
+++ b/tests/test_pr530_runtime_acceptance_and_spine_hardening.py
@@ -477,11 +477,6 @@ class TestNodeLayerRegression:
         oc._capability_dispatcher._node_id_to_key["node_reg_ok"] = "Node_reg_ok"
 
         sentinel = {"status": "node_ok"}
-        fake_node_info = {
-            "type": "function",
-            "execute": AsyncMock(return_value=sentinel),
-            "module": None,
-        }
 
         # 节点执行已收口 core.node_invocation.invoke_node(canonical),
         # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
@@ -501,11 +496,6 @@ class TestNodeLayerRegression:
         oc._node_id_to_key["node_inline_ok"] = "Node_inline_ok"
 
         sentinel = {"status": "inline_node_ok"}
-        fake_node_info = {
-            "type": "function",
-            "execute": AsyncMock(return_value=sentinel),
-            "module": None,
-        }
 
         # 节点执行已收口 core.node_invocation.invoke_node(canonical),
         # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
@@ -735,11 +725,6 @@ class TestMCPLayerRegression:
         oc._node_id_to_key["after_mcp_node"] = "Node_after_mcp"
         oc._capability_dispatcher._node_id_to_key["after_mcp_node"] = "Node_after_mcp"
         sentinel = {"node_after_mcp_fail": True}
-        fake_node_info = {
-            "type": "function",
-            "execute": AsyncMock(return_value=sentinel),
-            "module": None,
-        }
 
         # 节点执行已收口 core.node_invocation.invoke_node(canonical),
         # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
@@ -1124,11 +1109,6 @@ class TestFailurePaths:
         oc._node_id_to_key["degrade_node"] = "Node_degrade"
         oc._capability_dispatcher._node_id_to_key["degrade_node"] = "Node_degrade"
         sentinel = {"degrade": "node_ok"}
-        fake_node_info = {
-            "type": "function",
-            "execute": AsyncMock(return_value=sentinel),
-            "module": None,
-        }
         # 节点执行已收口 core.node_invocation.invoke_node(canonical),
         # core.routes._helpers 直载路径退役——桩改打 canonical 入口。
         from types import SimpleNamespace as _SN

--- a/tests/test_pr7_canonical_orchestration_gate.py
+++ b/tests/test_pr7_canonical_orchestration_gate.py
@@ -44,6 +44,7 @@ import sys
 import os
 import asyncio
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -148,7 +149,11 @@ class TestDagLoopCandidateGate(unittest.IsolatedAsyncioTestCase):
         rt._smart_orchestrator = self._make_orchestrator()
         pool = self._make_pool("dev_eligible")
 
+        # run() 现在先过【集体】调度门(participation 层无就绪设备即 BLOCKED,
+        # 逐候选门根本不被咨询)——给集体门一个候选,让本用例钉的逐候选门可达。
         with patch.object(rt, "_get_device_pool", return_value=pool), \
+             patch.object(rt, "_get_orchestration_candidate_set",
+                          return_value=[SimpleNamespace(device_id="dev_eligible")]), \
              patch.object(rt, "_try_node71", new_callable=AsyncMock, return_value=None), \
              patch.object(rt, "_is_orchestration_ready", return_value=True) as mock_gate:
             result = await rt.run(task_description="test task")
@@ -164,6 +169,8 @@ class TestDagLoopCandidateGate(unittest.IsolatedAsyncioTestCase):
         pool = self._make_pool("dev_not_eligible")
 
         with patch.object(rt, "_get_device_pool", return_value=pool), \
+             patch.object(rt, "_get_orchestration_candidate_set",
+                          return_value=[SimpleNamespace(device_id="dev_not_eligible")]), \
              patch.object(rt, "_try_node71", new_callable=AsyncMock, return_value=None), \
              patch.object(rt, "_is_orchestration_ready", return_value=False) as mock_gate:
             result = await rt.run(task_description="test task")
@@ -228,6 +235,8 @@ class TestGetOrchestrationReadyDevices(unittest.TestCase):
             return eligible_status if device_id == "dev_a" else ineligible_status
 
         with patch("core.device_participation._get_udm", return_value=udm), \
+             patch("core.device_participation._get_canonical_readiness",
+                   return_value=SimpleNamespace(registered=True, online=True, routable=True)), \
              patch("core.device_participation._get_selector_status", side_effect=fake_selector):
             results = get_orchestration_ready_devices()
 
@@ -243,7 +252,11 @@ class TestGetOrchestrationReadyDevices(unittest.TestCase):
         eligible_status = _make_selector_status(orchestration_eligible=True)
         udm = _make_udm(["dev_ok"])
 
+        # Layer-1 就绪(registered/routable)现在闸住 selector 资格——
+        # 有意加严:selector 说合格但传输不可达的设备不得入选。补就绪桩。
         with patch("core.device_participation._get_udm", return_value=udm), \
+             patch("core.device_participation._get_canonical_readiness",
+                   return_value=SimpleNamespace(registered=True, online=True, routable=True)), \
              patch("core.device_participation._get_selector_status", return_value=eligible_status):
             assert is_device_orchestration_ready("dev_ok") is True
 

--- a/tests/test_remote_agent_dispatch.py
+++ b/tests/test_remote_agent_dispatch.py
@@ -99,7 +99,9 @@ class TestRemoteDispatchEndToEnd:
             "request_id": task_id,
         }
 
-        with patch.object(cr, "route_command", return_value=mock_result) as mock_rc:
+        # PR-7:agent_execute 经 route_envelope(统一基底根)承载,
+        # route_command 为有意绕开的 compat shim。
+        with patch.object(cr, "route_envelope", return_value=mock_result) as mock_rc:
             result = await cr.dispatch_agent_remote(
                 device_id=REMOTE_DEVICE_ID,
                 agent_id=agent_id,
@@ -110,13 +112,12 @@ class TestRemoteDispatchEndToEnd:
                 task_id=task_id,
             )
 
-        # route_command must be called with command="agent_execute"
+        # route_envelope 必须携带 agent_execute 信封
         mock_rc.assert_called_once()
-        call_kwargs = mock_rc.call_args
-        assert call_kwargs.kwargs.get("command") == "agent_execute" or \
-               call_kwargs.args[1] == "agent_execute" or \
-               (len(call_kwargs.args) > 1 and call_kwargs.args[1] == "agent_execute"), \
-               f"Expected command='agent_execute', got: {call_kwargs}"
+        _env = mock_rc.call_args.args[0] if mock_rc.call_args.args \
+            else mock_rc.call_args.kwargs.get("envelope")
+        assert getattr(_env, "tool_name", None) == "agent_execute", \
+               f"Expected tool_name='agent_execute', got: {_env!r}"
 
         # Correlation IDs must be preserved
         assert result["agent_id"] == agent_id
@@ -133,11 +134,12 @@ class TestRemoteDispatchEndToEnd:
         cr = CommandRouter()
         captured_payload = {}
 
-        async def capture_route_command(device_id, command, payload, **kwargs):
-            captured_payload.update(payload)
+        async def capture_route_envelope(envelope, **kwargs):
+            # PR-7:全部字段承载于 TaskEnvelope.args
+            captured_payload.update(envelope.args or {})
             return _make_cr_result(success=True)
 
-        cr.route_command = capture_route_command
+        cr.route_envelope = capture_route_envelope
 
         trace_id = "trace_e2e_001"
         task_id = "task_e2e_001"
@@ -616,8 +618,9 @@ class TestWindowsAIPClientAgentExecute:
             "context": {},
         }
 
-        # autonomy_manager unavailable in test env
-        with patch("windows_client.windows_aip_client._get_manager", return_value=None):
+        # 执行仲裁器不可用(WindowsExecutionArbiter 已取代 WindowsAutonomyManager
+        # 直连成为设备端执行收口点)
+        with patch("windows_client.windows_aip_client._get_arbiter", return_value=None):
             result = _execute_agent_task(payload)
 
         assert result["agent_id"] == "agent_win_001"
@@ -630,9 +633,8 @@ class TestWindowsAIPClientAgentExecute:
         """_execute_agent_task must not raise even when autonomy manager throws."""
         from windows_client.windows_aip_client import _execute_agent_task
 
-        mock_manager = MagicMock()
-        mock_manager.execute_agent_task = MagicMock(side_effect=RuntimeError("simulated crash"))
-        mock_manager.execute_action = MagicMock(side_effect=RuntimeError("simulated crash"))
+        mock_arbiter = MagicMock()
+        mock_arbiter.route_command = MagicMock(side_effect=RuntimeError("simulated crash"))
 
         payload = {
             "agent_id": "agent_err",
@@ -643,7 +645,7 @@ class TestWindowsAIPClientAgentExecute:
             "agent_template": "analyst",
         }
 
-        with patch("windows_client.windows_aip_client._get_manager", return_value=mock_manager):
+        with patch("windows_client.windows_aip_client._get_arbiter", return_value=mock_arbiter):
             result = _execute_agent_task(payload)
 
         assert result["agent_id"] == "agent_err"

--- a/tests/test_task_cost_ledger.py
+++ b/tests/test_task_cost_ledger.py
@@ -1,0 +1,231 @@
+"""任务成本账本 + 效率闭环(Grok 借鉴 1→3→2)+ 哲学对齐接线 测试
+====================================================================
+
+北极星从"单次推理速度"换成"完成一个任务的总消耗":
+  1. 账本:开账→深链记账(LLM/工具/轮次)→结账落盘,契约完整。
+  2. router._record_call 漏斗自动记入当前任务账单。
+  3. runtime.handle_request 全生命周期开/结账,账单挂进响应 task_cost。
+  4. bandit 打分新增"啰嗦惩罚"(平均输出 token 越多越吃亏)。
+  5. 哲学对齐:intent.update 此前有订阅无发射——LIMINAL 期由 continuum tick
+     发射,阈限呼吸映射(0.15-0.85)终于有了数据源。
+"""
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. 账本契约
+# ---------------------------------------------------------------------------
+
+class TestLedgerContract:
+    def test_open_record_close_roundtrip(self, monkeypatch, tmp_path):
+        from core import task_cost_ledger as tcl
+        monkeypatch.setenv("GALAXY_TASK_LEDGER_PATH", str(tmp_path / "ledger.jsonl"))
+
+        token = tcl.open_task_bill("trace_t1", source="chat")
+        tcl.add_llm_usage("ollama", 100, 50, cost=0.001)
+        tcl.add_llm_usage("deepseek", 200, 80)
+        tcl.add_tool_call()
+        tcl.add_react_round()
+        tcl.add_react_round()
+        bill = tcl.close_task_bill(token, success=True)
+
+        assert bill["llm_calls"] == 2
+        assert bill["input_tokens"] == 300
+        assert bill["output_tokens"] == 130
+        assert bill["total_tokens"] == 430
+        assert bill["tool_calls"] == 1
+        assert bill["react_rounds"] == 2
+        assert bill["providers"] == {"ollama": 1, "deepseek": 1}
+        assert bill["success"] is True
+        assert bill["wall_ms"] >= 0
+
+        # JSONL 落盘(长期积累/微调原料)
+        lines = (tmp_path / "ledger.jsonl").read_text(encoding="utf-8").strip().splitlines()
+        assert json.loads(lines[-1])["trace_id"] == "trace_t1"
+
+        # 内存环形可查 + 汇总标尺
+        recent = tcl.get_task_cost_ledger().recent(5)
+        assert any(r["trace_id"] == "trace_t1" for r in recent)
+        assert tcl.get_task_cost_ledger().summary()["tasks"] >= 1
+
+    def test_no_bill_in_context_is_silent_noop(self):
+        from core import task_cost_ledger as tcl
+        # 无在途账单:深链记账入口必须静默无操作(绝不反噬)
+        tcl.add_llm_usage("x", 1, 1)
+        tcl.add_tool_call()
+        tcl.add_react_round()
+        assert tcl.current_task_bill() is None
+
+
+# ---------------------------------------------------------------------------
+# 2. router 漏斗自动记账
+# ---------------------------------------------------------------------------
+
+class TestRouterFunnelTap:
+    def test_record_call_feeds_current_bill(self, monkeypatch, tmp_path):
+        from core import task_cost_ledger as tcl
+        from core.multi_llm_router import MultiLLMRouter, TaskType, LLMResponse
+
+        monkeypatch.setenv("GALAXY_TASK_LEDGER_PATH", "off")
+        r = MultiLLMRouter.__new__(MultiLLMRouter)
+        r.providers = {}
+        r.call_history = []
+
+        token = tcl.open_task_bill("trace_r1", source="test")
+        resp = LLMResponse(content="x", provider="ollama", model="m",
+                           input_tokens=42, output_tokens=17, latency_ms=1.0)
+        r._record_call("ollama", "m", TaskType.GENERAL, resp, True)
+        bill = tcl.close_task_bill(token, success=True)
+
+        assert bill["llm_calls"] == 1
+        assert bill["input_tokens"] == 42 and bill["output_tokens"] == 17
+        # call_history 同步带上 tokens_out(bandit 啰嗦惩罚的数据源)
+        assert r.call_history[-1]["tokens_out"] == 17
+
+
+# ---------------------------------------------------------------------------
+# 3. runtime 全生命周期开/结账
+# ---------------------------------------------------------------------------
+
+class TestRuntimeBillLifecycle:
+    @pytest.mark.asyncio
+    async def test_handle_request_attaches_task_cost(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("GALAXY_TASK_LEDGER_PATH", str(tmp_path / "l.jsonl"))
+        from core.desktop_presence_runtime import DesktopPresenceRuntime
+        from core import task_cost_ledger as tcl
+
+        rt = DesktopPresenceRuntime()
+
+        async def _mock_process(**kwargs):
+            tcl.add_llm_usage("ollama", 10, 5)   # 深链某处记了一笔
+            return {"success": True, "response": "OK", "intent": "chat",
+                    "metadata": {"session_id": "s1"}}
+
+        with patch("core.openclawd.get_openclawd") as mock_get:
+            mock_clawd = MagicMock()
+            mock_clawd.process = AsyncMock(side_effect=_mock_process)
+            mock_get.return_value = mock_clawd
+            result = await rt.handle_request(message="hi", source="chat")
+
+        tc = result.get("task_cost")
+        assert tc, "响应必须携带 task_cost 账单"
+        assert tc["llm_calls"] == 1 and tc["total_tokens"] == 15
+        assert tc["source"] == "chat"
+        assert tc["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_bill_closed_even_on_error(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("GALAXY_TASK_LEDGER_PATH", str(tmp_path / "l.jsonl"))
+        from core.desktop_presence_runtime import DesktopPresenceRuntime
+        from core.task_cost_ledger import current_task_bill
+
+        rt = DesktopPresenceRuntime()
+        with patch("core.openclawd.get_openclawd") as mock_get:
+            mock_clawd = MagicMock()
+            mock_clawd.process = AsyncMock(side_effect=RuntimeError("boom"))
+            mock_get.return_value = mock_clawd
+            result = await rt.handle_request(message="hi", source="chat")
+
+        assert result.get("task_cost", {}).get("success") is False
+        assert current_task_bill() is None   # 上下文已复位,不泄漏到下个请求
+
+
+# ---------------------------------------------------------------------------
+# 4. bandit 啰嗦惩罚
+# ---------------------------------------------------------------------------
+
+class TestBanditVerbosityPenalty:
+    def _router_with_history(self, records):
+        from core.multi_llm_router import MultiLLMRouter
+        r = MultiLLMRouter.__new__(MultiLLMRouter)
+        r.call_history = records
+        return r
+
+    def test_verbose_provider_scores_lower(self):
+        """同成功率/延迟/成本,平均输出 token 高 4 倍的 provider 分更低。"""
+        base = {"task_type": "general", "latency_ms": 100.0,
+                "cost": 0.0, "success": True, "timestamp": 0.0}
+        records = []
+        for _ in range(20):
+            records.append({**base, "provider": "terse", "model": "m",
+                            "tokens": 600, "tokens_out": 400})
+            records.append({**base, "provider": "verbose", "model": "m",
+                            "tokens": 1800, "tokens_out": 1600})
+        r = self._router_with_history(records)
+        stats = r._provider_stats(None)
+        total = int(sum(s["calls"] for s in stats.values()))
+        assert r._bandit_score("terse", stats, total) > \
+            r._bandit_score("verbose", stats, total)
+
+    def test_legacy_records_without_tokens_out_tolerated(self):
+        """老 call_history 条目没有 tokens_out 字段:聚合按 0 处理,不炸。"""
+        records = [{"provider": "old", "model": "m", "task_type": "general",
+                    "latency_ms": 50.0, "tokens": 100, "cost": 0.0,
+                    "success": True, "timestamp": 0.0}] * 6
+        r = self._router_with_history(records)
+        stats = r._provider_stats(None)
+        assert stats["old"]["tokens_out_sum"] == 0.0
+        assert r._bandit_score("old", stats, 6) > 0
+
+
+# ---------------------------------------------------------------------------
+# 5. 哲学对齐:intent.update 终于有发射者
+# ---------------------------------------------------------------------------
+
+class TestIntentUpdateEmission:
+    @pytest.mark.asyncio
+    async def test_liminal_tick_emits_intent_update(self):
+        """LIMINAL 期 continuum tick 必须发射 intent.update(此前全仓库
+        只有订阅者没有发射者,阈限呼吸映射从未被驱动过)。"""
+        from core.desktop_presence_runtime import RuntimeSession, TriState
+        from core.state_event_bus import get_state_event_bus
+
+        bus = get_state_event_bus()
+        got = []
+        tok = bus.subscribe("intent.update", lambda e: got.append(
+            getattr(e, "payload", e)))
+
+        s = RuntimeSession(source="chat")
+        try:
+            s.advance(TriState.LIMINAL)   # 启动 continuum tick
+            await asyncio.sleep(0.45)     # 让 tick(200ms 周期)至少跑一拍
+            assert got, "LIMINAL 期必须周期性发射 intent.update"
+            payload = got[-1] if isinstance(got[-1], dict) else {}
+            assert "intent_strength" in payload
+        finally:
+            s.advance(TriState.SILENT)    # 停 tick
+            try:
+                bus.unsubscribe(tok)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+# ---------------------------------------------------------------------------
+# 6. 输出预算 env
+# ---------------------------------------------------------------------------
+
+class TestAnswerBudget:
+    @pytest.mark.asyncio
+    async def test_react_loop_respects_max_tokens_env(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_MAX_TOKENS_ANSWER", "1234")
+        from core.multi_llm_router import LLMResponse
+        from core.openclawd import OpenClawd
+
+        seen = {}
+
+        class _FakeRouter:
+            async def chat_with_tools(self, messages, tools=None, task_type=None,
+                                      max_tokens=4096, **kwargs):
+                seen["max_tokens"] = max_tokens
+                return LLMResponse(content="答", provider="p", model="m",
+                                   input_tokens=1, output_tokens=1, latency_ms=1.0)
+
+        clawd = OpenClawd.__new__(OpenClawd)
+        clawd._get_router = lambda: _FakeRouter()
+        result = await clawd._react_loop([{"role": "user", "content": "q"}], tools=None)
+        assert seen["max_tokens"] == 1234
+        assert result["response"] == "答"

--- a/tests/test_tristate_multimodal_sync.py
+++ b/tests/test_tristate_multimodal_sync.py
@@ -1,0 +1,242 @@
+"""三态×多模态一致性(动画随真实输入输出自然过渡)测试
+============================================================
+
+用户反馈的核查点:三态过渡是否自然、是否真的伴随多模态输入输出。
+钉住两处根修:
+
+  1. **speaking 生命周期归属**:相位切换(phase.silent/manifest)绝不踩掉
+     speaking——它由 speech_output 的 set_ai_speaking(播放起止)全权管理。
+     否则"响应文本一好 runtime 回 SILENT,TTS 还在播,嘴在动、动画已灭"。
+     且说话期间桥端维持可见的在场深度地板,说完才自然缓落。
+  2. **MANIFEST=首输出**:流式请求在第一个 token 流出的瞬间才 LIMINAL→MANIFEST,
+     LLM 思考期(CPU 机上数十秒)停留在 LIMINAL(思考动画),不再"拿到车道
+     就 manifest、阈限态几毫秒被跳过"。非流式调用保持原时序;零输出请求
+     仍补齐 canonical 三段轨迹(liminal→manifest→silent)。
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. 桥端:speaking 不被相位踩灭 + 说话深度地板
+# ---------------------------------------------------------------------------
+
+class TestBridgeSpeakingOwnership:
+    @pytest.mark.asyncio
+    async def test_phase_silent_does_not_stomp_speaking(self):
+        from core.lumiv_websocket_bridge import GalaxyPresenceBridge
+        bridge = GalaxyPresenceBridge.get_instance()
+        bridge._loop = asyncio.get_running_loop()
+        bridge._speaking = True   # TTS 播放中(set_ai_speaking(True) 已置)
+
+        bridge._on_phase_silent({})     # 响应完成,runtime 回 SILENT
+        assert bridge._speaking is True, "相位切换不得踩掉 speaking(播放未结束)"
+        assert bridge._current_mode == "static"
+
+        bridge._on_phase_manifest({})
+        assert bridge._speaking is True
+
+        bridge._speaking = False  # 复位,不污染其它测试
+
+    @pytest.mark.asyncio
+    async def test_speaking_floor_holds_visible_depth(self):
+        """SILENT+speaking:广播的 depth 维持地板(≥liminal),说完落回相位深度。"""
+        from core.lumiv_websocket_bridge import (
+            GalaxyPresenceBridge, MODE_DEPTH_MAP,
+        )
+        bridge = GalaxyPresenceBridge.get_instance()
+        bridge._loop = asyncio.get_running_loop()
+        bridge._on_phase_silent({})
+
+        bridge._speaking = True
+        msg = bridge._build_message()
+        assert msg["payload"]["depth_factor"] >= MODE_DEPTH_MAP["liminal"], \
+            "说话中即使相位已静默,也要维持可见在场深度"
+        assert msg["payload"]["speaking"] is True
+
+        bridge._speaking = False
+        msg = bridge._build_message()
+        assert msg["payload"]["depth_factor"] == MODE_DEPTH_MAP["static"], \
+            "说完自然落回相位深度(渲染端弹簧缓落)"
+
+    @pytest.mark.asyncio
+    async def test_manifest_depth_not_lowered_by_floor(self):
+        """MANIFEST(0.92)本就高于地板:地板只抬不压。"""
+        from core.lumiv_websocket_bridge import (
+            GalaxyPresenceBridge, MODE_DEPTH_MAP,
+        )
+        bridge = GalaxyPresenceBridge.get_instance()
+        bridge._loop = asyncio.get_running_loop()
+        bridge._on_phase_manifest({})
+        bridge._speaking = True
+        msg = bridge._build_message()
+        assert msg["payload"]["depth_factor"] == MODE_DEPTH_MAP["manifest"]
+        bridge._speaking = False
+        bridge._on_phase_silent({})
+
+
+# ---------------------------------------------------------------------------
+# 2. runtime:MANIFEST 由首输出驱动
+# ---------------------------------------------------------------------------
+
+def _phase_recorder():
+    """订阅三个相位事件,返回 (记录列表, 退订函数)。"""
+    from core.state_event_bus import get_state_event_bus
+    bus = get_state_event_bus()
+    seen = []
+    tokens = [
+        bus.subscribe(name, lambda e, _n=name: seen.append(_n.split(".")[1]))
+        for name in ("phase.silent", "phase.liminal", "phase.manifest")
+    ]
+
+    def _cleanup():
+        for t in tokens:
+            try:
+                bus.unsubscribe(t)
+            except Exception:  # noqa: BLE001
+                pass
+
+    return seen, _cleanup
+
+
+def _ok_result():
+    return {"success": True, "response": "OK", "intent": "chat",
+            "metadata": {"session_id": "s1"}}
+
+
+class TestManifestOnFirstToken:
+    @pytest.mark.asyncio
+    async def test_streaming_manifest_fires_at_first_delta(self, monkeypatch):
+        """流式请求:process 期间(思考)保持 LIMINAL;第一段文本流出瞬间进 MANIFEST。"""
+        monkeypatch.setenv("GALAXY_MANIFEST_ON_FIRST_TOKEN", "1")
+        from core.desktop_presence_runtime import DesktopPresenceRuntime
+        from core.llm_stream import TokenStream, use_stream
+
+        rt = DesktopPresenceRuntime()
+        seen, cleanup = _phase_recorder()
+        sink = TokenStream(on_delta=lambda t: None)
+        phase_at_feed = {}
+
+        async def _mock_process(**kwargs):
+            # 思考期:尚未流出任何 token → 不得已进 MANIFEST
+            phase_at_feed["before"] = list(seen)
+            sink.feed("第一段")           # ← 首输出瞬间
+            phase_at_feed["after"] = list(seen)
+            return _ok_result()
+
+        try:
+            with patch("core.openclawd.get_openclawd") as mock_get:
+                mock_clawd = MagicMock()
+                mock_clawd.process = AsyncMock(side_effect=_mock_process)
+                mock_get.return_value = mock_clawd
+                with use_stream(sink):
+                    result = await rt.handle_request(message="hi", source="chat")
+        finally:
+            cleanup()
+
+        assert result["tristate"] == "silent"
+        assert "manifest" not in phase_at_feed["before"], \
+            "思考期(无输出)不得提前进 MANIFEST"
+        assert "manifest" in phase_at_feed["after"], \
+            "首 token 流出瞬间必须进 MANIFEST"
+        # canonical 三段轨迹完整且有序
+        assert seen.index("liminal") < seen.index("manifest") < seen.index("silent")
+
+    @pytest.mark.asyncio
+    async def test_streaming_sink_callback_restored_after_request(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_MANIFEST_ON_FIRST_TOKEN", "1")
+        from core.desktop_presence_runtime import DesktopPresenceRuntime
+        from core.llm_stream import TokenStream, use_stream
+
+        rt = DesktopPresenceRuntime()
+        orig_cb = lambda t: None  # noqa: E731
+        sink = TokenStream(on_delta=orig_cb)
+
+        with patch("core.openclawd.get_openclawd") as mock_get:
+            mock_clawd = MagicMock()
+            mock_clawd.process = AsyncMock(return_value=_ok_result())
+            mock_get.return_value = mock_clawd
+            with use_stream(sink):
+                await rt.handle_request(message="hi", source="chat")
+
+        assert sink._on_delta is orig_cb, \
+            "请求结束必须恢复 sink 回调(伪流式兜底不得触发死会话的相位钩子)"
+
+    @pytest.mark.asyncio
+    async def test_zero_output_request_still_emits_canonical_order(self, monkeypatch):
+        """整个请求零输出(如异常):仍补齐 liminal→manifest→silent。"""
+        monkeypatch.setenv("GALAXY_MANIFEST_ON_FIRST_TOKEN", "1")
+        from core.desktop_presence_runtime import DesktopPresenceRuntime
+        from core.llm_stream import TokenStream, use_stream
+
+        rt = DesktopPresenceRuntime()
+        seen, cleanup = _phase_recorder()
+        sink = TokenStream(on_delta=lambda t: None)
+
+        try:
+            with patch("core.openclawd.get_openclawd") as mock_get:
+                mock_clawd = MagicMock()
+                mock_clawd.process = AsyncMock(side_effect=RuntimeError("boom"))
+                mock_get.return_value = mock_clawd
+                with use_stream(sink):
+                    result = await rt.handle_request(message="hi", source="chat")
+        finally:
+            cleanup()
+
+        assert result["tristate"] == "silent"
+        assert seen.index("liminal") < seen.index("manifest") < seen.index("silent")
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_keeps_original_timing(self, monkeypatch):
+        """非流式调用:保持旧时序——派发前就已在 MANIFEST。"""
+        monkeypatch.setenv("GALAXY_MANIFEST_ON_FIRST_TOKEN", "1")
+        from core.desktop_presence_runtime import DesktopPresenceRuntime
+
+        rt = DesktopPresenceRuntime()
+        seen, cleanup = _phase_recorder()
+        manifest_before_process = {}
+
+        async def _mock_process(**kwargs):
+            manifest_before_process["v"] = "manifest" in seen
+            return _ok_result()
+
+        try:
+            with patch("core.openclawd.get_openclawd") as mock_get:
+                mock_clawd = MagicMock()
+                mock_clawd.process = AsyncMock(side_effect=_mock_process)
+                mock_get.return_value = mock_clawd
+                result = await rt.handle_request(message="hi", source="chat")
+        finally:
+            cleanup()
+
+        assert manifest_before_process["v"] is True
+        assert result["tristate"] == "silent"
+
+    @pytest.mark.asyncio
+    async def test_kill_switch_reverts_to_old_behavior(self, monkeypatch):
+        """GALAXY_MANIFEST_ON_FIRST_TOKEN=0:流式也回旧时序(派发前 MANIFEST)。"""
+        monkeypatch.setenv("GALAXY_MANIFEST_ON_FIRST_TOKEN", "0")
+        from core.desktop_presence_runtime import DesktopPresenceRuntime
+        from core.llm_stream import TokenStream, use_stream
+
+        rt = DesktopPresenceRuntime()
+        seen, cleanup = _phase_recorder()
+        manifest_before_process = {}
+
+        async def _mock_process(**kwargs):
+            manifest_before_process["v"] = "manifest" in seen
+            return _ok_result()
+
+        try:
+            with patch("core.openclawd.get_openclawd") as mock_get:
+                mock_clawd = MagicMock()
+                mock_clawd.process = AsyncMock(side_effect=_mock_process)
+                mock_get.return_value = mock_clawd
+                with use_stream(TokenStream(on_delta=lambda t: None)):
+                    await rt.handle_request(message="hi", source="chat")
+        finally:
+            cleanup()
+
+        assert manifest_before_process["v"] is True

--- a/windows_client/windows_aip_client.py
+++ b/windows_client/windows_aip_client.py
@@ -107,11 +107,18 @@ def _execute_command(task_type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     if arbiter is None:
         return {"success": False, "error": "execution arbiter unavailable"}
 
-    result = arbiter.route_command(
-        action=task_type,
-        params=payload,
-        device_id="local",
-    )
+    try:
+        result = arbiter.route_command(
+            action=task_type,
+            params=payload,
+            device_id="local",
+        )
+    except Exception as exc:  # noqa: BLE001
+        # 设备端契约(Acceptance Gate A):执行器崩溃绝不外抛——回错误信封,
+        # 关联 ID 由上层补齐,消息处理循环保持存活。否则一次执行器故障就会
+        # 炸断整个 WS 消息处理。
+        logger.error("[%s] 执行仲裁器异常(已兜住): %s", task_type, exc)
+        return {"success": False, "error": str(exc)}
     # Normalise to the flat dict shape callers expect
     if isinstance(result, dict) and "result" in result:
         merged = {"success": result.get("success", False)}


### PR DESCRIPTION
# 一、Ollama 原生 function calling(真功能缺口)

OpenAI/Anthropic 适配器发 `tools`、解析 `tool_calls`,而 **OllamaAdapter 两头都没有**——本地-only 部署(正是真机形态)的主脑从来"看不到"工具,整个 ReAct 工具层对本地模型是哑的。补齐:`tools` 随请求体发送;非流式与 NDJSON 流式都解析并归一成 OpenAI 形状(dict 参数→JSON 字符串+合成 id);gemma 系无工具模板返回 400 时**去工具重试**并告警提示换 qwen/minicpm。

# 二、延迟优化(讨论定案的 A+C+B)

- **A. `GALAXY_OLLAMA_NUM_CTX`(默认 8192)**:此前不设,prompt 超模型默认 4096 即滑窗截断→前缀 KV 缓存每轮全废→每轮全量重预填(CPU 机"越聊越慢"元凶之一)。
- **C. `core/context_trim`**:工具结果头+尾保留式截断;ReAct 保最近 3 轮完整、更早大结果换短存根(>500 字才剪)。
- **B. 工具定义 auto 瘦身**:阈值(24)内原样不动;超了按词法相关性挑 top-K,核心工具永不裁,选后保持原序(前缀字节稳定)。

# 三、IndexTTS2 质量档(零样本克隆+情绪)

`GALAXY_TTS_ENGINE=indextts` 显式选择才启用,不进默认回退链(CPU 合成一句数秒到数十秒;实时对话留在 edge/kokoro)。参考音频克隆 + 官方四种情绪控制;权重自动拉取默认关(显式开、走 HF 镜像);签名漂移降级兜底,失败自动落回默认链。

# 四、三态×多模态一致性(动画随真实输入输出自然过渡)

- **speaking 归属**:相位事件不再踩掉 speaking;+说话深度地板——播放中即使相位已静默也维持可见在场,说完弹簧自然缓落("嘴在动、动画已灭"根修)。
- **MANIFEST=首输出**:流式请求在第一个 token 流出的瞬间才进 MANIFEST,LLM 思考期停留在 LIMINAL;非流式保持原时序;`GALAXY_MANIFEST_ON_FIRST_TOKEN=0` 可回退。
- 灵动岛文案:"倾听中"→"说话中"。

# 五、任务成本账本 + 效率闭环(Grok 借鉴,北极星=任务总消耗)

- **账本**(`core/task_cost_ledger.py`):runtime 开账挂 contextvars,深链三点自动记账(router 漏斗记 LLM/token/成本、ReAct 记轮次、派发记工具),结账落内存环形+JSONL(长期积累=将来微调专属小模型的原料)+一行日志+响应 `task_cost` 字段。
- **输出精简**:系统提示词表达原则(直接简洁/要调工具直接调)+`GALAXY_MAX_TOKENS_ANSWER` 输出预算。
- **bandit 啰嗦惩罚**:UCB1 新增第四项——同样办成事,平均输出 token 越多越吃亏(本地 输出 token≈等待秒数,云端≈账单)。
- **哲学-实现脱节对账(第一处接通)**:`intent.update` 有订阅者(阈限呼吸映射)却全仓库没有发射者、continuum tick 有发射没消费、且思考期数据恒零——同一设计的两半从未接上。现在 tick 思考期读活的持续认知场并在 LIMINAL 期发射 `intent.update`,阈限呼吸第一次有真数据,与"MANIFEST=首输出"成套。

## 验证

新增 36 条测试全绿(latency/tools/indextts 19 + tristate sync 8 + task ledger 9);相关回归 10 套件 223 条全过;lint 差分为零。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b