### PR TITLE
排查第五批(5a–5d):45 条基线清零 + 5 个真代码修复

### DIFF
--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -9297,7 +9297,11 @@ class OpenClawd:
                 tool_name=command,
                 args=payload or {},
                 remote_execution_mode=RemoteExecutionMode.command_only,
-                required_capabilities=_effective_caps,
+                # TaskEnvelope.required_capabilities 是非可空 List[str]:传 None
+                # 会让 Pydantic 校验在 try 里爆炸,整条 canonical 路由被静默
+                # 跳过、跌落 legacy websocket 兜底。与 envelope_from_command_
+                # request 同口径:空能力要求 == []。
+                required_capabilities=_effective_caps or [],
                 metadata={
                     "command_id": command_id,
                     "session_id": session_id,

--- a/core/recovery_truth_surface.py
+++ b/core/recovery_truth_surface.py
@@ -949,9 +949,15 @@ def _build_in_flight_continuity_entry(available_modules: List[str]) -> RecoveryT
             continuity_actions_present = None
 
     if continuity_contract_present:
+        # 诚实边界:这里只做了静态结构探测(模块在场、契约字段齐全),
+        # 没有观察到任何一次真实的重启恢复事件。按 RecoveryTruthStatus
+        # 语义,observed 必须有 live coordinator evidence 或 durable
+        # records 支撑——结构完整只配 partial。声称 observed 会恰好违背
+        # 证据里引用的 STATE_RESTORED_IS_NOT_CONTINUITY_RESTORED 原则
+        # (在场不等于确证)。
         return RecoveryTruthEntry(
             dimension=dimension,
-            status=RecoveryTruthStatus.observed,
+            status=RecoveryTruthStatus.partial,
             recovery_level=RecoveryLevel.task_continuity,
             evidence_summary=(
                 "InFlightTaskContinuityContract (PR-P1-1) is present and "
@@ -965,11 +971,17 @@ def _build_in_flight_continuity_entry(available_modules: List[str]) -> RecoveryT
                 "in RuntimeRecoveryReport.continuity_report.  "
                 "STATE_RESTORED_IS_NOT_CONTINUITY_RESTORED_POLICY enforced: "
                 "state presence in the registry does not equal continuity "
-                "confirmation."
+                "confirmation.  No live restart-recovery event was observed "
+                "in this process instance — structural wiring alone does not "
+                "upgrade this dimension to 'observed'."
             ),
             policy_reference=policy,
             supporting_modules=supporting,
-            deferred_note="",
+            deferred_note=(
+                "Upgrade to 'observed' requires a live recovery pass with a "
+                "non-empty TaskContinuityReport (durable evidence), not a "
+                "static module probe."
+            ),
         )
     if continuity_actions_present:
         return RecoveryTruthEntry(

--- a/galaxy_gateway/android/handlers/auth.py
+++ b/galaxy_gateway/android/handlers/auth.py
@@ -1,0 +1,150 @@
+"""
+galaxy_gateway/android/handlers/auth.py
+
+PR-AUTH-UNIFIED(服务端补齐):处理客户端 onOpen 后发送的统一 ``auth``
+首帧,并以 ``auth_ok`` / ``auth_failed`` 应答。
+
+背景
+----
+Android / WearOS 客户端的 AuthMessage 契约(shared-protocol
+AuthMessage.kt)早已上线:连接建立后第一帧发
+``{"type": "auth", "token": ..., "device_id": ..., "device_type": ...}``,
+并等待 ``auth_ok`` / ``auth_failed`` / ``auth_invalid``。此前 V2 侧没有
+任何应答者——客户端发了就石沉大海,文档写的认证状态机两端空转。
+
+语义(与 core.auth 的 canonical 口径一致,不另起炉灶)
+----------------------------------------------------
+- 认证开关:``core.auth.is_auth_enabled()``(GALAXY_AUTH_ENABLED,
+  production 模式强制开)。**关闭时诚实应答**:回 ``auth_ok`` 且
+  ``auth_enforced=false``——不假装校验过。
+- 令牌源:``core.auth.get_active_tokens()``(支持轮换重叠窗口)。
+- 失败语义:开了认证而令牌缺失/不匹配 → ``auth_failed`` + reason;
+  服务端不在此处强行断连(传输层归属 websocket 路由),由客户端按
+  契约自行断开并停止重连风暴。
+- 连接级状态:结果记入 ``bridge`` 的连接认证表,供后续按需门控。
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any, Dict
+
+if TYPE_CHECKING:
+    from galaxy_gateway.android_bridge import AndroidBridge
+
+logger = logging.getLogger(__name__)
+
+_VALID_DEVICE_TYPES = frozenset({"android", "wearos", "windows", "desktop"})
+
+
+def _mask(value: str, keep: int = 4) -> str:
+    """Return a log-safe masked form of a secret-ish string."""
+    if not value:
+        return "<empty>"
+    if len(value) <= keep * 2:
+        return "*" * len(value)
+    return f"{value[:keep]}…{value[-keep:]}"
+
+
+async def handle_auth(
+    bridge: "AndroidBridge", websocket: Any, message: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Handle the unified post-connect ``auth`` frame.
+
+    Returns an ``auth_ok`` or ``auth_failed`` response dict that the
+    ingress loop writes back to the socket.
+    """
+    device_id = str(message.get("device_id") or "").strip()
+    device_type = str(message.get("device_type") or "").strip().lower()
+    token = str(message.get("token") or "")
+    message_id = str(message.get("message_id") or uuid.uuid4())
+
+    def _response(
+        ok: bool,
+        *,
+        reason: str = "",
+        auth_enforced: bool,
+    ) -> Dict[str, Any]:
+        return {
+            "version": "3.0",
+            "type": "auth_ok" if ok else "auth_failed",
+            "message_id": str(uuid.uuid4()),
+            "correlation_id": message_id,
+            "device_id": device_id,
+            "auth_enforced": auth_enforced,
+            **({"reason": reason} if reason else {}),
+        }
+
+    if device_type and device_type not in _VALID_DEVICE_TYPES:
+        logger.warning(
+            "[WS:AUTH] unknown device_type=%r device_id=%s — continuing "
+            "(forward-compat: new platforms must not be locked out by the "
+            "auth surface)",
+            device_type,
+            _mask(device_id),
+        )
+
+    try:
+        from core.auth import get_active_tokens, is_auth_enabled
+    except Exception as exc:  # pragma: no cover — auth module must not hard-fail ingress
+        logger.error("[WS:AUTH] core.auth unavailable (%s) — failing closed", exc)
+        return _response(False, reason="auth_backend_unavailable", auth_enforced=True)
+
+    if not is_auth_enabled():
+        # 诚实语义:未开启认证就明说没校验,客户端据此知道自己处于
+        # 开放网关模式,而不是误以为令牌被验证过。
+        logger.info(
+            "[WS:AUTH] auth disabled (GALAXY_AUTH_ENABLED off) — auth_ok "
+            "with auth_enforced=false device_id=%s",
+            _mask(device_id),
+        )
+        _record_connection_auth(bridge, device_id, authenticated=True, enforced=False)
+        return _response(True, auth_enforced=False)
+
+    active_tokens = get_active_tokens()
+    if not active_tokens:
+        logger.error(
+            "[WS:AUTH] auth enabled but no active tokens configured "
+            "(GALAXY_API_TOKEN / GALAXY_API_TOKENS) — auth_failed"
+        )
+        return _response(False, reason="server_not_configured", auth_enforced=True)
+
+    if not token:
+        logger.warning("[WS:AUTH] missing token device_id=%s", _mask(device_id))
+        return _response(False, reason="missing_token", auth_enforced=True)
+
+    if token not in active_tokens:
+        logger.warning(
+            "[WS:AUTH] invalid token device_id=%s token=%s",
+            _mask(device_id),
+            _mask(token),
+        )
+        return _response(False, reason="invalid_token", auth_enforced=True)
+
+    logger.info(
+        "[WS:AUTH] auth_ok device_id=%s device_type=%s",
+        _mask(device_id),
+        device_type or "unknown",
+    )
+    _record_connection_auth(bridge, device_id, authenticated=True, enforced=True)
+    return _response(True, auth_enforced=True)
+
+
+def _record_connection_auth(
+    bridge: "AndroidBridge", device_id: str, *, authenticated: bool, enforced: bool
+) -> None:
+    """Best-effort: record the auth outcome on the bridge for later gating."""
+    if not device_id:
+        return
+    try:
+        table = getattr(bridge, "_connection_auth_state", None)
+        if table is None:
+            table = {}
+            setattr(bridge, "_connection_auth_state", table)
+        table[device_id] = {
+            "authenticated": authenticated,
+            "auth_enforced": enforced,
+        }
+    except Exception as exc:  # noqa: BLE001 — observability only, never blocks auth
+        logger.debug("[WS:AUTH] connection auth state record skipped: %s", exc)

--- a/galaxy_gateway/android/handlers/task_lifecycle.py
+++ b/galaxy_gateway/android/handlers/task_lifecycle.py
@@ -651,12 +651,17 @@ async def handle_task_result(
     )
 
     # ── Durable idempotency: suppress cross-restart duplicate results ──
+    # 只查不记:记录延后到本条消息真正被接纳之后(见下方 ingress 之后的
+    # 补记)。"收到即记录"有两个实际危害:
+    #   1) 统一 ingress 在消息缺 message_id/idempotency_key 时回退用裸
+    #      task_id 作联合幂等键,读的是同一个持久库——会把本条消息刚记
+    #      的键当成重复(duplicate_ignored),完成通知被错误抑制,
+    #      device_router 的 awaiter 只能靠超时结束;
+    #   2) 被后续门(schema/连续性合法性)拒绝的结果也已占坑,合法重试
+    #      会被误杀为跨重启重复。
     if task_id:
         try:
-            from core.durable_result_idempotency import (
-                check_result_idempotency,
-                record_result_idempotency,
-            )
+            from core.durable_result_idempotency import check_result_idempotency
             if check_result_idempotency(task_id):
                 logger.info(
                     "task_lifecycle: duplicate task result suppressed (durable store): "
@@ -665,7 +670,6 @@ async def handle_task_result(
                     device_id,
                 )
                 return
-            record_result_idempotency(task_id)
         except Exception as _idem_exc:  # noqa: BLE001 — durable store must never block dispatch
             logger.debug(
                 "task_lifecycle: durable idempotency check skipped (non-fatal): %s",
@@ -911,6 +915,21 @@ async def handle_task_result(
                 "falling back to legacy truth chain task_id=%s err=%s",
                 task_id,
                 _local_ingress_err,
+            )
+
+    # ── Durable idempotency: deferred record ──
+    # 统一 ingress 运行时,其 _record_idempotency 已在 first_accepted 后
+    # 记录联合幂等键(idempotency_key/lineage,含裸 task_id 回退),这里
+    # 不再重复占键;仅当 ingress 不可用走 legacy 链时,才补记裸 task_id
+    # 以保住跨重启去重。
+    if task_id and not _unified_result_ingress_ran:
+        try:
+            from core.durable_result_idempotency import record_result_idempotency
+            record_result_idempotency(task_id)
+        except Exception as _idem_rec_exc:  # noqa: BLE001 — durable store must never block dispatch
+            logger.debug(
+                "task_lifecycle: durable idempotency record skipped (non-fatal): %s",
+                _idem_rec_exc,
             )
 
     # PR-TTC: Run the canonical must-run truth chain when local-mode unified

--- a/galaxy_gateway/android_bridge.py
+++ b/galaxy_gateway/android_bridge.py
@@ -87,6 +87,7 @@ from galaxy_gateway.android.handlers.goal_execution import (
     handle_parallel_subtask,
     handle_goal_execution_result,
 )
+from galaxy_gateway.android.handlers.auth import handle_auth
 from galaxy_gateway.android.handlers.capability_report import handle_capability_report
 from galaxy_gateway.android.handlers.diagnostics import handle_diagnostics_payload
 from galaxy_gateway.android.handlers.vision import handle_vision_request
@@ -961,6 +962,9 @@ class AndroidBridge:
                 return await fn(self, websocket, message)
             return _wrapped_handler
 
+        # PR-AUTH-UNIFIED:客户端 onOpen 首帧 auth 的服务端应答者
+        # (auth_ok/auth_failed)。此前该类型无处理者,状态机两端空转。
+        self._message_handlers[MessageType.AUTH] = _wrap(handle_auth)
         self._message_handlers[MessageType.DEVICE_REGISTER] = _wrap(handle_device_register)
         self._message_handlers[MessageType.DEVICE_HEARTBEAT] = _wrap(handle_heartbeat)
         self._message_handlers[MessageType.TASK_RESULT] = _wrap(handle_task_result)

--- a/galaxy_gateway/device_router.py
+++ b/galaxy_gateway/device_router.py
@@ -1954,7 +1954,13 @@ class DeviceRouter:
                     record_result_idempotency,
                 )
 
-                if check_result_idempotency(task_id):
+                # 自有命名空间:本层防的是"重启后同一完成通知被重投递",
+                # 用裸 task_id 会与 unified_result_ingress 的联合幂等回退键
+                # (消息缺 message_id 时同样落在裸 task_id)共用一个槽——
+                # ingress 刚在 first_accepted 后记录,这里紧接着的首次通知
+                # 就会被误判为跨重启重复,完成唤醒被吞。
+                _dr_durable_key = f"device_router_notify:{task_id}"
+                if check_result_idempotency(_dr_durable_key):
                     # Already processed in a previous V2 process lifetime.
                     # Populate the in-memory set so subsequent calls skip level-2.
                     self._seen_task_result_ids.add(task_id)
@@ -1967,7 +1973,7 @@ class DeviceRouter:
                         },
                     )
                     return
-                record_result_idempotency(task_id)
+                record_result_idempotency(_dr_durable_key)
             except Exception as _idem_exc:  # noqa: BLE001 — durable store must never block dispatch
                 logger.debug(
                     "device_router: durable idempotency check skipped (non-fatal): %s",

--- a/galaxy_gateway/protocol/aip_v3.py
+++ b/galaxy_gateway/protocol/aip_v3.py
@@ -176,6 +176,14 @@ class MessageType(str, Enum):
     #   - aip_to_unified(aip_type, target_platform) -> PlatformSpecificType
     # ===
 
+    # === AIP_STANDARD: 连接认证(PR-AUTH-UNIFIED)===
+    # 客户端(Android/WearOS)onOpen 后发送的首帧统一认证消息;服务端以
+    # auth_ok / auth_failed 应答。此前客户端契约已上线而服务端无应答者
+    # ——状态机两端空转,本次补齐服务端。
+    AUTH = "auth"
+    AUTH_OK = "auth_ok"
+    AUTH_FAILED = "auth_failed"
+
     # === AIP_STANDARD: 设备管理 ===
     DEVICE_REGISTER = "device_register"
     DEVICE_REGISTER_ACK = "device_register_ack"

--- a/scripts/node_audit.py
+++ b/scripts/node_audit.py
@@ -378,17 +378,56 @@ def _check_runtime_contract(main_py: Path) -> Tuple[bool, bool]:
     return bool(_HEALTH_PATTERNS.search(content)), bool(_STATUS_PATTERNS.search(content))
 
 
+_GIT_TRACKED_CACHE: Optional[frozenset] = None
+
+
+def _git_tracked_paths(repo_root: Path) -> frozenset:
+    """Return the set of git-tracked relative paths (cached; empty on failure)."""
+    global _GIT_TRACKED_CACHE  # noqa: PLW0603
+    if _GIT_TRACKED_CACHE is None:
+        try:
+            import subprocess
+            out = subprocess.run(
+                ["git", "ls-files"],
+                cwd=str(repo_root),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            _GIT_TRACKED_CACHE = frozenset(
+                line.strip() for line in out.stdout.splitlines() if line.strip()
+            )
+        except Exception:
+            _GIT_TRACKED_CACHE = frozenset()
+    return _GIT_TRACKED_CACHE
+
+
 def _check_hygiene(node_dir: Path) -> List[str]:
     """
     Return a list of runtime-generated artifact paths found directly inside
     the node directory (non-recursive scan).
+
+    Git 感知(与 check_repo_hygiene 同一裁决):测试/运行进程会在 import
+    时生成 __pycache__ 等产物,这类**未被 git 跟踪**的本地产物不算仓库
+    卫生违规;被 git 跟踪(即被提交进仓库)的运行时产物才是真违规。
     """
     violations: List[str] = []
     try:
+        repo_root = node_dir.parent.parent
+        tracked = _git_tracked_paths(repo_root)
         for child in node_dir.iterdir():
-            if child.name in _HYGIENE_NAMES:
-                violations.append(child.name)
-            elif child.suffix in _HYGIENE_SUFFIXES:
+            is_artifact = (
+                child.name in _HYGIENE_NAMES or child.suffix in _HYGIENE_SUFFIXES
+            )
+            if not is_artifact:
+                continue
+            rel = child.relative_to(repo_root).as_posix()
+            if child.is_dir():
+                child_tracked = any(t.startswith(rel + "/") for t in tracked)
+            else:
+                child_tracked = rel in tracked
+            if child_tracked or not tracked:
+                # tracked 为空集 == git 不可用:保守起见退回原行为(全报)。
                 violations.append(child.name)
     except Exception:
         pass

--- a/tests/test_autonomous_loops.py
+++ b/tests/test_autonomous_loops.py
@@ -170,35 +170,27 @@ class TestLearningPlannerFeedback:
         planner = self._planner_with_resource()
         planner.update_decision_weights({})  # missing average_success_rate
 
-    def test_galaxy_l4_calls_update_decision_weights(self):
-        """_perform_optimization in galaxy_main_loop_l4 must call update_decision_weights."""
-        import importlib.util
-        import asyncio
+    def test_root_l4_file_retired_canonical_module_importable(self):
+        """根 galaxy_main_loop_l4.py 已退役删除,canonical L4 在 core 包内。
 
-        spec = importlib.util.spec_from_file_location(
-            "gml4", str(PROJECT_ROOT / "galaxy_main_loop_l4.py")
+        终局钉:canonical 晋升清理(commit 842774e8 "promote canonical L4
+        module")删除了根文件;旧的 _perform_optimization/_learn_from_
+        execution 编排级权重反哺随之退役(planner 级 update_decision_weights
+        API 仍在,由本类其余用例直接覆盖)。根文件不得复活。
+        """
+        assert not (PROJECT_ROOT / "galaxy_main_loop_l4.py").exists(), (
+            "root galaxy_main_loop_l4.py was deleted when the canonical L4 "
+            "module was promoted — do not recreate"
         )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-
-        loop = mod.GalaxyMainLoopL4()
-
-        # Replace planner and optimizer with mocks so no real IO happens.
-        mock_optimizer = MagicMock()
-        # Return a non-empty insight list so the early-return is not triggered.
-        mock_optimizer.analyze_performance.return_value = [{"type": "test"}]
-        mock_optimizer.generate_optimization_plan.return_value = []
-        mock_optimizer.performance_metrics = {"average_success_rate": 0.85}
-        loop.learning_optimizer = mock_optimizer
-
-        mock_planner = MagicMock()
-        loop.planner = mock_planner
-
-        asyncio.run(loop._perform_optimization())
-
-        mock_planner.update_decision_weights.assert_called_once_with(
-            mock_optimizer.performance_metrics
+        from core.galaxy_main_loop_l4_enhanced import (
+            GalaxyMainLoopL4,
+            get_galaxy_loop,
         )
+        assert callable(GalaxyMainLoopL4)
+        assert callable(get_galaxy_loop)
+        # 旧编排钩子确已退役
+        assert not hasattr(GalaxyMainLoopL4, "_perform_optimization")
+        assert not hasattr(GalaxyMainLoopL4, "_learn_from_execution")
 
 
 # ---------------------------------------------------------------------------
@@ -458,77 +450,33 @@ class TestSelfHealingPhaseLogging:
 # ---------------------------------------------------------------------------
 
 class TestForcedDecisionWeightUpdate:
-    """Loop 2: _learn_from_execution must call update_decision_weights even without
-    the full learning engine (e.g., when numpy is unavailable)."""
+    """Loop 2 的 L4 编排面已退役,权重反哺行为下沉到 planner 层直接钉。
 
-    def test_learn_from_execution_updates_weights_without_learning_engine(self):
-        """Even when learning_optimizer is None, planner.update_decision_weights is called."""
-        import importlib.util
-        import asyncio
+    原两用例经根 galaxy_main_loop_l4.py 的 _learn_from_execution 验证
+    "无学习引擎也强制更新权重"——该编排钩子随 canonical L4 晋升清理
+    (commit 842774e8)一并退役。planner 级契约(update_decision_weights
+    对 availability 的影响)在此直接验证,不再经 L4。
+    """
 
-        spec = importlib.util.spec_from_file_location(
-            "gml4_forced", str(PROJECT_ROOT / "galaxy_main_loop_l4.py")
-        )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+    def test_l4_learn_from_execution_retired(self):
+        """终局钉:根 L4 文件与 _learn_from_execution 编排钩子不得复活。"""
+        assert not (PROJECT_ROOT / "galaxy_main_loop_l4.py").exists()
+        from core.galaxy_main_loop_l4_enhanced import GalaxyMainLoopL4
+        assert not hasattr(GalaxyMainLoopL4, "_learn_from_execution")
 
-        loop_obj = mod.GalaxyMainLoopL4()
-        # Force learning engine to None to simulate numpy unavailable
-        loop_obj.learning_optimizer = None
-
-        mock_planner = MagicMock()
-        loop_obj.planner = mock_planner
-
-        execution_result = {
-            "success": True,
-            "summary": {
-                "goal": "test",
-                "total_duration": 1.0,
-                "total_actions": 2,
-                "success_rate": 0.9,
-            },
-        }
-
-        asyncio.run(loop_obj._learn_from_execution(execution_result))
-
-        mock_planner.update_decision_weights.assert_called_once()
-        call_kwargs = mock_planner.update_decision_weights.call_args[0][0]
-        assert "average_success_rate" in call_kwargs
-
-    def test_forced_weight_update_affects_routing(self):
-        """After _learn_from_execution, resource availability changes based on success rate."""
-        import importlib.util
-        import asyncio
+    def test_weight_update_affects_routing_at_planner_level(self):
+        """低成功率指标直接驱动 planner 资源可用度下降(行为契约保留)。"""
         from enhancements.reasoning.autonomous_planner import (
             AutonomousPlanner, Resource, ResourceType,
         )
-
-        spec = importlib.util.spec_from_file_location(
-            "gml4_routing", str(PROJECT_ROOT / "galaxy_main_loop_l4.py")
-        )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-
-        loop_obj = mod.GalaxyMainLoopL4()
-        loop_obj.learning_optimizer = None
 
         resource = Resource(
             id="r1", type=ResourceType.NODE, name="TestNode",
             capabilities=[], availability=0.5, metadata={}
         )
-        real_planner = AutonomousPlanner(available_resources=[resource])
-        loop_obj.planner = real_planner
-
-        # Low success rate → availability should decrease
-        execution_result = {
-            "success": False,
-            "summary": {
-                "goal": "test", "total_duration": 1.0,
-                "total_actions": 1, "success_rate": 0.1,
-            },
-        }
-        asyncio.run(loop_obj._learn_from_execution(execution_result))
-        assert real_planner.available_resources[0].availability < 0.5
+        planner = AutonomousPlanner(available_resources=[resource])
+        planner.update_decision_weights({"average_success_rate": 0.1})
+        assert planner.available_resources[0].availability < 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -586,8 +534,47 @@ class TestCodeFixSandboxGating:
         applied = fixer.apply_code_fix(target_dir=str(tmp_path))
         assert applied == ""
 
-    def test_auto_commit_calls_apply_on_success(self, tmp_path):
-        """When auto_commit=True and CODE_FIX succeeds, apply_code_fix is invoked."""
+    def test_code_fix_success_delegates_to_mediated_loop(self, tmp_path):
+        """CODE_FIX 成功 → 委托中介式 SelfHealingLoop 六阶段提案链(PR-6)。
+
+        钉住现契约:staged 代码改进的唯一权威是 core.self_improvement 的
+        SelfHealingLoop(propose→gather→plan→apply→validate→record),
+        auto_commit 元数据随 apply_patch 传递;直呼 apply_code_fix 落盘
+        只剩委托抛异常时的降级兜底。"auto_commit=True 即直呼 apply_code_
+        fix" 是中介化之前的退役契约(由下一个用例钉降级路径)。
+        """
+        engine = self.SelfHealingEngine({
+            "report_dir": str(tmp_path),
+            "auto_commit": True,
+            "applied_fixes_dir": str(tmp_path / "fixes"),
+        })
+        code_fix_result = self.FixResult(
+            action=self.FixAction.CODE_FIX, success=True,
+            message="fixed", timestamp="t"
+        )
+        mock_loop = MagicMock()
+        mock_loop.submit_diagnosis.return_value = MagicMock(proposal_id="prop-1")
+        with patch.object(engine.detector, "collect_metrics",
+                          return_value=self._make_metrics()), \
+             patch.object(engine.diagnoser, "diagnose",
+                          return_value=self._make_diag()), \
+             patch.object(engine.fixer, "fix", return_value=code_fix_result), \
+             patch.object(engine.reporter, "generate_report",
+                          return_value=MagicMock()), \
+             patch("core.self_improvement.get_self_healing_loop",
+                   return_value=mock_loop), \
+             patch.object(engine.fixer, "apply_code_fix") as mock_apply:
+            engine.run_once()
+        # 六阶段全部走到,auto_commit 经 apply_patch 元数据传递
+        mock_loop.submit_diagnosis.assert_called_once()
+        mock_loop.apply_patch.assert_called_once()
+        assert mock_loop.apply_patch.call_args.kwargs["apply_metadata"]["auto_commit"] is True
+        mock_loop.record_outcome.assert_called_once()
+        # 中介化后不得再直呼落盘
+        mock_apply.assert_not_called()
+
+    def test_code_fix_falls_back_to_direct_apply_when_loop_unavailable(self, tmp_path):
+        """中介 loop 委托抛异常 → 降级按 auto_commit 直呼 apply_code_fix。"""
         engine = self.SelfHealingEngine({
             "report_dir": str(tmp_path),
             "auto_commit": True,
@@ -604,6 +591,8 @@ class TestCodeFixSandboxGating:
              patch.object(engine.fixer, "fix", return_value=code_fix_result), \
              patch.object(engine.reporter, "generate_report",
                           return_value=MagicMock()), \
+             patch("core.self_improvement.get_self_healing_loop",
+                   side_effect=RuntimeError("loop unavailable")), \
              patch.object(engine.fixer, "apply_code_fix",
                           return_value=str(tmp_path / "fixes" / "fix.py")) as mock_apply:
             engine.run_once()

--- a/tests/test_constellation_runtime.py
+++ b/tests/test_constellation_runtime.py
@@ -17,8 +17,27 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@contextmanager
+def _open_scheduling_gate(rt, device_id="dev_test"):
+    """给集体调度门(Layer-1 就绪)开一个测试候选。
+
+    run() 现在先过【集体】调度门:participation 层无就绪设备即 BLOCKED
+    (reason=no_orchestration_ready_devices),设备池/账本/演化器根本
+    不被咨询——这是有意的 deny-by-default。本文件各用例钉的是门后的
+    行为,须给门供一个可通过的候选。
+    """
+    with patch.object(
+        rt, "_get_orchestration_candidate_set",
+        return_value=[SimpleNamespace(device_id=device_id)],
+    ), patch.object(rt, "_is_orchestration_ready", return_value=True):
+        yield
 
 
 # ===========================================================================
@@ -137,7 +156,8 @@ class TestDAGEvolution:
         with patch.object(DAGEvolver, "on_task_failed", _spy_on_failed):
             with patch("core.constellation_runtime.ConstellationRuntime._try_node71",
                        new_callable=AsyncMock, return_value=None):
-                await rt.run(task_description="fail test")
+                with _open_scheduling_gate(rt):
+                    await rt.run(task_description="fail test")
 
         assert len(evolver_calls) > 0
 
@@ -179,7 +199,8 @@ class TestDevicePoolIntegration:
         with patch.object(rt, "_get_device_pool", return_value=mock_pool):
             with patch("core.constellation_runtime.ConstellationRuntime._try_node71",
                        new_callable=AsyncMock, return_value=None):
-                await rt.run(task_description="device test")
+                with _open_scheduling_gate(rt, device_id="dev_android_1"):
+                    await rt.run(task_description="device test")
 
         mock_pool.select_device.assert_called()
 
@@ -216,7 +237,8 @@ class TestAuditLedgerEvents:
         with patch.object(rt, "_get_audit_ledger", return_value=fresh_ledger):
             with patch("core.constellation_runtime.ConstellationRuntime._try_node71",
                        new_callable=AsyncMock, return_value=None):
-                await rt.run(task_description="audit test")
+                with _open_scheduling_gate(rt):
+                    await rt.run(task_description="audit test")
 
         event_types = [ev.event_type for ev in fresh_ledger.all_events]
         assert EventType.TASK_CREATED in event_types

--- a/tests/test_inflight_task_continuity_contract.py
+++ b/tests/test_inflight_task_continuity_contract.py
@@ -874,7 +874,15 @@ class TestGroupU_RuntimeRecoveryReportToDict:
 # ---------------------------------------------------------------------------
 
 class TestGroupV_RecoveryTruthSurface:
-    def test_V01_in_flight_continuity_entry_is_observed_with_contract(self):
+    def test_V01_in_flight_continuity_entry_is_partial_with_contract(self):
+        """契约在场且接线完整 → partial(而非 observed)。
+
+        诚实边界对账(与 test_recovery_truth_surface.F03 同一原则):
+        build_recovery_truth_report() 只做静态结构探测,observed 必须有
+        live recovery event 或 durable records 支撑——结构完整只到
+        partial。"契约在场即 observed" 是与 STATE_RESTORED_IS_NOT_
+        CONTINUITY_RESTORED 原则相悖的退役契约。
+        """
         from core.recovery_truth_surface import (
             build_recovery_truth_report,
             RecoveryTruthDimension,
@@ -885,8 +893,10 @@ class TestGroupV_RecoveryTruthSurface:
             RecoveryTruthDimension.in_flight_task_continuity_preserved
         )
         assert entry is not None
-        # With InFlightTaskContinuityContract present, status should be observed
-        assert entry.status == RecoveryTruthStatus.observed
+        # With InFlightTaskContinuityContract present but no live recovery
+        # event, status caps at partial and the upgrade path is documented.
+        assert entry.status == RecoveryTruthStatus.partial
+        assert "observed" in (entry.deferred_note or "")
 
     def test_V02_inflight_contract_in_supporting_modules(self):
         from core.recovery_truth_surface import (

--- a/tests/test_pr02_v2_handoff_v2_result_gateway.py
+++ b/tests/test_pr02_v2_handoff_v2_result_gateway.py
@@ -114,6 +114,9 @@ class TestHandlerRegistration:
 def _make_ack_message(handoff_id: str = "", device_id: str = "device-test") -> Dict[str, Any]:
     return {
         "type": "handoff_ack",
+        # PR-46 跨仓 schema 门:缺 schema_version 的上行在进 canonical
+        # 真相链之前就被 REJECT(有意加固),真实 Android 端总是带版本。
+        "schema_version": "1",
         "device_id": device_id,
         "message_id": str(uuid.uuid4()),
         "payload": {
@@ -126,6 +129,11 @@ def _make_ack_message(handoff_id: str = "", device_id: str = "device-test") -> D
 def _make_result_message(handoff_id: str = "", device_id: str = "device-test") -> Dict[str, Any]:
     return {
         "type": "handoff_result",
+        # 终局上行还须带 completion-closure 契约版本(PR-46 第二层门)。
+        "completion_closure_contract_version": "1",
+        # PR-46 跨仓 schema 门:缺 schema_version 的上行在进 canonical
+        # 真相链之前就被 REJECT(有意加固),真实 Android 端总是带版本。
+        "schema_version": "1",
         "device_id": device_id,
         "message_id": str(uuid.uuid4()),
         "payload": {
@@ -138,6 +146,11 @@ def _make_result_message(handoff_id: str = "", device_id: str = "device-test") -
 def _make_failure_message(handoff_id: str = "", device_id: str = "device-test") -> Dict[str, Any]:
     return {
         "type": "handoff_failure",
+        # 终局上行还须带 completion-closure 契约版本(PR-46 第二层门)。
+        "completion_closure_contract_version": "1",
+        # PR-46 跨仓 schema 门:缺 schema_version 的上行在进 canonical
+        # 真相链之前就被 REJECT(有意加固),真实 Android 端总是带版本。
+        "schema_version": "1",
         "device_id": device_id,
         "message_id": str(uuid.uuid4()),
         "payload": {
@@ -153,6 +166,11 @@ def _make_envelope_v2_result_message(
 ) -> Dict[str, Any]:
     return {
         "type": "handoff_envelope_v2_result",
+        # 终局上行还须带 completion-closure 契约版本(PR-46 第二层门)。
+        "completion_closure_contract_version": "1",
+        # PR-46 跨仓 schema 门:缺 schema_version 的上行在进 canonical
+        # 真相链之前就被 REJECT(有意加固),真实 Android 端总是带版本。
+        "schema_version": "1",
         "device_id": device_id,
         "message_id": str(uuid.uuid4()),
         "payload": {

--- a/tests/test_pr12v2_completion_closure_done_semantics_convergence.py
+++ b/tests/test_pr12v2_completion_closure_done_semantics_convergence.py
@@ -23,8 +23,12 @@ def test_shared_execution_visibility_separates_authority_truth_from_done_summary
 
     visibility = _derive_shared_execution_visibility(payload)
 
-    assert visibility["completion_state"] == "closed"
-    assert visibility["closure_candidate_state"] == "closed"
+    # 诚实降级(代码内注释在案):表层闭合信号可见但证据边界未确证成熟
+    # canonical 闭合(is_fully_closed=False + accept_provisional)时,对外
+    # 状态降为 incomplete——advisory 真相不得伪装成 closed。
+    # "表层信号即 closed" 是降级引入前的退役契约。
+    assert visibility["completion_state"] == "incomplete"
+    assert visibility["closure_candidate_state"] == "incomplete"
     assert visibility["authority_completion_truth"] is False
     assert visibility["acceptance_completion_truth"] is False
     assert visibility["operator_visible_done_summary_role"] == "operator_visible_interpretation_only"

--- a/tests/test_pr16_canonical_perception_state.py
+++ b/tests/test_pr16_canonical_perception_state.py
@@ -453,11 +453,19 @@ class TestShellCoreBoundary:
         assert hasattr(DesktopPresenceRuntime, "snapshot_continuous_perception")
         assert callable(DesktopPresenceRuntime.snapshot_continuous_perception)
 
-    def test_snapshot_continuous_perception_returns_none_when_bus_not_running(self):
+    def test_snapshot_continuous_perception_returns_none_when_bus_opted_out(self):
+        # 连续宿主感知现为规范默认路径(MULTIMODAL_INGEST_CANONICAL_
+        # DEFAULT_PATH,裸构造 runtime 即自动起 bus);"裸构造=无 bus" 是
+        # 默认开之前的退役契约。text-only/受限部署是显式 opt-out——钉
+        # opt-out 形态下 snapshot 返回 None。
+        from unittest.mock import patch
         from core.desktop_presence_runtime import DesktopPresenceRuntime
-        runtime = DesktopPresenceRuntime()
-        result = runtime.snapshot_continuous_perception()
-        # Without an active ingest bus, returns None
+        with patch.object(DesktopPresenceRuntime, "_try_start_ingest_bus",
+                          lambda self: None):
+            runtime = DesktopPresenceRuntime()
+        with patch("core.multimodal.ingest_runtime.get_ingest_bus",
+                   return_value=None):
+            result = runtime.snapshot_continuous_perception()
         assert result is None
 
     def test_openclawd_has_build_canonical_perception_state_helper(self):
@@ -634,14 +642,18 @@ class TestOpenClawdIntegration:
             return {"success": True, "response": "ok", "intent": "chat",
                     "metadata": {}, "execution_path": "local"}
 
-        with patch.object(oc, "_get_kernel", return_value=None):
-            with patch.object(oc, "sync_device_capabilities", return_value=0):
-                with patch.object(oc, "_parse_intent", return_value=None):
-                    with patch.object(oc, "_dispatch_chat", side_effect=_mock_chat):
-                        result = await oc.process(
-                            message="hello",
-                            runtime_session_id="rs-cps-test",
-                        )
+        # 连续感知默认开(规范路径):text-only 形态须显式 opt-out,
+        # 否则进程内已存在的 ingest bus 会让 has_continuous_perception=True。
+        with patch("core.multimodal.ingest_runtime.get_ingest_bus",
+                   return_value=None):
+            with patch.object(oc, "_get_kernel", return_value=None):
+                with patch.object(oc, "sync_device_capabilities", return_value=0):
+                    with patch.object(oc, "_parse_intent", return_value=None):
+                        with patch.object(oc, "_dispatch_chat", side_effect=_mock_chat):
+                            result = await oc.process(
+                                message="hello",
+                                runtime_session_id="rs-cps-test",
+                            )
 
         assert result.get("success") is True
         meta = result.get("metadata", {})

--- a/tests/test_pr1_entry_unification.py
+++ b/tests/test_pr1_entry_unification.py
@@ -29,6 +29,48 @@ from core.schemas.task_envelope import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _bypass_dispatch_gates(monkeypatch):
+    """V3 槽位门 sanctioned 旁路(本文件钉入口统一,不钉门行为)。
+
+    route_envelope 的 canonical 槽位门会拦下未注册 UDM 的假设备
+    (deny-by-default,有意语义);入口统一用例须让派发走到执行器。
+    """
+    from core.canonical_dispatch_slot_authority import (
+        CanonicalDispatchSlot,
+        CanonicalDispatchSlotStatus,
+        CanonicalDispatchSlotsResult,
+    )
+
+    def _approve_all(device_ids, execution_mode, **kwargs):
+        slots = [
+            CanonicalDispatchSlot(
+                device_id=d,
+                execution_mode=execution_mode,
+                slot_approved=True,
+                status=CanonicalDispatchSlotStatus.SLOT_APPROVED.value,
+                reason="test override — pr1 entry unification suite",
+            )
+            for d in device_ids
+        ]
+        return CanonicalDispatchSlotsResult(
+            execution_mode=execution_mode,
+            approved_slots=slots,
+            blocked_slots=[],
+            can_proceed=True,
+            block_reason="",
+        )
+
+    monkeypatch.setattr(
+        "core.canonical_dispatch_slot_authority.get_canonical_dispatch_slots",
+        _approve_all,
+    )
+    monkeypatch.setattr(
+        "core.capability_aware_routing_default.infer_dispatch_capabilities",
+        lambda tool_name: [],
+    )
+
+
 def _make_router(executor=None):
     """Return a CommandRouter wired to a simple mock executor."""
     from core.command_router import CommandRouter

--- a/tests/test_pr1_p0_completion_and_capability_closure.py
+++ b/tests/test_pr1_p0_completion_and_capability_closure.py
@@ -32,6 +32,23 @@ PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 
+def _reset_durable_result_store():
+    """清空持久幂等库(与 test_pr9_stability_idempotency 同一卫生模式)。
+
+    本文件用固定 task_id(task-abc/task-xyz 等):不清库的话,上一次
+    进程/用例留下的持久记录会把本次首个结果误判为跨重启重复。
+    """
+    try:
+        from core.durable_result_idempotency import (
+            get_durable_result_id_store,
+            reset_durable_result_id_store,
+        )
+        get_durable_result_id_store().clear()
+        reset_durable_result_id_store()
+    except Exception:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # V3 slot gate test helpers
 # ---------------------------------------------------------------------------
@@ -73,6 +90,9 @@ def _v3_all_approved_side_effect(device_ids, execution_mode, **kw):
 class TestTaskResultWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
     """PR-1 P0: handle_task_result must call device_router.handle_task_result."""
 
+    def setUp(self):
+        _reset_durable_result_store()
+
     async def test_handle_task_result_wakes_device_router_event(self):
         """When handle_task_result is called, the DeviceRouter event is set."""
         from galaxy_gateway.android.handlers.task_lifecycle import handle_task_result
@@ -100,10 +120,11 @@ class TestTaskResultWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
             new_callable=AsyncMock,
         ), patch(
             "galaxy_gateway.android.handlers.task_lifecycle._reconcile_inbound_message",
-            None,
+            MagicMock(),
         ), patch(
-            "galaxy_gateway.android.handlers.task_lifecycle._ingest_participant_truth",
-            None,
+            # handler 对该钩子是直呼(非 None 守卫):要中和须用可调用桩
+            "galaxy_gateway.android.handlers.task_lifecycle._try_ingest_participant_truth",
+            MagicMock(),
         ), patch(
             "galaxy_gateway.device_router.device_router",
             router,
@@ -142,10 +163,11 @@ class TestTaskResultWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
             new_callable=AsyncMock,
         ), patch(
             "galaxy_gateway.android.handlers.task_lifecycle._reconcile_inbound_message",
-            None,
+            MagicMock(),
         ), patch(
-            "galaxy_gateway.android.handlers.task_lifecycle._ingest_participant_truth",
-            None,
+            # handler 对该钩子是直呼(非 None 守卫):要中和须用可调用桩
+            "galaxy_gateway.android.handlers.task_lifecycle._try_ingest_participant_truth",
+            MagicMock(),
         ), patch(
             "galaxy_gateway.device_router.device_router",
             router,
@@ -161,6 +183,9 @@ class TestTaskResultWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
 
 class TestTaskEndWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
     """PR-1 P0: handle_task_end must also call device_router.handle_task_result."""
+
+    def setUp(self):
+        _reset_durable_result_store()
 
     async def test_handle_task_end_wakes_device_router_event(self):
         from galaxy_gateway.android.handlers.task_lifecycle import handle_task_end
@@ -183,10 +208,11 @@ class TestTaskEndWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
 
         with patch(
             "galaxy_gateway.android.handlers.task_lifecycle._reconcile_inbound_message",
-            None,
+            MagicMock(),
         ), patch(
-            "galaxy_gateway.android.handlers.task_lifecycle._ingest_participant_truth",
-            None,
+            # handler 对该钩子是直呼(非 None 守卫):要中和须用可调用桩
+            "galaxy_gateway.android.handlers.task_lifecycle._try_ingest_participant_truth",
+            MagicMock(),
         ), patch(
             "galaxy_gateway.device_router.device_router",
             router,
@@ -205,6 +231,9 @@ class TestTaskEndWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
 
 class TestHandoffV2TerminalWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
     """PR-1 P0: terminal handoff_v2 result must call device_router.handle_task_result."""
+
+    def setUp(self):
+        _reset_durable_result_store()
 
     async def test_terminal_handoff_result_wakes_device_router(self):
         from galaxy_gateway.android.handlers.handoff_v2_result import handle_handoff_v2_result
@@ -232,6 +261,10 @@ class TestHandoffV2TerminalWakesDeviceRouter(unittest.IsolatedAsyncioTestCase):
 
         msg = {
             "type": "handoff_result",
+            # PR-46 跨仓 schema 门:终局上行须带 schema 版本与 completion-
+            # closure 契约版本,缺失会在 canonical 真相链之前被 REJECT。
+            "schema_version": "1",
+            "completion_closure_contract_version": "1",
             "device_id": "android-dev-1",
             "message_id": "msg-001",
             "task_id": "handoff-task-1",

--- a/tests/test_pr2_task_envelope_pipeline.py
+++ b/tests/test_pr2_task_envelope_pipeline.py
@@ -255,24 +255,33 @@ class TestNATSExecutorEnvelopeIds:
 # ---------------------------------------------------------------------------
 
 class TestDeviceRouterDispatchTaskEnvelope:
-    """PR-2: dispatch_task 内部转换为 TaskEnvelope + route_envelope。"""
+    """PR-AIP-UNIFIED: dispatch_task 是基底层,统一走 AIPTransport。
+
+    钉住现契约(v51 P1/P2):DeviceRouter 不得回环调用编排层的
+    CommandRouter.route_envelope(P2 修复移除了该循环调用);传输统一
+    经 core.aip_transport.get_aip_transport().send()(P1)。
+    "dispatch_task 内部转 route_envelope" 是收口前的退役契约。
+    """
 
     @pytest.mark.asyncio
-    async def test_dispatch_task_uses_route_envelope(self):
-        """When executor is set, dispatch_task should call route_envelope."""
+    async def test_dispatch_task_routes_via_aip_transport(self):
+        """dispatch_task sends through AIPTransport, not route_envelope."""
+        from unittest.mock import AsyncMock, MagicMock, patch as _patch
         from galaxy_gateway.device_router import DeviceRouter, Device
 
+        # 若基底层错误地回环进编排层,这个 executor 会被调用 —— 断言其为空。
         executor = _make_mock_executor()
-
-        # Patch CommandRouter so get_command_router() returns a router with our executor
         from core.command_router import CommandRouter
         mock_router = CommandRouter(executor=executor)
 
-        import galaxy_gateway.device_router as _dr_mod
         import core.command_router as _cr_mod
-
         original_get_router = _cr_mod.get_command_router
         _cr_mod.get_command_router = lambda: mock_router
+
+        mock_transport = MagicMock()
+        mock_transport.send = AsyncMock(
+            return_value={"success": True, "result": {"ok": True}}
+        )
         try:
             dr = DeviceRouter()
             device = Device(
@@ -290,11 +299,20 @@ class TestDeviceRouterDispatchTaskEnvelope:
                     "params": {},
                 },
             }
-            with _patch_v3_slot_gate(["test_device"]):
+            with _patch(
+                "core.aip_transport.get_aip_transport",
+                return_value=mock_transport,
+            ):
                 result = await dr.dispatch_task(task, device)
-            # route_envelope was called → executor was invoked
-            assert executor.calls, "route_envelope should have called the executor"
-            assert executor.calls[0]["target"] == "test_device"
+
+            mock_transport.send.assert_called_once()
+            _msg, _target = mock_transport.send.call_args.args
+            assert _target == "test_device"
+            assert result["success"] is True
+            assert result["via"] == "device_router->aip_transport"
+            assert result["task_id"] == "dr-task-1"
+            # 基底层不得回环进编排层:executor(经 route_envelope)不应被碰
+            assert executor.calls == []
         finally:
             _cr_mod.get_command_router = original_get_router
 

--- a/tests/test_pr2_ucm_udm_authority.py
+++ b/tests/test_pr2_ucm_udm_authority.py
@@ -315,11 +315,24 @@ class TestGatewayWSManagerDisconnect(unittest.TestCase):
     """Tests 32–33: UCM/SSOT called before local map cleanup on disconnect."""
 
     def _make_manager(self):
+        import asyncio
         from galaxy_gateway.websocket_handler import GatewayWSManager
         mgr = GatewayWSManager.__new__(GatewayWSManager)
         mgr.active_connections = {}
         mgr.device_connections = {}
+        # B4:disconnect 改为 async + 锁保护(见 websocket_handler.disconnect
+        # 的 "B4 fixed" 注释),同步直调只会拿到未执行的协程。
+        mgr._lock = asyncio.Lock()
         return mgr
+
+    @staticmethod
+    def _run(coro):
+        import asyncio
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
 
     def test_32_disconnect_calls_ucm_unregister_before_local_cleanup(self):
         """UCM unregister is invoked on disconnect path."""
@@ -348,7 +361,7 @@ class TestGatewayWSManagerDisconnect(unittest.TestCase):
              patch.object(mgr, "_ucm", return_value=ucm), \
              patch("asyncio.get_running_loop", side_effect=RuntimeError("no loop")):
 
-            mgr.disconnect("conn-1")
+            self._run(mgr.disconnect("conn-1"))
 
         # Both UCM and UDM must have been called
         ucm_called = any(tag == "ucm_mark_offline" for tag, _ in call_order)
@@ -375,7 +388,7 @@ class TestGatewayWSManagerDisconnect(unittest.TestCase):
              patch.object(mgr, "_ucm", return_value=MagicMock(mark_offline=MagicMock())), \
              patch("asyncio.get_running_loop", side_effect=RuntimeError("no loop")):
 
-            mgr.disconnect("conn-2")
+            self._run(mgr.disconnect("conn-2"))
 
         self.assertIn("dev-ssot-2", udm_called,
                       "udm_write_unregister must be called with the device_id")

--- a/tests/test_pr46_schema_version_gate_runtime_enforcement.py
+++ b/tests/test_pr46_schema_version_gate_runtime_enforcement.py
@@ -373,6 +373,14 @@ class TestTaskResultGateEnforcement:
                 "core.durable_result_idempotency.record_result_idempotency",
                 return_value=None,
             ),
+            # 本类钉的是 schema 门语义,不是真相链选择:统一 ingress 正常
+            # 运行时 legacy 真相链被有意跳过(if not _unified_result_
+            # ingress_ran)。令 ingress 不可用,走"falls back to legacy
+            # truth chain"分支,使 _run_task_result_truth_chain 可观察。
+            patch(
+                "core.unified_result_ingress.ingest_result_async",
+                side_effect=RuntimeError("ingress unavailable (test)"),
+            ),
         ):
             self._run(handle_task_result(bridge, _make_websocket(), message))
 
@@ -441,6 +449,14 @@ class TestTaskResultGateEnforcement:
             patch(
                 "core.durable_result_idempotency.record_result_idempotency",
                 return_value=None,
+            ),
+            # 本类钉的是 schema 门语义,不是真相链选择:统一 ingress 正常
+            # 运行时 legacy 真相链被有意跳过(if not _unified_result_
+            # ingress_ran)。令 ingress 不可用,走"falls back to legacy
+            # truth chain"分支,使 _run_task_result_truth_chain 可观察。
+            patch(
+                "core.unified_result_ingress.ingest_result_async",
+                side_effect=RuntimeError("ingress unavailable (test)"),
             ),
         ):
             self._run(handle_task_result(bridge, _make_websocket(), message))

--- a/tests/test_pr47_canonical_cross_device_chain.py
+++ b/tests/test_pr47_canonical_cross_device_chain.py
@@ -360,6 +360,9 @@ class TestChainExecutionRecord:
             "record_id", "task_id", "trace_id", "device_id", "route_mode",
             "steps_completed", "is_canonical", "legacy_path_used",
             "result_envelope", "dispatched_at", "completed_at", "extra",
+            # 验收闭环字段:acceptance_state / acceptance_closed 已进入
+            # ChainExecutionRecord 契约(to_dict/from_dict 双向携带)。
+            "acceptance_state", "acceptance_closed",
         }
         assert expected_keys == set(d.keys())
 
@@ -663,17 +666,22 @@ class TestLegacyPathRegistryPR7:
         assert entry.status is LegacyPathStatus.LEGACY_COMPATIBILITY
 
     def test_all_pr7_entries_have_pr7_guardrail(self):
+        # PR-S3 收拢派发权威:DeviceRouter.route_task 从 PR-7 的
+        # LEGACY_COMPATIBILITY 晋升为 ACTIVE canonical 单一派发入口,
+        # CrossDeviceCoordinator 收为其内部兜底——两者 guardrail 标记
+        # 相应升为 PR-S3(注册表 notes 有案)。"全部仍是 PR-7" 是晋升
+        # 前的退役契约。
         from core.orchestration_authority.legacy_paths import LEGACY_PATH_REGISTRY
-        pr7_paths = [
-            "galaxy_gateway.orchestrator.galaxy_orchestrator",
-            "galaxy_gateway.orchestrator.task_orchestrator.TaskOrchestrator",
-            "galaxy_gateway.device_router.DeviceRouter.route_task",
-            "galaxy_gateway.cross_device_coordinator.CrossDeviceCoordinator",
-        ]
-        for path in pr7_paths:
+        expected_guardrails = {
+            "galaxy_gateway.orchestrator.galaxy_orchestrator": "PR-7",
+            "galaxy_gateway.orchestrator.task_orchestrator.TaskOrchestrator": "PR-7",
+            "galaxy_gateway.device_router.DeviceRouter.route_task": "PR-S3",
+            "galaxy_gateway.cross_device_coordinator.CrossDeviceCoordinator": "PR-S3",
+        }
+        for path, tag in expected_guardrails.items():
             entry = LEGACY_PATH_REGISTRY[path]
-            assert entry.pr_guardrail_added == "PR-7", (
-                f"{path} should have pr_guardrail_added='PR-7'"
+            assert entry.pr_guardrail_added == tag, (
+                f"{path} should have pr_guardrail_added={tag!r}"
             )
 
     def test_pr7_entries_have_recommendation(self):
@@ -919,7 +927,9 @@ class TestGalaxyOrchestratorDemoted:
             "galaxy_gateway.orchestrator.galaxy_orchestrator.DeviceManager",
             return_value=MagicMock(),
         ):
-            with caplog.at_level(logging.WARNING, logger="Galaxy.OrchestrationAuthority"):
+            # PR-R9-CLEAN:守卫从 WARNING 降为 DEBUG(降噪),前缀统一为
+            # "LEGACY GUARDRAIL"。钉住"init 仍发守卫"这一事实,级别按现契约。
+            with caplog.at_level(logging.DEBUG, logger="Galaxy.OrchestrationAuthority"):
                 try:
                     from galaxy_gateway.orchestrator.galaxy_orchestrator import GalaxyOrchestrator
                     GalaxyOrchestrator(config={})
@@ -927,7 +937,8 @@ class TestGalaxyOrchestratorDemoted:
                     pass  # Construction errors are not what we're testing
         legacy_records = [
             r for r in caplog.records
-            if "LEGACY PATH GUARDRAIL" in r.message
+            if "LEGACY GUARDRAIL" in r.message
+            and "galaxy_gateway.orchestrator.galaxy_orchestrator" in r.message
         ]
         assert len(legacy_records) >= 1
 

--- a/tests/test_pr5_liminal_projection_engine.py
+++ b/tests/test_pr5_liminal_projection_engine.py
@@ -512,16 +512,26 @@ class TestLiminalSurface:
         result = self.surface.render(_LIMINAL_SAMPLE)
         assert "Liminal" in result
 
-    def test_render_contains_depth_label(self):
+    # PR-55:默认渲染改为三部制阈限空间地图(本地链/跨设备链/沙箱推演
+    # ——三类唯一允许的内容),Depth/Topology/Ambient 维度条退居 legacy
+    # 兜底(_render_legacy,仅当三部制映射不可用)。"默认渲染含维度条"
+    # 是三部制落地前的退役契约。
+
+    def test_render_contains_local_chain_panel(self):
         result = self.surface.render(_LIMINAL_SAMPLE)
+        assert "Local Execution Chain" in result
+
+    def test_render_contains_speculative_panel(self):
+        result = self.surface.render(_LIMINAL_SAMPLE)
+        assert "Speculative" in result
+
+    def test_legacy_fallback_still_renders_dimension_bars(self):
+        """legacy 兜底路径保留维度条(仅在三部制映射不可用时使用)。"""
+        from desktop_projection import StateSpaceMapper
+        liminal = StateSpaceMapper().map(_LIMINAL_SAMPLE)
+        result = self.surface._render_legacy(liminal)
         assert "Depth" in result
-
-    def test_render_contains_topology_label(self):
-        result = self.surface.render(_LIMINAL_SAMPLE)
         assert "Topology" in result
-
-    def test_render_contains_ambient_label(self):
-        result = self.surface.render(_LIMINAL_SAMPLE)
         assert "Ambient" in result
 
     def test_render_minimal_projection(self):

--- a/tests/test_pr5_remote_execution_mode.py
+++ b/tests/test_pr5_remote_execution_mode.py
@@ -308,6 +308,45 @@ class TestOpenClawdRemoteAgentMode:
 class TestCommandRouterPreservesMode:
     """route_envelope propagates remote_execution_mode into the result dict."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_dispatch_gates(self, monkeypatch):
+        # V3 槽位门 sanctioned 旁路:本类钉 remote_execution_mode 透传到结果,
+        # 不钉门行为;假设备未注册 UDM 会被 canonical 槽位门拦下
+        # (deny-by-default,有意语义),须放行到执行器。
+        from core.canonical_dispatch_slot_authority import (
+            CanonicalDispatchSlot,
+            CanonicalDispatchSlotStatus,
+            CanonicalDispatchSlotsResult,
+        )
+
+        def _approve_all(device_ids, execution_mode, **kwargs):
+            slots = [
+                CanonicalDispatchSlot(
+                    device_id=d,
+                    execution_mode=execution_mode,
+                    slot_approved=True,
+                    status=CanonicalDispatchSlotStatus.SLOT_APPROVED.value,
+                    reason="test override",
+                )
+                for d in device_ids
+            ]
+            return CanonicalDispatchSlotsResult(
+                execution_mode=execution_mode,
+                approved_slots=slots,
+                blocked_slots=[],
+                can_proceed=True,
+                block_reason="",
+            )
+
+        monkeypatch.setattr(
+            "core.canonical_dispatch_slot_authority.get_canonical_dispatch_slots",
+            _approve_all,
+        )
+        monkeypatch.setattr(
+            "core.capability_aware_routing_default.infer_dispatch_capabilities",
+            lambda tool_name: [],
+        )
+
     def _build_router(self):
         from core.command_router import CommandRouter
 

--- a/tests/test_pr5a_policy_engine_mainline_convergence.py
+++ b/tests/test_pr5a_policy_engine_mainline_convergence.py
@@ -241,48 +241,60 @@ class TestCommandRouterPolicyIntegration:
 
 
 class TestDelegatedSignalHandlerConsumerWiring:
-    def test_M_handler_module_has_android_result_consumer_binding(self):
+    """PR-11-V2:consumer 接线收编进生命周期协调器,handler 只委托。
+
+    原三用例钉 handler 模块直绑 _android_result_consumer / 直呼
+    _ingest_delegated_signal——PR-11-V2 之后 ingress、状态归约与 PR-5A
+    result 转发统一由 core.android_delegated_runtime_lifecycle_coordinator
+    持有(handler 模块 docstring 有案),且 result 语义为 AndroidSignalKind
+    的 final_result/error(非字符串 "result")。改钉协调器契约。
+    """
+
+    def test_M_coordinator_owns_android_result_consumer_binding(self):
+        import core.android_delegated_runtime_lifecycle_coordinator as _co
         import galaxy_gateway.android.handlers.delegated_signal as _ds
 
-        # The module-level _android_result_consumer may be None (when import fails)
-        # but the binding should exist.
-        assert hasattr(_ds, "_android_result_consumer")
+        # 绑定在协调器上(可为 None——import 失败时,但绑定点必须存在)
+        assert hasattr(_co, "_android_result_consumer")
+        assert hasattr(_co, "_RESULT_CONSUMER_AVAILABLE")
+        # handler 不再直绑 consumer(委托收口,不得回退直连)
+        assert not hasattr(_ds, "_android_result_consumer")
 
-    def test_N_handler_forwards_result_kind_to_consumer(self):
-        """When a result-kind signal arrives and outcome.was_updated=True,
-        consume_android_behavioral_result should be called."""
-        import asyncio
-
-        import galaxy_gateway.android.handlers.delegated_signal as _ds
-
-        # Build a mock outcome
+    @staticmethod
+    def _make_ingress_outcome(kind: str):
         mock_outcome = MagicMock()
         mock_outcome.was_updated = True
         mock_outcome.reject_reason = ""
         mock_env = MagicMock()
         mock_env.signal_kind = MagicMock()
-        mock_env.signal_kind.value = "result"
+        mock_env.signal_kind.value = kind
         mock_env.contract_id = "contract_xyz"
-        mock_env.session_id = "sess_xyz"
+        mock_env.session_id = ""
         mock_env.signal_id = "sig_001"
         mock_env.emission_seq = 1
         mock_env.task_id = "task_xyz"
         mock_env.trace_id = "trace_xyz"
         mock_outcome.envelope = mock_env
-        mock_record = MagicMock()
-        mock_record.phase = MagicMock()
-        mock_record.phase.value = "result"
-        mock_outcome.record = mock_record
+        return mock_outcome
+
+    def _run_handler_with_kind(self, kind: str):
+        import asyncio
+        import core.android_delegated_runtime_lifecycle_coordinator as _co
+        import galaxy_gateway.android.handlers.delegated_signal as _ds
 
         mock_consumer = MagicMock()
         mock_consumer.consume_android_behavioral_result = MagicMock(
             return_value={"consumed": True}
         )
+        mock_outcome = self._make_ingress_outcome(kind)
 
         loop = asyncio.new_event_loop()
         try:
-            with patch.object(_ds, "_ingest_delegated_signal", return_value=mock_outcome), \
-                 patch.object(_ds, "_android_result_consumer", mock_consumer):
+            with patch.object(_co, "_EXECUTION_SIGNAL_AVAILABLE", True), \
+                 patch.object(_co, "_ingest_execution_signal",
+                              MagicMock(return_value=mock_outcome)), \
+                 patch.object(_co, "_RESULT_CONSUMER_AVAILABLE", True), \
+                 patch.object(_co, "_android_result_consumer", mock_consumer):
                 result = loop.run_until_complete(
                     _ds.handle_delegated_execution_signal(
                         bridge=MagicMock(),
@@ -292,50 +304,17 @@ class TestDelegatedSignalHandlerConsumerWiring:
                 )
         finally:
             loop.close()
+        return result, mock_consumer
 
+    def test_N_coordinator_forwards_terminal_result_kind_to_consumer(self):
+        """final_result 终局信号 → PR-5A 稳定 consumer 被调,handler 回 ACK。"""
+        result, mock_consumer = self._run_handler_with_kind("final_result")
         assert result["type"] == "delegated_execution_signal_ack"
         mock_consumer.consume_android_behavioral_result.assert_called_once()
 
-    def test_O_handler_does_not_forward_non_result_kind(self):
-        """When signal_kind is 'progress', consumer should NOT be called."""
-        import asyncio
-
-        import galaxy_gateway.android.handlers.delegated_signal as _ds
-
-        mock_outcome = MagicMock()
-        mock_outcome.was_updated = True
-        mock_outcome.reject_reason = ""
-        mock_env = MagicMock()
-        mock_env.signal_kind = MagicMock()
-        mock_env.signal_kind.value = "progress"  # NOT result
-        mock_env.contract_id = "contract_xyz"
-        mock_env.session_id = "sess_xyz"
-        mock_env.signal_id = "sig_002"
-        mock_env.emission_seq = 2
-        mock_env.task_id = "task_xyz"
-        mock_env.trace_id = "trace_xyz"
-        mock_outcome.envelope = mock_env
-        mock_record = MagicMock()
-        mock_record.phase = MagicMock()
-        mock_record.phase.value = "progress"
-        mock_outcome.record = mock_record
-
-        mock_consumer = MagicMock()
-        mock_consumer.consume_android_behavioral_result = MagicMock()
-
-        loop = asyncio.new_event_loop()
-        try:
-            with patch.object(_ds, "_ingest_delegated_signal", return_value=mock_outcome), \
-                 patch.object(_ds, "_android_result_consumer", mock_consumer):
-                result = loop.run_until_complete(
-                    _ds.handle_delegated_execution_signal(
-                        bridge=MagicMock(),
-                        websocket=MagicMock(),
-                        message={"device_id": "dev_001", "message_id": "msg_002"},
-                    )
-                )
-        finally:
-            loop.close()
-
+    def test_O_coordinator_does_not_forward_non_result_kind(self):
+        """progress 非终局信号 → consumer 不得被调。"""
+        result, mock_consumer = self._run_handler_with_kind("progress")
         assert result["type"] == "delegated_execution_signal_ack"
         mock_consumer.consume_android_behavioral_result.assert_not_called()
+

--- a/tests/test_pr6_node_audit.py
+++ b/tests/test_pr6_node_audit.py
@@ -318,7 +318,9 @@ def test_34_run_audit_every_entry_has_valid_action(audit_report):
 
 
 def test_35_run_audit_nominal_count_gte_130(audit_report):
-    assert audit_report.nominal_count >= 130
+    # 节点数收敛为 125(全量审计口径,见 node_dependencies.json)——
+    # 130 是收敛前的旧地板。
+    assert audit_report.nominal_count >= 125
 
 
 def test_36_run_audit_orchestrated_count_gte_90(audit_report):

--- a/tests/test_pr7_cross_device_substrate.py
+++ b/tests/test_pr7_cross_device_substrate.py
@@ -804,6 +804,45 @@ class TestOpenClawdAgentDispatchAlwaysAgentRuntime:
 class TestBackwardCompatibility:
     """Existing callers that do not set remote_execution_mode continue to work."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_dispatch_gates(self, monkeypatch):
+        # V3 槽位门 sanctioned 旁路:本类钉 无模式信封的向后兼容路由,
+        # 不钉门行为;假设备未注册 UDM 会被 canonical 槽位门拦下
+        # (deny-by-default,有意语义),须放行到执行器。
+        from core.canonical_dispatch_slot_authority import (
+            CanonicalDispatchSlot,
+            CanonicalDispatchSlotStatus,
+            CanonicalDispatchSlotsResult,
+        )
+
+        def _approve_all(device_ids, execution_mode, **kwargs):
+            slots = [
+                CanonicalDispatchSlot(
+                    device_id=d,
+                    execution_mode=execution_mode,
+                    slot_approved=True,
+                    status=CanonicalDispatchSlotStatus.SLOT_APPROVED.value,
+                    reason="test override",
+                )
+                for d in device_ids
+            ]
+            return CanonicalDispatchSlotsResult(
+                execution_mode=execution_mode,
+                approved_slots=slots,
+                blocked_slots=[],
+                can_proceed=True,
+                block_reason="",
+            )
+
+        monkeypatch.setattr(
+            "core.canonical_dispatch_slot_authority.get_canonical_dispatch_slots",
+            _approve_all,
+        )
+        monkeypatch.setattr(
+            "core.capability_aware_routing_default.infer_dispatch_capabilities",
+            lambda tool_name: [],
+        )
+
     def test_route_envelope_without_mode_succeeds(self):
         """A TaskEnvelope without remote_execution_mode routes successfully."""
         from core.schemas.task_envelope import TaskEnvelope

--- a/tests/test_prB_legacy_ingress_dispatch_convergence.py
+++ b/tests/test_prB_legacy_ingress_dispatch_convergence.py
@@ -235,8 +235,16 @@ class TestSchedulerRelaySpineRouting(unittest.TestCase):
         mock_get.assert_not_called()
         ctx_router.route_envelope.assert_called_once()
 
-    def test_16_exec_relay_falls_back_to_proxy_relay_when_spine_fails(self):
-        """When route_envelope raises, ProxyRelay fallback is attempted."""
+    def test_16_exec_relay_legacy_fallback_gated_when_spine_fails(self):
+        """When route_envelope raises, the legacy ProxyRelay fallback is GATED.
+
+        钉住现契约(canonical 收口):spine 失败时默认**封锁** legacy 回退
+        (CANONICAL_ROUTE_REQUIRED),只有显式 opt-in
+        allow_legacy_scheduler_fallback 才走 ProxyRelay。
+        "spine 失败即无条件回退 ProxyRelay" 是收口前的退役契约。
+        """
+        import json
+
         sched = self._make_scheduler()
 
         mock_router = MagicMock()
@@ -250,17 +258,36 @@ class TestSchedulerRelaySpineRouting(unittest.TestCase):
 
         context = {"command_router": mock_router}
 
+        # ── 默认:回退被封,ProxyRelay 不得被调用 ──
+        with patch("core.proxy_relay.get_proxy_relay", return_value=mock_proxy_relay):
+            with patch("core.proxy_relay.RelayRequest", MagicMock()):
+                blocked_raw = _run(sched._exec_relay(
+                    {"source_device": "s", "target_device": "t", "payload": {}},
+                    context,
+                ))
+        mock_proxy_relay.relay.assert_not_called()
+        blocked = json.loads(blocked_raw)
+        self.assertFalse(blocked.get("success"))
+        self.assertEqual(blocked.get("error_code"), "CANONICAL_ROUTE_REQUIRED")
+        self.assertTrue(blocked.get("legacy_fallback_blocked"))
+
+        # ── 显式 opt-in:ProxyRelay 回退可用,并打 legacy_fallback 标记 ──
         with patch("core.proxy_relay.get_proxy_relay", return_value=mock_proxy_relay):
             with patch("core.proxy_relay.RelayRequest", MagicMock()):
                 result_raw = _run(sched._exec_relay(
-                    {"source_device": "s", "target_device": "t", "payload": {}},
+                    {
+                        "source_device": "s",
+                        "target_device": "t",
+                        "payload": {},
+                        "allow_legacy_scheduler_fallback": True,
+                    },
                     context,
                 ))
 
         mock_proxy_relay.relay.assert_called_once()
-        import json
         result = json.loads(result_raw)
         self.assertTrue(result.get("relayed"))
+        self.assertEqual(result.get("routing_plane"), "legacy_fallback")
 
     def test_17_exec_relay_uses_get_command_router_when_no_context_router(self):
         """_exec_relay calls get_command_router() when context has no router."""
@@ -327,43 +354,70 @@ class TestSchedulerMeshSendSpineRouting(unittest.TestCase):
         result = json.loads(result_raw)
         self.assertTrue(result.get("success"))
 
-    def test_20_exec_mesh_send_falls_back_to_mesh_coordinator_when_spine_fails(self):
-        """When route_envelope raises, MeshCoordinator fallback is attempted."""
-        sched = self._make_scheduler()
+    @staticmethod
+    def _make_mesh_coord(reachable=True):
+        """PR-MESH-COLLAB 协作路由的 mesh 协调器桩。
 
-        mock_router = MagicMock()
-        mock_router.route_envelope = AsyncMock(side_effect=RuntimeError("spine down"))
+        peer 属性必须是真实原语(而非裸 MagicMock):调度器会把
+        reachable_direct/reachable_relay/latency_ms 装进 mesh_advice
+        并 JSON 序列化——MagicMock 漏进去即崩,那是桩的问题不是代码的。
+        """
+        from types import SimpleNamespace
 
         mock_mesh_result = MagicMock()
         mock_mesh_result.to_dict.return_value = {"mesh_sent": True}
 
         mock_mesh_coord = MagicMock()
         mock_mesh_coord.send = AsyncMock(return_value=mock_mesh_result)
+        if reachable:
+            mock_mesh_coord.get_peer.return_value = SimpleNamespace(
+                reachable_direct=True, reachable_relay=False, latency_ms=12.5,
+            )
+        else:
+            mock_mesh_coord.get_peer.return_value = None
+        return mock_mesh_coord
+
+    def test_20_exec_mesh_send_uses_mesh_when_peer_reachable(self):
+        """PR-MESH-COLLAB:mesh 建议可达 → mesh.send() 执行,带 mesh_advice。
+
+        钉住协作路由契约(mesh 建议先行,"NOT a fallback chain"):
+        peer 可达时走 mesh_routed,spine 路由器根本不参与。
+        "spine 失败才回退 mesh" 是收口前的退役契约。
+        """
+        import json
+
+        sched = self._make_scheduler()
+
+        mock_router = MagicMock()
+        mock_router.route_envelope = AsyncMock(side_effect=RuntimeError("spine down"))
+        mock_mesh_coord = self._make_mesh_coord(reachable=True)
 
         with patch("core.command_router.get_command_router", return_value=mock_router):
             with patch("core.mesh_coordinator.get_mesh_coordinator", return_value=mock_mesh_coord):
                 result_raw = _run(sched._exec_mesh_send({"target_device": "tgt"}))
 
         mock_mesh_coord.send.assert_called_once()
-        import json
+        mock_router.route_envelope.assert_not_called()
         result = json.loads(result_raw)
         self.assertTrue(result.get("mesh_sent"))
+        self.assertEqual(result.get("via"), "mesh_routed")
+        self.assertTrue(result.get("mesh_advice", {}).get("reachable_direct"))
 
-    def test_21_exec_mesh_send_uses_node_registry_when_router_unavailable(self):
-        """When CommandRouter is unavailable, falls back to MeshCoordinator."""
+    def test_21_exec_mesh_send_mesh_path_works_when_router_unavailable(self):
+        """CommandRouter 不可用时,mesh 可达路径照常工作(协作路由独立于 spine)。"""
+        import json
+
         sched = self._make_scheduler()
-
-        mock_mesh_result = MagicMock()
-        mock_mesh_result.to_dict.return_value = {"mesh_sent": True, "direct": True}
-
-        mock_mesh_coord = MagicMock()
-        mock_mesh_coord.send = AsyncMock(return_value=mock_mesh_result)
+        mock_mesh_coord = self._make_mesh_coord(reachable=True)
 
         with patch("core.command_router.get_command_router", side_effect=ImportError("no router")):
             with patch("core.mesh_coordinator.get_mesh_coordinator", return_value=mock_mesh_coord):
                 result_raw = _run(sched._exec_mesh_send({"target_device": "tgt"}))
 
         mock_mesh_coord.send.assert_called_once()
+        result = json.loads(result_raw)
+        self.assertTrue(result.get("mesh_sent"))
+        self.assertEqual(result.get("via"), "mesh_routed")
 
     def test_22_exec_mesh_send_records_ingress(self):
         """record_legacy_ingress is called with SCHEDULER source."""

--- a/tests/test_prg_observability_production_hooks.py
+++ b/tests/test_prg_observability_production_hooks.py
@@ -352,6 +352,45 @@ class TestMeshSessionTransitionEmits:
 class TestDispatchDecisionEmit:
     """emit_dispatch_decision_event is called from CommandRouter.route_envelope."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_dispatch_gates(self, monkeypatch):
+        # plan_selected 事件在 V3 槽位门之后才发(门拦下即无方案可言,
+        # 是有意语义)。测试用的假设备不在 UDM,须走 sanctioned 旁路
+        # 让派发真正走到选案发射点。
+        from core.canonical_dispatch_slot_authority import (
+            CanonicalDispatchSlot,
+            CanonicalDispatchSlotStatus,
+            CanonicalDispatchSlotsResult,
+        )
+
+        def _approve_all(device_ids, execution_mode, **kwargs):
+            slots = [
+                CanonicalDispatchSlot(
+                    device_id=d,
+                    execution_mode=execution_mode,
+                    slot_approved=True,
+                    status=CanonicalDispatchSlotStatus.SLOT_APPROVED.value,
+                    reason="test override — prg observability suite",
+                )
+                for d in device_ids
+            ]
+            return CanonicalDispatchSlotsResult(
+                execution_mode=execution_mode,
+                approved_slots=slots,
+                blocked_slots=[],
+                can_proceed=True,
+                block_reason="",
+            )
+
+        monkeypatch.setattr(
+            "core.canonical_dispatch_slot_authority.get_canonical_dispatch_slots",
+            _approve_all,
+        )
+        monkeypatch.setattr(
+            "core.capability_aware_routing_default.infer_dispatch_capabilities",
+            lambda tool_name: [],
+        )
+
     def setup_method(self):
         from core.runtime.runtime_observability_sink import reset_observability_sink
         reset_observability_sink()

--- a/tests/test_ws_auth_handshake.py
+++ b/tests/test_ws_auth_handshake.py
@@ -1,0 +1,116 @@
+"""
+PR-AUTH-UNIFIED(服务端补齐)—— WebSocket auth 首帧应答者测试
+=============================================================
+
+客户端契约(Android/WearOS shared-protocol AuthMessage.kt)early 上线:
+onOpen 后首帧发 ``{"type": "auth", ...}``,等待 auth_ok/auth_failed。
+此前 V2 无应答者,状态机两端空转。本套件钉住服务端应答语义:
+
+1. 认证关闭(默认)→ auth_ok 且 auth_enforced=false(诚实:没校验)。
+2. 认证开启 + 令牌缺失 → auth_failed reason=missing_token。
+3. 认证开启 + 令牌错误 → auth_failed reason=invalid_token。
+4. 认证开启 + 令牌正确 → auth_ok 且 auth_enforced=true。
+5. 认证开启 + 服务端没配令牌 → auth_failed reason=server_not_configured。
+6. AUTH 类型已注册进 AndroidBridge 消息处理表。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _msg(token: str = "", device_id: str = "dev-auth-1") -> dict:
+    return {
+        "type": "auth",
+        "token": token,
+        "device_id": device_id,
+        "device_type": "android",
+        "protocol_version": "3.0",
+        "message_id": "msg-auth-1",
+    }
+
+
+@pytest.fixture()
+def _auth_env(monkeypatch):
+    """认证开启 + 单一有效令牌的标准环境。"""
+    monkeypatch.setenv("GALAXY_AUTH_ENABLED", "1")
+    monkeypatch.setenv("GALAXY_API_TOKEN", "valid-token-abc")
+    monkeypatch.delenv("GALAXY_API_TOKENS", raising=False)
+    monkeypatch.delenv("GALAXY_MODE", raising=False)
+
+
+class TestAuthDisabled:
+    def test_auth_ok_with_enforced_false(self, monkeypatch):
+        monkeypatch.delenv("GALAXY_AUTH_ENABLED", raising=False)
+        monkeypatch.delenv("GALAXY_MODE", raising=False)
+        from galaxy_gateway.android.handlers.auth import handle_auth
+
+        resp = _run(handle_auth(MagicMock(), None, _msg()))
+        assert resp["type"] == "auth_ok"
+        assert resp["auth_enforced"] is False
+        assert resp["correlation_id"] == "msg-auth-1"
+
+
+class TestAuthEnabled:
+    def test_missing_token_fails(self, _auth_env):
+        from galaxy_gateway.android.handlers.auth import handle_auth
+
+        resp = _run(handle_auth(MagicMock(), None, _msg(token="")))
+        assert resp["type"] == "auth_failed"
+        assert resp["reason"] == "missing_token"
+        assert resp["auth_enforced"] is True
+
+    def test_invalid_token_fails(self, _auth_env):
+        from galaxy_gateway.android.handlers.auth import handle_auth
+
+        resp = _run(handle_auth(MagicMock(), None, _msg(token="wrong")))
+        assert resp["type"] == "auth_failed"
+        assert resp["reason"] == "invalid_token"
+
+    def test_valid_token_ok(self, _auth_env):
+        from galaxy_gateway.android.handlers.auth import handle_auth
+
+        bridge = MagicMock(spec=[])
+        resp = _run(handle_auth(bridge, None, _msg(token="valid-token-abc")))
+        assert resp["type"] == "auth_ok"
+        assert resp["auth_enforced"] is True
+        # 连接级认证状态被记录,供后续按需门控
+        assert getattr(bridge, "_connection_auth_state")["dev-auth-1"] == {
+            "authenticated": True,
+            "auth_enforced": True,
+        }
+
+    def test_no_server_tokens_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_AUTH_ENABLED", "1")
+        monkeypatch.delenv("GALAXY_API_TOKEN", raising=False)
+        monkeypatch.delenv("GALAXY_API_TOKENS", raising=False)
+        from galaxy_gateway.android.handlers.auth import handle_auth
+
+        resp = _run(handle_auth(MagicMock(), None, _msg(token="anything")))
+        assert resp["type"] == "auth_failed"
+        assert resp["reason"] == "server_not_configured"
+
+
+class TestBridgeWiring:
+    def test_auth_type_registered_in_bridge(self):
+        from galaxy_gateway.protocol.aip_v3 import MessageType
+
+        assert MessageType.AUTH.value == "auth"
+        assert MessageType.AUTH_OK.value == "auth_ok"
+        assert MessageType.AUTH_FAILED.value == "auth_failed"
+
+        from galaxy_gateway.android_bridge import AndroidBridge
+
+        bridge = AndroidBridge()
+        assert MessageType.AUTH in bridge._message_handlers


### PR DESCRIPTION
## 概要

排查第五批四波(5a–5d):从 dashboard 裁决落地后的 121 条本地基线(CI ~117)清零 **45 条**,挖出 **5 个真代码 bug**。

## 真代码修复

1. **`core/openclawd.py` — canonical 路由被静默跳过**:`send_gateway_command` 给非可空 `List[str]` 字段传 `None`,Pydantic 在 try 内爆炸 → 每个不带能力要求的网关命令都静默跌落 legacy websocket,canonical CommandRouter 从此入口永远走不到。改 `or []`。
2. **`core/recovery_truth_surface.py` — 诚实边界违规**:in_flight 维度凭静态结构探测声称 `observed`,违背枚举语义与其证据自引的 STATE_RESTORED≠CONTINUITY 原则。封顶 `partial`,互相矛盾的 F03/V01 两测按诚实原则统一。
3. **`galaxy_gateway/android/handlers/task_lifecycle.py` — 幂等自碰撞(链式)**:持久幂等预检"收到即记录"裸 task_id,统一 ingress 的联合幂等回退键(缺 message_id 时同为裸 task_id)读同一库 → 把本条消息当自己的重复(duplicate_ignored),完成通知被抑制;且被门拒的结果占坑误杀合法重试。改"只查不记 + 接纳后补记(仅 ingress 未运行时)"。
4. **`galaxy_gateway/device_router.py` — 同库第三层碰撞**:完成通知的持久去重用裸 task_id,ingress 刚记录后首次通知即被误判跨重启重复,唤醒被吞。加自有命名空间 `device_router_notify:{task_id}`。
5. **`scripts/node_audit.py` — 卫生审计自我误报**:同一跑内先 import 节点再审计,进程生成的 `__pycache__` 被当仓库卫生违规。改 git 感知(与 check_repo_hygiene 同一裁决):未跟踪的运行时产物豁免,被跟踪的才违规。

## 测试改钉(方向均已证实为代码有意,45 条,四波提交)

5a(19): prB relay/mesh 协作路由、prg 槽位门后事件、constellation 集体调度门、pr1_entry 门旁路、pr02 PR-46 schema 门、pr47 PR-S3 晋升/验收字段/守卫降级、validate_runtime dashboard 终局。
5b(6): pr1_p0 改名追随+可调用桩+持久库卫生 setUp、pr2 PR-AIP-UNIFIED 基底层不回环、pr12v2 诚实降级(incomplete)。
5c(10): L4 canonical 晋升终局钉+planner 级行为下沉、CODE_FIX 中介式 SelfHealingLoop 六阶段、三部制阈限渲染。
5d(10): pr46 门语义与链选择解耦、pr7/pr5 槽位门旁路、pr2_ucm async disconnect、pr16 连续感知规范默认(text-only 为显式 opt-out)、pr6 节点数收敛 125。

## 验证

每波:相关套件合跑零败(5a: 557,5b: 182,5c: 116,5d: 276);lint 差分 ≤0(累计 -3)。

## 已知遗留(下一波)

phase234 CapabilityRegistry 改名(→AppExecutionCapabilityRegistry)、audit_fixes 钉已删除的 Node_41_MQTT(node_dependencies.json 仍注册,需一致性裁决)、cross_device_hardening 路由内省 helper、continuity_replay emit_runtime_event 移位、e2e_integration_gaps/android_v2_canonical、desktop_existence 与 slot authority 顺序污染、tts_overlay 污染源、integration 长尾(~76 条)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b