### PR TITLE
V2 后端加固 + 设备配对系统后端脊梁(P3-1 全后端)

### DIFF
--- a/config/llm_routing_policy.yaml
+++ b/config/llm_routing_policy.yaml
@@ -34,11 +34,13 @@ global_slo:
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 任务类型路由规则 (2026-05-29: 加入minimax/step/mimo)
+# LOCAL-FIRST (2026-07-15): 每个任务的 priorities 均以 ollama 打头,贯彻本地主脑
+#   优先设计。ollama 仅在本地实际运行时才被选中;未运行则自动跳过 → 回退云端。
 # ─────────────────────────────────────────────────────────────────────────────
 task_routing:
 
   reasoning:
-    priorities: [anthropic, anthropic, openai, deepseek, google, qwen, step, xai]
+    priorities: [ollama, anthropic, anthropic, openai, deepseek, google, qwen, step, xai]
     # ^ 双anthropic = Fable 5 (Mythos-class) → Opus 4.8 (safeguard fallback)
     constraints:
       require_tools: false
@@ -50,7 +52,7 @@ task_routing:
     fallback_chain: [deepseek, openai]
 
   fast_response:
-    priorities: [deepseek, agnes, mimo, groq, google, openai, zhipu, moonshot]
+    priorities: [ollama, deepseek, agnes, mimo, groq, google, openai, zhipu, moonshot]
     constraints:
       require_tools: false
     cost_budget:
@@ -61,7 +63,7 @@ task_routing:
     fallback_chain: [openai, anthropic]
 
   coding:
-    priorities: [anthropic, deepseek, qwen, openai, step, mimo]
+    priorities: [ollama, anthropic, deepseek, qwen, openai, step, mimo]
     # ^ anthropic = Fable 5 (SWE-Bench Pro 80.3%, 代码迁移50M行Ruby一天完成)
     constraints:
       require_tools: false
@@ -73,7 +75,7 @@ task_routing:
     fallback_chain: [openai, anthropic]
 
   creative:
-    priorities: [openai, anthropic, mistral, deepseek, minimax]
+    priorities: [ollama, openai, anthropic, mistral, deepseek, minimax]
     constraints:
       require_tools: false
     cost_budget:
@@ -84,7 +86,7 @@ task_routing:
     fallback_chain: [deepseek, openai]
 
   analysis:
-    priorities: [anthropic, openai, deepseek, google, perplexity, qwen, step]
+    priorities: [ollama, anthropic, openai, deepseek, google, perplexity, qwen, step]
     # ^ anthropic = Fable 5 (Hex analytics首个>90%模型)
     constraints:
       require_tools: false
@@ -96,7 +98,7 @@ task_routing:
     fallback_chain: [deepseek, openai]
 
   planning:
-    priorities: [anthropic, openai, deepseek, xai, qwen, minimax, step]
+    priorities: [ollama, anthropic, openai, deepseek, xai, qwen, minimax, step]
     # ^ anthropic = Fable 5 (长程规划，多步自主任务)
     constraints:
       require_tools: false
@@ -108,7 +110,7 @@ task_routing:
     fallback_chain: [openai, deepseek]
 
   agent_control:
-    priorities: [anthropic, openai, deepseek, minimax, step]
+    priorities: [ollama, anthropic, openai, deepseek, minimax, step]
     # ^ anthropic = Fable 5 (长程agentic任务最优，持久记忆游戏通关率3x)
     constraints:
       require_tools: true
@@ -120,7 +122,7 @@ task_routing:
     fallback_chain: [openai, anthropic]
 
   general:
-    priorities: [openai, anthropic, deepseek, google, agnes, qwen, zhipu, minimax, step, mimo]
+    priorities: [ollama, openai, anthropic, deepseek, google, agnes, qwen, zhipu, minimax, step, mimo]
     constraints:
       require_tools: false
     cost_budget:

--- a/core/auth.py
+++ b/core/auth.py
@@ -261,10 +261,20 @@ def verify_api_token(token: str) -> bool:
         logger.warning("Token contains non-ASCII characters, rejecting")
         return False
 
+    # 每设备 token(配对发放的专属 token)优先校验:命中即通过,可按设备单独吊销。
+    # 与下面的环境共享 token 叠加生效——共享 token 保留作管理员兜底。
+    try:
+        from core.device_token_registry import verify_device_token
+
+        if verify_device_token(token) is not None:
+            return True
+    except Exception as exc:  # noqa: BLE001  注册表不可用不应阻断环境 token 校验
+        logger.debug("每设备 token 校验跳过(非致命): %s", exc)
+
     active = get_active_tokens()
 
     if not active:
-        # No tokens configured → refuse (dev mode bypass removed for security)
+        # 无共享 env token:仅当每设备 token 也未命中时才失败(上面已 return True)。
         logger.warning("No active API tokens configured — token validation failed")
         return False
 

--- a/core/device_enrollment.py
+++ b/core/device_enrollment.py
@@ -1,0 +1,239 @@
+"""
+core/device_enrollment.py — 设备入伙(配对/发放)协调器 + 智能体准入(P3-1 阶段二)
+==============================================================================
+
+在阶段一"每设备 token 注册表"(core/device_token_registry.py)之上,补上**配对流程
+与准入判断**:新设备发来"入伙请求",经**智能体预判 + 你终裁**批准后,才调用注册表
+发放它专属的 token(推回给设备)。核心设计取向(与所有者对齐):
+
+- **别处批准(device-authorization grant)**:新设备零输入——它只管发请求(带自己的
+  指纹),你在**已信任的桌面/手机**上批准。批准动作不在新设备上做。
+- **智能体这一道判断**:请求到达时先过一个**策略钩子**(智能体预判,给出建议 verdict:
+  approve/deny/None),但**最终 approve/deny 是显式的**(HITL 终裁)。默认无策略 = 纯
+  HITL(全部 pending 等你拍板)。
+- **配对码(可选)**:桌面可生成一个短时效配对码,给"有摄像头/键盘"的设备扫/输,作为
+  更强的信任信号(code_verified),策略可据此自动建议批准;无码也能走"别处批准"。
+- **不做账号**:信任挂在设备上,不引入用户账户。
+
+本模块只管"请求生命周期 + 发放决策",不碰 WS 注册/mesh enroll(那是网关的职责);
+它把 token 交出去,由端点/网关决定何时把设备放进 mesh(准入之后)。纯内存 + 可注入
+registry,完全可单测。
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from core.device_token_registry import DeviceTokenRegistry, get_device_token_registry
+
+logger = logging.getLogger("Galaxy.DeviceEnrollment")
+
+# 状态
+PENDING = "pending"
+APPROVED = "approved"
+DENIED = "denied"
+EXPIRED = "expired"
+CLAIMED = "claimed"  # 已批准且设备已领走 token
+
+_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"  # 去掉易混字符 I/O/0/1
+
+
+def _gen_pairing_code(n: int = 6) -> str:
+    return "".join(secrets.choice(_CODE_ALPHABET) for _ in range(n))
+
+
+@dataclass
+class EnrollmentRequest:
+    request_id: str
+    device_id: str
+    device_type: Optional[str] = None
+    name: Optional[str] = None
+    fingerprint: Optional[Dict[str, Any]] = None
+    created_at: float = field(default_factory=time.time)
+    status: str = PENDING
+    code_verified: bool = False  # 是否携带了有效配对码(更强信任信号)
+    suggested_verdict: Optional[str] = None  # 智能体预判(非绑定):approve/deny/None
+    decided_at: Optional[float] = None
+    deny_reason: Optional[str] = None
+    # 批准后暂存的明文 token(仅供设备 claim 一次),claim 后清空
+    _token: Optional[str] = None
+
+    def public_view(self) -> Dict[str, Any]:
+        """给批准/管理界面看的视图,绝不含 token。"""
+        return {
+            "request_id": self.request_id,
+            "device_id": self.device_id,
+            "device_type": self.device_type,
+            "name": self.name,
+            "fingerprint": self.fingerprint,
+            "created_at": self.created_at,
+            "status": self.status,
+            "code_verified": self.code_verified,
+            "suggested_verdict": self.suggested_verdict,
+            "decided_at": self.decided_at,
+            "deny_reason": self.deny_reason,
+        }
+
+
+# 策略钩子:智能体预判。输入请求,返回建议 verdict(approve/deny/None=不表态)。非绑定。
+AdmissionPolicy = Callable[[EnrollmentRequest], Optional[str]]
+
+
+class DeviceEnrollmentCoordinator:
+    def __init__(
+        self,
+        registry: Optional[DeviceTokenRegistry] = None,
+        *,
+        code_ttl: float = 300.0,
+        request_ttl: float = 600.0,
+        policy: Optional[AdmissionPolicy] = None,
+    ) -> None:
+        self._registry = registry or get_device_token_registry()
+        self._code_ttl = code_ttl
+        self._request_ttl = request_ttl
+        self._policy = policy
+        self._lock = threading.RLock()
+        self._codes: Dict[str, float] = {}  # code -> expiry_at(用完即删)
+        self._requests: Dict[str, EnrollmentRequest] = {}
+
+    # ── 配对码(桌面侧,可选) ────────────────────────────────────────────
+    def create_pairing_code(self, ttl: Optional[float] = None) -> Dict[str, Any]:
+        """桌面生成一个短时效配对码(可展示为二维码/文本),供设备携带作为信任信号。"""
+        code = _gen_pairing_code()
+        with self._lock:
+            self._codes[code] = time.time() + (ttl if ttl is not None else self._code_ttl)
+        return {"code": code, "expires_in": ttl if ttl is not None else self._code_ttl}
+
+    def _consume_code(self, code: Optional[str]) -> bool:
+        """校验并消费配对码(一次性)。无码/无效返回 False,不阻断请求(只是不加信任)。"""
+        if not code:
+            return False
+        with self._lock:
+            exp = self._codes.get(code)
+            if exp is None or time.time() > exp:
+                self._codes.pop(code, None)
+                return False
+            del self._codes[code]  # 一次性
+            return True
+
+    # ── 入伙请求 ────────────────────────────────────────────────────────
+    def submit_enrollment(
+        self,
+        device_id: str,
+        *,
+        device_type: Optional[str] = None,
+        name: Optional[str] = None,
+        fingerprint: Optional[Dict[str, Any]] = None,
+        pairing_code: Optional[str] = None,
+    ) -> EnrollmentRequest:
+        """新设备提交入伙请求。生成 pending 请求,过一遍策略钩子(智能体预判),等终裁。"""
+        if not device_id or not str(device_id).strip():
+            raise ValueError("device_id 不能为空")
+        self._expire_locked_free()
+        req = EnrollmentRequest(
+            request_id=uuid.uuid4().hex,
+            device_id=str(device_id).strip(),
+            device_type=device_type,
+            name=name,
+            fingerprint=fingerprint or {},
+            code_verified=self._consume_code(pairing_code),
+        )
+        # 智能体预判(非绑定):失败不影响流程,保持 pending 等 HITL。
+        if self._policy is not None:
+            try:
+                v = self._policy(req)
+                if v in (APPROVED, DENIED, "approve", "deny"):
+                    req.suggested_verdict = "approve" if v in (APPROVED, "approve") else "deny"
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("准入策略预判失败(忽略,转 HITL): %s", exc)
+        with self._lock:
+            self._requests[req.request_id] = req
+        logger.info(
+            "入伙请求: request_id=%s device_id=%s type=%s code_verified=%s 建议=%s",
+            req.request_id,
+            req.device_id,
+            device_type,
+            req.code_verified,
+            req.suggested_verdict,
+        )
+        return req
+
+    def pending(self) -> List[Dict[str, Any]]:
+        """列出待终裁的请求(供桌面/手机批准界面),不含 token。"""
+        self._expire_locked_free()
+        with self._lock:
+            return [r.public_view() for r in self._requests.values() if r.status == PENDING]
+
+    def get(self, request_id: str) -> Optional[Dict[str, Any]]:
+        self._expire_locked_free()
+        with self._lock:
+            r = self._requests.get(request_id)
+            return r.public_view() if r else None
+
+    # ── 终裁 ────────────────────────────────────────────────────────────
+    def approve(self, request_id: str) -> Optional[str]:
+        """批准(HITL 终裁):经注册表发放专属 token 并暂存,返回明文 token(供推回设备)。"""
+        with self._lock:
+            r = self._requests.get(request_id)
+            if r is None or r.status != PENDING:
+                return None
+            token = self._registry.issue(r.device_id, device_type=r.device_type, name=r.name)
+            r.status = APPROVED
+            r.decided_at = time.time()
+            r._token = token
+        logger.info("入伙已批准: request_id=%s device_id=%s", request_id, r.device_id)
+        return token
+
+    def deny(self, request_id: str, reason: Optional[str] = None) -> bool:
+        with self._lock:
+            r = self._requests.get(request_id)
+            if r is None or r.status != PENDING:
+                return False
+            r.status = DENIED
+            r.decided_at = time.time()
+            r.deny_reason = reason
+        logger.info("入伙已拒绝: request_id=%s reason=%s", request_id, reason)
+        return True
+
+    def claim(self, request_id: str) -> Optional[str]:
+        """设备侧领取 token:仅当已批准且未领过,返回一次明文 token,随后清空转 CLAIMED。"""
+        with self._lock:
+            r = self._requests.get(request_id)
+            if r is None or r.status != APPROVED or r._token is None:
+                return None
+            tok = r._token
+            r._token = None
+            r.status = CLAIMED
+            return tok
+
+    # ── 过期清理 ────────────────────────────────────────────────────────
+    def _expire_locked_free(self) -> None:
+        now = time.time()
+        with self._lock:
+            for code, exp in list(self._codes.items()):
+                if now > exp:
+                    del self._codes[code]
+            for rid, r in list(self._requests.items()):
+                if r.status == PENDING and (now - r.created_at) > self._request_ttl:
+                    r.status = EXPIRED
+                    r.decided_at = now
+
+
+# ── 进程级单例 ────────────────────────────────────────────────────────────
+_coordinator: Optional[DeviceEnrollmentCoordinator] = None
+_coord_lock = threading.Lock()
+
+
+def get_enrollment_coordinator() -> DeviceEnrollmentCoordinator:
+    global _coordinator
+    if _coordinator is None:
+        with _coord_lock:
+            if _coordinator is None:
+                _coordinator = DeviceEnrollmentCoordinator()
+    return _coordinator

--- a/core/device_token_registry.py
+++ b/core/device_token_registry.py
@@ -29,7 +29,6 @@ UI 能填、``/api/v1/config`` 也不吐 token,更没有"给某台设备发一�
 from __future__ import annotations
 
 import hashlib
-import hmac
 import logging
 import os
 import secrets
@@ -157,7 +156,11 @@ class DeviceTokenRegistry:
     def verify(self, token: str) -> Optional[Dict[str, Any]]:
         """校验呈递的 token;命中且未吊销则返回其设备记录(不含明文),否则 None。
 
-        常量时间比较,避免时序侧信道;命中即刷新 last_seen。
+        实现:把呈递 token 取 sha256,按摘要做 O(1) 字典查(安全性来自 sha256 的
+        原像抗性,而非比较时序——攻击者要伪造需先求出摘要的原像,不可行)。
+        命中只在【内存】刷新 last_seen,【不】落盘——否则每次鉴权都写一次文件,
+        高频连接下是明显的 I/O 负担;last_seen 属可丢的观测字段,落盘由 issue/revoke
+        触发即可。
         """
         if not token:
             return None
@@ -166,20 +169,11 @@ class DeviceTokenRegistry:
         except Exception:  # noqa: BLE001
             return None
         with self._lock:
-            match: Optional[Dict[str, Any]] = None
-            for h, rec in self._by_hash.items():
-                # 常量时间比较每个摘要(摘要等长,compare_digest 安全)
-                if hmac.compare_digest(h, presented):
-                    match = rec
-                    break
-            if match is None:
+            rec = self._by_hash.get(presented)
+            if rec is None or rec.get("revoked"):
                 return None
-            if match.get("revoked"):
-                return None
-            match["last_seen"] = time.time()
-            self._persist()
-            # 返回副本,避免调用方改到内部状态
-            return dict(match)
+            rec["last_seen"] = time.time()  # 仅内存,不落盘
+            return dict(rec)  # 返回副本,避免调用方改到内部状态
 
     def revoke_device(self, device_id: str) -> int:
         """吊销某设备名下的【全部】token,返回吊销条数。"""

--- a/core/device_token_registry.py
+++ b/core/device_token_registry.py
@@ -1,0 +1,235 @@
+"""
+core/device_token_registry.py — 每设备 token 注册表(配对发放的凭证底座)
+======================================================================
+
+背景 / 为什么要有它
+-------------------
+此前网关鉴权只认环境变量里**一个大家共用的** token(``core/auth.py`` 的
+``GALAXY_API_TOKEN`` / ``GALAXY_API_TOKENS``),并且**没有任何发放路径**:没有
+UI 能填、``/api/v1/config`` 也不吐 token,更没有"给某台设备发一个专属 token"的
+端点。直接后果是——要么鉴权全关(谁连上谁就是自己人),要么一开就把所有设备
+全挡在外面(没办法把共享 token 送到设备上)。
+
+本模块补上"每设备一个可单独吊销的 token"这一层:配对批准后为设备**发放**一个
+专属 token,设备之后凭它连接;可**按设备吊销**而不影响其它设备。共享 env token
+仍由 ``core.auth`` 保留作管理员兜底,两者叠加生效。
+
+安全取舍(单用户 / 局域网或 tailnet 场景)
+------------------------------------------
+- 文件里**只存 token 的 sha256 摘要,绝不存明文**——存储被读走也拿不到可用 token。
+- 校验时对"呈递 token 的摘要"与"存储摘要"做**常量时间比较**(见 verify)。
+- 原子落盘(临时文件 + os.replace),多进程/崩溃不会写坏半个文件。
+- 存储路径默认在仓库【之外】(``~/.galaxy/device_tokens.json``),不进 git;可用
+  ``GALAXY_DEVICE_TOKEN_STORE`` 覆盖。
+
+本模块只管"凭证的发放/校验/吊销/枚举",不含配对流程/智能体准入(那是上层
+端点的职责)——保持单一职责,便于单测。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.DeviceTokenRegistry")
+
+_STORE_SCHEMA_VERSION = 1
+
+
+def _default_store_path() -> Path:
+    """默认存储路径:仓库之外(不进 git),可用 GALAXY_DEVICE_TOKEN_STORE 覆盖。"""
+    override = os.environ.get("GALAXY_DEVICE_TOKEN_STORE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    base = os.environ.get("GALAXY_DATA_DIR", "").strip()
+    root = Path(base).expanduser() if base else (Path.home() / ".galaxy")
+    return root / "device_tokens.json"
+
+
+def _hash_token(token: str) -> str:
+    """token → sha256 十六进制摘要(存储/比较用,绝不落明文)。"""
+    return hashlib.sha256(token.encode("utf-8", errors="strict")).hexdigest()
+
+
+class DeviceTokenRegistry:
+    """文件落地的每设备 token 注册表(线程安全)。
+
+    记录形状(内存 & 磁盘,均只含摘要不含明文)::
+
+        {
+          "token_sha256": "<hex>",
+          "device_id": "<uuid/稳定身份>",
+          "device_type": "android" | "wearos" | ...,
+          "name": "小米17",              # 人类可读,用于批准/管理界面
+          "issued_at": 1700000000.0,
+          "last_seen": 1700000123.0,     # 最近一次成功校验
+          "revoked": false,
+          "revoked_at": null,
+        }
+    """
+
+    def __init__(self, store_path: Optional[Path] = None) -> None:
+        self._path = Path(store_path) if store_path else _default_store_path()
+        self._lock = threading.RLock()
+        # token_sha256 -> record
+        self._by_hash: Dict[str, Dict[str, Any]] = {}
+        self._load()
+
+    # ── 持久化 ────────────────────────────────────────────────────────────
+    def _load(self) -> None:
+        with self._lock:
+            self._by_hash = {}
+            try:
+                if not self._path.exists():
+                    return
+                import json
+
+                data = json.loads(self._path.read_text(encoding="utf-8") or "{}")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("设备 token 存储读取失败(以空表启动): %s", exc)
+                return
+            for rec in data.get("tokens", []):
+                h = rec.get("token_sha256")
+                if isinstance(h, str) and h:
+                    self._by_hash[h] = rec
+
+    def _persist(self) -> None:
+        """原子落盘:临时文件 + os.replace,避免写坏半个文件。"""
+        import json
+
+        with self._lock:
+            payload = {
+                "schema_version": _STORE_SCHEMA_VERSION,
+                "tokens": list(self._by_hash.values()),
+            }
+            try:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                tmp = self._path.with_suffix(self._path.suffix + f".tmp.{os.getpid()}")
+                tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+                try:
+                    os.chmod(tmp, 0o600)  # 尽量收紧权限(best-effort,Windows 上忽略)
+                except OSError:
+                    pass
+                os.replace(tmp, self._path)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("设备 token 存储落盘失败: %s", exc)
+
+    # ── 发放 / 校验 / 吊销 / 枚举 ─────────────────────────────────────────
+    def issue(
+        self,
+        device_id: str,
+        *,
+        device_type: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> str:
+        """为设备发放一个新的专属 token,返回【明文 token(仅此一次可见)】。
+
+        同一 device_id 再次发放会新增一条记录(轮换);旧记录不自动作废,需显式
+        revoke(便于重装/换机的过渡窗口)。调用方(配对端点)应在**智能体准入
+        批准之后**才调用本方法。
+        """
+        if not device_id or not str(device_id).strip():
+            raise ValueError("device_id 不能为空")
+        raw = secrets.token_urlsafe(32)
+        rec = {
+            "token_sha256": _hash_token(raw),
+            "device_id": str(device_id).strip(),
+            "device_type": device_type,
+            "name": name,
+            "issued_at": time.time(),
+            "last_seen": None,
+            "revoked": False,
+            "revoked_at": None,
+        }
+        with self._lock:
+            self._by_hash[rec["token_sha256"]] = rec
+            self._persist()
+        logger.info("为设备发放 token: device_id=%s type=%s name=%s", device_id, device_type, name)
+        return raw
+
+    def verify(self, token: str) -> Optional[Dict[str, Any]]:
+        """校验呈递的 token;命中且未吊销则返回其设备记录(不含明文),否则 None。
+
+        常量时间比较,避免时序侧信道;命中即刷新 last_seen。
+        """
+        if not token:
+            return None
+        try:
+            presented = _hash_token(token)
+        except Exception:  # noqa: BLE001
+            return None
+        with self._lock:
+            match: Optional[Dict[str, Any]] = None
+            for h, rec in self._by_hash.items():
+                # 常量时间比较每个摘要(摘要等长,compare_digest 安全)
+                if hmac.compare_digest(h, presented):
+                    match = rec
+                    break
+            if match is None:
+                return None
+            if match.get("revoked"):
+                return None
+            match["last_seen"] = time.time()
+            self._persist()
+            # 返回副本,避免调用方改到内部状态
+            return dict(match)
+
+    def revoke_device(self, device_id: str) -> int:
+        """吊销某设备名下的【全部】token,返回吊销条数。"""
+        did = str(device_id).strip()
+        n = 0
+        with self._lock:
+            for rec in self._by_hash.values():
+                if rec.get("device_id") == did and not rec.get("revoked"):
+                    rec["revoked"] = True
+                    rec["revoked_at"] = time.time()
+                    n += 1
+            if n:
+                self._persist()
+        if n:
+            logger.info("吊销设备 token: device_id=%s 条数=%d", did, n)
+        return n
+
+    def list_devices(self) -> List[Dict[str, Any]]:
+        """枚举所有记录的**元数据**(绝不含明文/摘要),供管理/批准界面用。"""
+        with self._lock:
+            out = []
+            for rec in self._by_hash.values():
+                out.append(
+                    {
+                        "device_id": rec.get("device_id"),
+                        "device_type": rec.get("device_type"),
+                        "name": rec.get("name"),
+                        "issued_at": rec.get("issued_at"),
+                        "last_seen": rec.get("last_seen"),
+                        "revoked": bool(rec.get("revoked")),
+                    }
+                )
+            return out
+
+
+# ── 进程级单例(默认路径) ────────────────────────────────────────────────
+_registry: Optional[DeviceTokenRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def get_device_token_registry() -> DeviceTokenRegistry:
+    """返回默认存储路径的进程级单例。"""
+    global _registry
+    if _registry is None:
+        with _registry_lock:
+            if _registry is None:
+                _registry = DeviceTokenRegistry()
+    return _registry
+
+
+def verify_device_token(token: str) -> Optional[Dict[str, Any]]:
+    """便捷入口:用单例校验一个每设备 token。"""
+    return get_device_token_registry().verify(token)

--- a/core/device_types.py
+++ b/core/device_types.py
@@ -151,6 +151,19 @@ _PREFIX_TO_DEVICE_TYPE: dict[str, DeviceType] = {
     "virtual": DeviceType.CUSTOM,
 }
 
+# 客户端实发字符串别名(不匹配枚举/AIP 值,但语义已知)。
+# Wear OS 手表实际发的是 "wearos"(见 galaxy-wearos AuthMessage.kt),而规范 AIP 值是
+# "android_wear" → 直接发 wearos 会掉进 CUSTOM。Wear OS 本质是 Android,归 ANDROID,
+# 与 android_wear 一致。理想上手表应改发 android_wear(客户端侧另修),此处先兜住。
+_STRING_ALIASES: dict[str, DeviceType] = {
+    "wearos": DeviceType.ANDROID,
+    "wear_os": DeviceType.ANDROID,
+    "wear": DeviceType.ANDROID,
+    "watch": DeviceType.ANDROID,
+    "raspberrypi": DeviceType.LINUX,
+    "raspberry_pi": DeviceType.LINUX,
+}
+
 
 def resolve_device_type(raw: str) -> DeviceType:
     """将任意设备类型字符串解析为统一的 DeviceType。
@@ -179,6 +192,10 @@ def resolve_device_type(raw: str) -> DeviceType:
     # 2. AIP v3 细分类型
     if raw_lower in _AIP_TO_DEVICE_TYPE:
         return _AIP_TO_DEVICE_TYPE[raw_lower]
+
+    # 2.5 客户端实发字符串别名(如手表 "wearos" → ANDROID)
+    if raw_lower in _STRING_ALIASES:
+        return _STRING_ALIASES[raw_lower]
 
     # 3. 前缀匹配
     prefix = raw_lower.split("_")[0]

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -183,6 +183,7 @@ _PROVIDER_ENV_KEY_MAP: Dict[str, str] = {
     "moonshot": "MOONSHOT_API_KEY",
     "perplexity": "PERPLEXITY_API_KEY",
     "groq": "GROQ_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
     "ollama": "OLLAMA_URL",
     "oneapi": "ONEAPI_API_KEY",
     "oneapi_url": "ONEAPI_URL",
@@ -194,17 +195,21 @@ _PROVIDER_ENV_KEY_MAP: Dict[str, str] = {
 # 云端结果会回流到本地主脑进行整合。
 TASK_ROUTING_PREFERENCES: Dict[TaskType, List[str]] = {
     # 本地主脑优先，API 专科后备
-    # LOCAL-BRAIN-FIRST: hf_local (HuggingFace local models) are checked after ollama
+    # 2026-07-15: 移除 "hf_local"——其内部适配器从未被实现过,故永远不会注册,
+    #   却曾占据每个列表的第 2 位,污染自动选择顺序。发现/注册代码保留在别处,
+    #   仅从偏好列表里剔除。每个列表仍以本地 ollama 主脑打头。
+    # 2026-07-15: 把已注册但从未进偏好列表的 agnes/moonshot/openrouter 接入自动路由——
+    #   agnes(免费+多模态+工具)排在便宜开源之后、专有之前;moonshot(Kimi)入
+    #   CODING/GENERAL/FAST_RESPONSE 尾;openrouter(聚合器)入 GENERAL/ANALYSIS 尾。
     # 2026-05-29: 新增 minimax/step/mimo 三个国产提供商
     # 2026-07-10: 新增 meta(Muse Spark 1.1,agentic/多模态/1M ctx)——
     # 定位在专有兜底梯队,agentic 任务(AGENT_CONTROL/CODING/PLANNING)优先级靠前
-    TaskType.REASONING: ["ollama", "hf_local", "anthropic", "openai", "meta", "deepseek", "google", "qwen", "step"],
-    TaskType.FAST_RESPONSE: ["ollama", "hf_local", "deepseek", "mimo", "groq", "google", "openai", "zhipu"],
-    TaskType.CODING: ["ollama", "hf_local", "deepseek", "qwen", "anthropic", "openai", "meta", "step", "mimo"],
-    TaskType.CREATIVE: ["ollama", "hf_local", "openai", "anthropic", "mistral", "deepseek", "minimax"],
+    TaskType.REASONING: ["ollama", "anthropic", "openai", "meta", "deepseek", "google", "qwen", "step"],
+    TaskType.FAST_RESPONSE: ["ollama", "deepseek", "mimo", "agnes", "groq", "google", "openai", "zhipu", "moonshot"],
+    TaskType.CODING: ["ollama", "deepseek", "qwen", "anthropic", "openai", "meta", "step", "mimo", "moonshot"],
+    TaskType.CREATIVE: ["ollama", "openai", "anthropic", "mistral", "deepseek", "minimax"],
     TaskType.ANALYSIS: [
         "ollama",
-        "hf_local",
         "anthropic",
         "openai",
         "meta",
@@ -213,10 +218,10 @@ TASK_ROUTING_PREFERENCES: Dict[TaskType, List[str]] = {
         "perplexity",
         "qwen",
         "step",
+        "openrouter",
     ],
     TaskType.PLANNING: [
         "ollama",
-        "hf_local",
         "anthropic",
         "openai",
         "meta",
@@ -226,20 +231,22 @@ TASK_ROUTING_PREFERENCES: Dict[TaskType, List[str]] = {
         "minimax",
         "step",
     ],
-    TaskType.AGENT_CONTROL: ["ollama", "hf_local", "anthropic", "openai", "meta", "deepseek", "minimax", "step"],
+    TaskType.AGENT_CONTROL: ["ollama", "anthropic", "openai", "meta", "deepseek", "minimax", "step"],
     TaskType.GENERAL: [
         "ollama",
-        "hf_local",
         "openai",
         "anthropic",
         "meta",
         "deepseek",
+        "agnes",
         "google",
         "qwen",
         "zhipu",
         "minimax",
         "step",
         "mimo",
+        "moonshot",
+        "openrouter",
     ],
 }
 
@@ -255,6 +262,7 @@ TASK_ROUTING_PREFERENCES: Dict[TaskType, List[str]] = {
 OPEN_SOURCE_PROVIDERS: set = {
     "ollama",  # 本地原生多模态主脑（Gemma4 / MiniCPM-o）
     "hf_local",  # 本地 HuggingFace 模型
+    "agnes",  # Agnes AI（全模态免费 API，开放/免费档友好）
     "deepseek",  # DeepSeek（开源权重）
     "qwen",  # 通义千问（开源权重）
     "zhipu",  # 智谱 GLM（开源权重）
@@ -336,6 +344,8 @@ PROVIDER_QUALITY_TIER: Dict[str, int] = {
     "mimo": 2,
     "perplexity": 2,
     "oneapi": 2,
+    "agnes": 2,
+    "openrouter": 2,
     # tier 1 —— 本地轻量（无 GPU 笔电主脑）
     "ollama": 1,
     "hf_local": 1,
@@ -489,6 +499,16 @@ PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
         TaskType.CODING: "kimi-k2.6",
         TaskType.ANALYSIS: "kimi-k2.5",
         TaskType.FAST_RESPONSE: "kimi-k2.5",
+    },
+    "agnes": {
+        # 免费全模态,默认走 2.5-flash;直连路径据此解析出具体模型串。
+        TaskType.FAST_RESPONSE: "agnes-2.5-flash",
+        TaskType.GENERAL: "agnes-2.5-flash",
+    },
+    "openrouter": {
+        # 聚合器,"auto" 让 OpenRouter 自选底层模型。
+        TaskType.ANALYSIS: "openrouter/auto",
+        TaskType.GENERAL: "openrouter/auto",
     },
     "perplexity": {
         TaskType.REASONING: "sonar-deep-research",
@@ -1409,6 +1429,7 @@ ADAPTER_MAP = {
     "moonshot": OpenAIAdapter,
     "perplexity": OpenAIAdapter,
     "groq": OpenAIAdapter,
+    "openrouter": OpenAIAdapter,
     "ollama": OllamaAdapter,
     "hf_local": OpenAIAdapter,
 }
@@ -1597,6 +1618,20 @@ PROVIDER_REGISTRY: List[Dict[str, Any]] = [
         "default_model": "llama-3.3-70b-versatile",
         "cost_in": 0.00059,
         "cost_out": 0.00079,
+        "extra": {"supports_tools": True},
+    },
+    {
+        # OpenRouter:OpenAI 兼容的聚合器,"openrouter/auto" 让其自选底层模型。
+        # cost 0 为占位——真实成本随所选底层模型浮动,由计费层回填。
+        "name": "openrouter",
+        "env_key": "OPENROUTER_API_KEY",
+        "base_url": "https://openrouter.ai/api/v1",
+        "models": ["openrouter/auto"],
+        "default_model": "openrouter/auto",
+        "cost_in": 0.0,
+        "cost_out": 0.0,
+        # extra 会被 **unpack 进 ProviderConfig,只能用其合法字段;聚合器语义用
+        # source_type="api" 即可(无 aggregator 字段,误用会让整个路由器构造崩溃)。
         "extra": {"supports_tools": True},
     },
 ]

--- a/core/unified/llm_router.py
+++ b/core/unified/llm_router.py
@@ -1026,56 +1026,77 @@ class UnifiedLLMRouter:
             task_type_str,
             preferred_provider=effective_provider,
         )
-        # 取策略层最优先 provider；若无策略顺序（空列表或 None）则使用 effective_provider。
-        # `_provider_order[0]` is safe here because we only access index 0 when the list is
-        # non-empty (truthy), which is guaranteed by the `if _provider_order` guard.
-        _effective_provider = _provider_order[0] if _provider_order else effective_provider
+        # 【故障转移修复】此前只取 _provider_order[0] 强制成单一 provider,导致执行层
+        # route() 返回它时 alternatives 为空、无从兜底 —— 工具路径中途失败即降级。
+        # 现改为【沿策略顺序逐个尝试】:某候选抛异常或软降级(provider=="none")就换
+        # 下一个,首个真成功即返回。强制 model 只对首选生效;换 provider 时让其自选默认
+        # 模型(原 model 名对新 provider 无意义)。
+        _candidates: List[Optional[str]] = (
+            list(_provider_order) if _provider_order else ([effective_provider] if effective_provider else [None])
+        )
 
-        start = time.monotonic()
-        try:
-            # 执行层（MultiLLMRouter）负责 provider 内部故障转移（auto_failover 默认 True）
-            result = await self._backend.chat(
-                messages=enriched_messages,
-                task_type=task_type_str,
-                provider=_effective_provider,
-                model=model,
-                tools=tools,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                **kwargs,
-            )
-            latency_ms = (time.monotonic() - start) * 1000
-            _actual_provider = getattr(result, "provider", _effective_provider or "unknown")
-            is_fallback = bool(_effective_provider and _actual_provider != _effective_provider)
-            self._telemetry.record(
-                provider=_actual_provider,
-                success=True,
-                latency_ms=latency_ms,
-                is_fallback=is_fallback,
-            )
-            logger.info(
-                "chat_with_tools completed",
-                extra={
-                    "event": "chat_with_tools_done",
-                    "task_type": task_type_str,
-                    "preferred_provider": _effective_provider,
-                    "actual_provider": _actual_provider,
-                    "model": getattr(result, "model", "unknown"),
-                    "latency_ms": round(latency_ms, 2),
-                    "is_fallback": is_fallback,
-                    "has_tools": bool(tools),
-                },
-            )
-            return result
-        except Exception as exc:
-            logger.debug("Fallback triggered: %s", exc)
-            latency_ms = (time.monotonic() - start) * 1000
-            self._telemetry.record(
-                _effective_provider or "unknown",
-                success=False,
-                latency_ms=latency_ms,
-            )
-            raise
+        def _is_soft_failure(res: Any) -> bool:
+            if res is None:
+                return True
+            p = getattr(res, "provider", None)
+            return p is None or str(p).lower() in ("none", "")
+
+        last_result: Any = None
+        last_exc: Optional[Exception] = None
+        for _idx, _cand in enumerate(_candidates):
+            start = time.monotonic()
+            try:
+                result = await self._backend.chat(
+                    messages=enriched_messages,
+                    task_type=task_type_str,
+                    provider=_cand,
+                    model=model if _idx == 0 else None,
+                    tools=tools,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    **kwargs,
+                )
+                latency_ms = (time.monotonic() - start) * 1000
+                if _is_soft_failure(result):
+                    # 软降级:该候选没答出来,记失败并换下一个。
+                    last_result = result
+                    self._telemetry.record(_cand or "unknown", success=False, latency_ms=latency_ms)
+                    logger.debug("chat_with_tools 候选 %s 软降级,换下一个", _cand)
+                    continue
+                _actual_provider = getattr(result, "provider", _cand or "unknown")
+                is_fallback = _idx > 0 or bool(_cand and _actual_provider != _cand)
+                self._telemetry.record(
+                    provider=_actual_provider,
+                    success=True,
+                    latency_ms=latency_ms,
+                    is_fallback=is_fallback,
+                )
+                logger.info(
+                    "chat_with_tools completed",
+                    extra={
+                        "event": "chat_with_tools_done",
+                        "task_type": task_type_str,
+                        "preferred_provider": _cand,
+                        "actual_provider": _actual_provider,
+                        "model": getattr(result, "model", "unknown"),
+                        "latency_ms": round(latency_ms, 2),
+                        "is_fallback": is_fallback,
+                        "has_tools": bool(tools),
+                    },
+                )
+                return result
+            except Exception as exc:  # noqa: BLE001
+                latency_ms = (time.monotonic() - start) * 1000
+                last_exc = exc
+                self._telemetry.record(_cand or "unknown", success=False, latency_ms=latency_ms)
+                logger.debug("chat_with_tools 候选 %s 失败,换下一个: %s", _cand, exc)
+                continue
+
+        # 所有候选都没答出来:契约统一 —— 有软降级结果就返回它(与 MultiLLMRouter.chat
+        # 的软返回一致,不抛给上层),否则(纯异常无软结果)才抛。
+        if last_result is not None:
+            return last_result
+        raise last_exc if last_exc is not None else NoAvailableProviderError(task_type=task_type)
 
     def compute_complexity_vector(
         self,

--- a/galaxy_gateway/android/handlers/registration.py
+++ b/galaxy_gateway/android/handlers/registration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import uuid
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -665,6 +666,25 @@ def _evaluate_ingress_authentication(message: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _should_gate_unapproved(auth_outcome: Dict[str, Any]) -> bool:
+    """设备准入闸决策:是否应把【未批准】设备降级为 control_only。
+
+    仅当环境开关 GALAXY_REQUIRE_DEVICE_APPROVAL 打开、且设备【未批准】时返回 True。
+    默认关 → 恒 False → 注册行为与现状逐字节一致(opt-in)。
+
+    "已批准" == auth_outcome["token_valid"]:core.auth.verify_api_token 已【优先】校验
+    每设备 token(core/device_token_registry),故设备持有效每设备 token 时 token_valid
+    即 True——即便处于默认开放模式;配对批准发放的正是这种 token,天然闭环。
+    """
+    require = os.environ.get("GALAXY_REQUIRE_DEVICE_APPROVAL", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    return require and not bool(auth_outcome.get("token_valid"))
+
+
 def _evaluate_ingress_identity(
     *,
     message_device_id: str,
@@ -788,6 +808,9 @@ async def handle_device_register(
     device_id = message.get("device_id")
     websocket_device_id = str(message.get("_ingress_connection_device_id") or "").strip() or None
     auth_outcome = _evaluate_ingress_authentication(message)
+    # 设备准入闸(opt-in,默认关 → 行为与现状逐字节一致)。开启后:未批准的设备
+    # 仍可连接,但被降为 control_only(永不作为派发目标),批准后可原地升级。
+    _gate_unapproved = _should_gate_unapproved(auth_outcome)
     identity_outcome = _evaluate_ingress_identity(
         message_device_id=str(device_id or ""),
         websocket_device_id=websocket_device_id,
@@ -865,6 +888,16 @@ async def handle_device_register(
         _inbound_runtime_posture = str(_raw_runtime_posture or "").strip().lower()
         if _inbound_runtime_posture not in {"join_runtime", "control_only"}:
             _inbound_runtime_posture = "join_runtime"
+        # 准入闸(承重改动):未批准且开关开启 → 降为 control_only。posture 是唯一的
+        # 杠杆——它级联卡住三处:附着运行时会话、参与档(封顶 control_only)、以及
+        # delegated 派发硬闸(select_delegated_target 判 bad_posture)。设备仍完全连接,
+        # 只是永不作为派发目标;批准后 reconnect/capability 事件把 posture 升回 join_runtime。
+        if _gate_unapproved and _inbound_runtime_posture == "join_runtime":
+            logger.info(
+                "设备准入闸:device_id=%s 未批准,降为 control_only(仅连接,非派发目标)",
+                device_id,
+            )
+            _inbound_runtime_posture = "control_only"
         if inbound_durable_session_id:
             logger.debug(
                 "handle_device_register: durable continuity fields present: "
@@ -1103,19 +1136,24 @@ async def handle_device_register(
 
         # PR-I: notify the auto-enrollment service so that MeshMembership and
         # Formation auto-enrollment are triggered as part of the registration chain.
-        try:
-            from core.mesh.mesh_auto_enrollment import notify_device_registered
-            notify_device_registered(
-                device_id,
-                roles=_roles,
-                session_id=inbound_attachment_id,
-                metadata={"registration_trigger": "android_device_register"},
-            )
-        except Exception as _ae_exc:
-            logger.debug(
-                "android_bridge: auto_enrollment notify non-fatal: device_id=%s error=%s",
-                device_id, _ae_exc,
-            )
+        # 准入闸:未批准且开关开启时【不】把设备登记进 mesh/formation 成员表(保持
+        # 干净)。这只是清理——真正的派发拦截由上面的 control_only posture 承担。
+        if _gate_unapproved:
+            logger.debug("设备准入闸:device_id=%s 未批准,跳过 mesh 自动登记", device_id)
+        else:
+            try:
+                from core.mesh.mesh_auto_enrollment import notify_device_registered
+                notify_device_registered(
+                    device_id,
+                    roles=_roles,
+                    session_id=inbound_attachment_id,
+                    metadata={"registration_trigger": "android_device_register"},
+                )
+            except Exception as _ae_exc:
+                logger.debug(
+                    "android_bridge: auto_enrollment notify non-fatal: device_id=%s error=%s",
+                    device_id, _ae_exc,
+                )
 
         logger.info(
             "Android device registered: device_id=%s model=%s platform=%s "

--- a/galaxy_gateway/android_bridge.py
+++ b/galaxy_gateway/android_bridge.py
@@ -1327,15 +1327,29 @@ class AndroidBridge:
                 await device.websocket.send_json(message)
 
             if wait_response:
-                message_id = message.get("message_id") or message.get("task_id")
                 future = asyncio.get_running_loop().create_future()
-                self._pending_responses[message_id] = future
+                # 双键登记:设备回包可能只带 message_id 或只带 task_id(结果处理器多按
+                # task_id 解析),此前只按 `message_id or task_id` 单键登记 → 若消息同时
+                # 带二者、设备只回 task_id,future 永远等不到、白白超时。现在两个 id 都
+                # 指向同一个 future,任一命中即可解析,消除"设备回了却超时"。
+                keys = [k for k in (message.get("message_id"), message.get("task_id")) if k]
+                if not keys:
+                    keys = [None]  # 无任何 id:保持旧行为(登记单个 None 键)
+                for k in keys:
+                    self._pending_responses[k] = future
+
+                # future 完成(被任一键解析 / 取消 / 超时)时,清掉它名下所有键,避免残留。
+                def _cleanup(_f: "asyncio.Future", _keys: tuple = tuple(keys)) -> None:
+                    for _k in _keys:
+                        if self._pending_responses.get(_k) is future:
+                            self._pending_responses.pop(_k, None)
+
+                future.add_done_callback(_cleanup)
 
                 try:
                     return await asyncio.wait_for(future, timeout=timeout)
                 except asyncio.TimeoutError:
-                    self._pending_responses.pop(message_id, None)
-                    logger.warning("Response timeout for message: %s", message_id)
+                    logger.warning("Response timeout for message keys: %s", keys)
                     return None
 
             return {"success": True}

--- a/galaxy_gateway/api/config.py
+++ b/galaxy_gateway/api/config.py
@@ -195,6 +195,36 @@ def _build_feature_flags() -> Dict[str, bool]:
     }
 
 
+def _build_discovery() -> Dict[str, Any]:
+    """发现与配对提示,让客户端【从服务端拿】而非编译期硬编码。
+
+    - mDNS 服务类型:局域网零配置发现(网关 mdns_announcer 广播 _galaxy._tcp)。
+    - Tailscale:跨设备可选网络层;网关的 tailnet 地址由客户端【自己】查本机
+      tailscale/MagicDNS 得到,这里【不】per-request shell 出去(避免阻塞/延迟)。
+    - 配对流程路径:新设备据此走 enroll → status → claim(去硬编码 IP/流程)。
+    """
+    try:
+        import zeroconf  # noqa: F401
+
+        mdns_available = True
+    except Exception:  # noqa: BLE001
+        mdns_available = False
+    return {
+        "mdns_service": "_galaxy._tcp",
+        "mdns_enabled": mdns_available,
+        "tailscale": {
+            "recommended_for_cross_device": True,
+            "network_layer": "tailscale",  # 跨设备模式的网络底座(选填,设置里开启)
+            "magicdns_hint": "客户端连接稳定 MagicDNS 名而非硬编码 IP",
+        },
+        "pairing": {
+            "enroll_path": "/api/v1/pairing/enroll",
+            "status_path": "/api/v1/pairing/status/{request_id}",
+            "claim_path": "/api/v1/pairing/claim/{request_id}",
+        },
+    }
+
+
 def build_client_config() -> Dict[str, Any]:
     """
     Assemble the full client configuration dictionary.
@@ -220,6 +250,7 @@ def build_client_config() -> Dict[str, Any]:
         "turn_servers": _build_turn_servers(),
         "transport_priority": _build_transport_priority(),
         "feature_flags": _build_feature_flags(),
+        "discovery": _build_discovery(),
     }
 
 

--- a/galaxy_gateway/api/pairing.py
+++ b/galaxy_gateway/api/pairing.py
@@ -1,0 +1,107 @@
+"""
+galaxy_gateway/api/pairing.py — 设备配对/发放 REST 端点(P3-1 阶段二)
+=====================================================================
+
+把 core.device_enrollment 的协调器暴露成一组 REST 端点。信任边界:
+
+- **设备侧(无凭证,开放)**:``/enroll`` 提交入伙请求、``/status`` 查状态、
+  ``/claim`` 领 token —— 新设备此时还没有任何凭证,这些必须开放;request_id 是
+  uuid4(不可猜),充当"领取自己 token"的一次性能力凭据。
+- **信任侧(你在已信任设备上操作,require_auth)**:``/code`` 生成配对码、
+  ``/pending`` 看待批准、``/approve`` / ``/deny`` 终裁 —— 这些是"别处批准"的动作,
+  应由已鉴权的可信面完成。鉴权当前默认关(与全系统现状一致);随 P3-1 推进到
+  auth-on 后,批准方用自己的每设备 token。
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from core.auth import require_auth
+from core.device_enrollment import get_enrollment_coordinator
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/pairing", tags=["device-pairing"])
+
+
+class EnrollBody(BaseModel):
+    device_id: str
+    device_type: Optional[str] = None
+    name: Optional[str] = None
+    fingerprint: Optional[Dict[str, Any]] = None
+    pairing_code: Optional[str] = None
+
+
+class DecisionBody(BaseModel):
+    request_id: str
+    reason: Optional[str] = None
+
+
+# ── 信任侧(require_auth) ────────────────────────────────────────────────
+@router.post("/code")
+async def create_pairing_code(_auth: dict = Depends(require_auth)) -> Dict[str, Any]:
+    """桌面生成一个短时效配对码(可展示为二维码/文本)。"""
+    return get_enrollment_coordinator().create_pairing_code()
+
+
+@router.get("/pending")
+async def list_pending(_auth: dict = Depends(require_auth)) -> Dict[str, Any]:
+    """列出待你终裁的入伙请求(供批准界面)。不含任何 token。"""
+    return {"pending": get_enrollment_coordinator().pending()}
+
+
+@router.post("/approve")
+async def approve(body: DecisionBody, _auth: dict = Depends(require_auth)) -> Dict[str, Any]:
+    """批准(HITL 终裁):发放该设备专属 token。token 不在此返回,由设备 /claim 领取。"""
+    tok = get_enrollment_coordinator().approve(body.request_id)
+    if tok is None:
+        return {"ok": False, "error": "request not pending or not found"}
+    return {"ok": True, "request_id": body.request_id, "status": "approved"}
+
+
+@router.post("/deny")
+async def deny(body: DecisionBody, _auth: dict = Depends(require_auth)) -> Dict[str, Any]:
+    ok = get_enrollment_coordinator().deny(body.request_id, reason=body.reason)
+    return {"ok": ok, "request_id": body.request_id, "status": "denied" if ok else "not_pending"}
+
+
+# ── 设备侧(开放:新设备尚无凭证) ─────────────────────────────────────────
+@router.post("/enroll")
+async def enroll(body: EnrollBody) -> Dict[str, Any]:
+    """新设备提交入伙请求。返回 request_id;设备随后轮询 /status,批准后 /claim 领 token。"""
+    try:
+        req = get_enrollment_coordinator().submit_enrollment(
+            body.device_id,
+            device_type=body.device_type,
+            name=body.name,
+            fingerprint=body.fingerprint,
+            pairing_code=body.pairing_code,
+        )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    return {
+        "ok": True,
+        "request_id": req.request_id,
+        "status": req.status,
+        "code_verified": req.code_verified,
+    }
+
+
+@router.get("/status/{request_id}")
+async def status(request_id: str) -> Dict[str, Any]:
+    view = get_enrollment_coordinator().get(request_id)
+    if view is None:
+        return {"ok": False, "error": "unknown request_id"}
+    return {"ok": True, **view}
+
+
+@router.post("/claim/{request_id}")
+async def claim(request_id: str) -> Dict[str, Any]:
+    """设备领取自己的 token(仅批准后、且一次性)。request_id 即一次性能力凭据。"""
+    tok = get_enrollment_coordinator().claim(request_id)
+    if tok is None:
+        return {"ok": False, "error": "not approved or already claimed"}
+    return {"ok": True, "token": tok}

--- a/galaxy_gateway/api/pairing.py
+++ b/galaxy_gateway/api/pairing.py
@@ -81,7 +81,10 @@ async def enroll(body: EnrollBody) -> Dict[str, Any]:
             pairing_code=body.pairing_code,
         )
     except ValueError as exc:
-        return {"ok": False, "error": str(exc)}
+        # 不把异常文本回给未鉴权的设备端(CodeQL:信息泄漏)——详情落日志,
+        # 对外只给静态、无堆栈的校验提示。
+        logger.warning("enroll rejected (invalid request): %s", exc)
+        return {"ok": False, "error": "invalid enrollment request (device_id required)"}
     return {
         "ok": True,
         "request_id": req.request_id,

--- a/galaxy_gateway/app.py
+++ b/galaxy_gateway/app.py
@@ -171,6 +171,13 @@ try:
 except Exception as _cfg_err:
     logger.warning("Client config route mount skipped: %s", _cfg_err)
 
+try:
+    from .api.pairing import router as _pairing_router
+    app.include_router(_pairing_router)
+    logger.info("Device pairing routes mounted: /api/v1/pairing/*")
+except Exception as _pair_err:
+    logger.warning("Device pairing routes mount skipped: %s", _pair_err)
+
 
 # ============================================================================
 # Main entry point

--- a/galaxy_gateway/mdns_announcer.py
+++ b/galaxy_gateway/mdns_announcer.py
@@ -9,7 +9,7 @@ the same Wi-Fi network. Falls back to Tailscale for off-LAN use.
 
 Usage:
     from galaxy_gateway.mdns_announcer import MdnsAnnouncer
-    announcer = MdnsAnnouncer(port=8765)
+    announcer = MdnsAnnouncer(port=9000)  # 与统一网关端口一致
     announcer.start()   # non-blocking
     ...
     announcer.stop()
@@ -56,7 +56,7 @@ class MdnsAnnouncer:
     SERVICE_TYPE = "_galaxy._tcp.local."
     SERVICE_NAME = "Galaxy Gateway"
 
-    def __init__(self, port: int = 8765, gateway_token: str = ""):
+    def __init__(self, port: int = 9000, gateway_token: str = ""):
         self.port = port
         self.gateway_token = gateway_token
         self._zc: Optional[Any] = None

--- a/galaxy_gateway/mdns_announcer.py
+++ b/galaxy_gateway/mdns_announcer.py
@@ -26,8 +26,9 @@ _zeroconf = None
 _Zeroconf = None
 _ServiceInfo = None
 
+
 def _ensure_zeroconf():
-    global _zeroconf, _Zeroconf, _ServiceInfo
+    global _Zeroconf, _ServiceInfo  # _zeroconf 从不在本函数赋值,不列(F824)
     if _Zeroconf is not None:
         return True
     try:
@@ -119,7 +120,7 @@ class MdnsAnnouncer:
                 addresses=[socket.inet_aton(ip)],
                 port=self.port,
                 properties=desc,
-                server=f"galaxy-gateway.local.",
+                server="galaxy-gateway.local.",
             )
             self._zc = _Zeroconf()
             self._zc.register_service(self._info)

--- a/tests/test_cross_device_response_dual_key.py
+++ b/tests/test_cross_device_response_dual_key.py
@@ -1,0 +1,77 @@
+"""跨设备回包关联回归:send_to_device 的 future 必须双键(message_id + task_id)登记。
+
+此前只按 `message_id or task_id` 单键登记 future,而结果处理器多按 task_id 解析
+(task_lifecycle.py:968/1073/1203/1263)。若一条派发消息同时带 message_id 与 task_id、
+设备只回 task_id,future 永远等不到 → "设备回了却超时"。本测试锁死:两个 id 都指向
+同一 future,按 task_id 解析即可完成等待,且完成后两个键都被清理。
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from galaxy_gateway.android_bridge import AndroidBridge
+
+
+class _FakeWS:
+    async def send_json(self, msg):  # noqa: ANN001
+        return None
+
+
+def _bridge_with_device(dev_id="dev1"):
+    b = AndroidBridge.__new__(AndroidBridge)
+    b._lock = asyncio.Lock()
+    b._devices = {dev_id: SimpleNamespace(connected=True, websocket=_FakeWS())}
+    b._pending_responses = {}
+    return b
+
+
+@pytest.mark.asyncio
+async def test_future_registered_under_both_ids_and_resolves_by_task_id(monkeypatch):
+    # 强制 AIPTransport 抛错 → 走 websocket.send_json 兜底路径(与真机同)。
+    import core.aip_transport as _t
+
+    monkeypatch.setattr(_t, "get_aip_transport", lambda: (_ for _ in ()).throw(RuntimeError("no transport")))
+
+    b = _bridge_with_device()
+    msg = {"type": "task_assign", "device_id": "dev1", "message_id": "mid-1", "task_id": "tid-1"}
+
+    task = asyncio.create_task(b.send_to_device("dev1", msg, wait_response=True, timeout=3))
+    # 让 send_to_device 跑到登记 future
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if "tid-1" in b._pending_responses:
+            break
+
+    # 双键都登记,且指向同一个 future
+    assert "mid-1" in b._pending_responses, "message_id 未登记"
+    assert "tid-1" in b._pending_responses, "task_id 未登记"
+    assert b._pending_responses["mid-1"] is b._pending_responses["tid-1"]
+
+    # 结果处理器按 task_id 解析(此前会 miss 掉 message_id 键的 future)
+    b._pending_responses["tid-1"].set_result({"ok": True, "via": "task_id"})
+
+    out = await asyncio.wait_for(task, timeout=3)
+    assert out == {"ok": True, "via": "task_id"}, "按 task_id 解析应成功返回"
+
+    # 完成后 done-callback 清掉两个键,无残留
+    await asyncio.sleep(0.02)
+    assert "mid-1" not in b._pending_responses
+    assert "tid-1" not in b._pending_responses
+
+
+@pytest.mark.asyncio
+async def test_timeout_cleans_up_both_keys(monkeypatch):
+    import core.aip_transport as _t
+
+    monkeypatch.setattr(_t, "get_aip_transport", lambda: (_ for _ in ()).throw(RuntimeError("no transport")))
+
+    b = _bridge_with_device()
+    msg = {"type": "task_assign", "device_id": "dev1", "message_id": "mid-2", "task_id": "tid-2"}
+
+    out = await b.send_to_device("dev1", msg, wait_response=True, timeout=0.1)
+    assert out is None, "超时应返回 None"
+    # 超时后两个键都不残留
+    assert "mid-2" not in b._pending_responses
+    assert "tid-2" not in b._pending_responses

--- a/tests/test_device_approval_gate.py
+++ b/tests/test_device_approval_gate.py
@@ -1,0 +1,43 @@
+"""设备准入闸(P3-1 阶段二收尾)决策回归。
+
+锁死 opt-in 语义:GALAXY_REQUIRE_DEVICE_APPROVAL 默认关 → 恒不拦(注册行为与现状
+逐字节一致);开启后只拦【未批准】设备(token_valid=False)降为 control_only,
+已批准(持有效每设备 token → token_valid=True)放行。
+
+注:handle_device_register 整条链路依赖 UDM/mesh/session 等重组件,无法纯单测;
+此处直击安全相关的【决策】助手 _should_gate_unapproved(承重的 posture 降级即由它驱动)。
+"""
+
+import pytest
+
+from galaxy_gateway.android.handlers.registration import _should_gate_unapproved
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("GALAXY_REQUIRE_DEVICE_APPROVAL", raising=False)
+    yield
+
+
+def test_default_off_never_gates(monkeypatch):
+    monkeypatch.delenv("GALAXY_REQUIRE_DEVICE_APPROVAL", raising=False)
+    # 默认关:无论批准与否都不拦 → 现状行为
+    assert _should_gate_unapproved({"token_valid": False}) is False
+    assert _should_gate_unapproved({"token_valid": True}) is False
+    assert _should_gate_unapproved({}) is False
+
+
+@pytest.mark.parametrize("flag", ["1", "true", "yes", "on", "TRUE", "On"])
+def test_on_gates_only_unapproved(monkeypatch, flag):
+    monkeypatch.setenv("GALAXY_REQUIRE_DEVICE_APPROVAL", flag)
+    # 未批准 → 拦(降 control_only)
+    assert _should_gate_unapproved({"token_valid": False}) is True
+    assert _should_gate_unapproved({}) is True
+    # 已批准(持有效每设备 token)→ 放行
+    assert _should_gate_unapproved({"token_valid": True}) is False
+
+
+@pytest.mark.parametrize("flag", ["0", "false", "no", "off", ""])
+def test_falsey_flag_values_off(monkeypatch, flag):
+    monkeypatch.setenv("GALAXY_REQUIRE_DEVICE_APPROVAL", flag)
+    assert _should_gate_unapproved({"token_valid": False}) is False

--- a/tests/test_device_enrollment.py
+++ b/tests/test_device_enrollment.py
@@ -1,0 +1,106 @@
+"""设备入伙协调器(配对/发放 + 智能体准入)回归测试。
+
+锁死:请求→pending→批准发 token→设备 claim 一次;拒绝;TTL 过期;配对码一次性 +
+增强信任信号;策略钩子(智能体预判)只建议不绑定;终裁前 token 不存在。
+"""
+
+import time
+
+from core.device_enrollment import (
+    CLAIMED,
+    DENIED,
+    EXPIRED,
+    PENDING,
+    DeviceEnrollmentCoordinator,
+)
+from core.device_token_registry import DeviceTokenRegistry
+
+
+def _coord(tmp_path, **kw):
+    reg = DeviceTokenRegistry(store_path=tmp_path / "device_tokens.json")
+    return DeviceEnrollmentCoordinator(registry=reg, **kw), reg
+
+
+def test_submit_then_approve_then_claim(tmp_path):
+    c, reg = _coord(tmp_path)
+    req = c.submit_enrollment("dev-1", device_type="android", name="小米17")
+    assert req.status == PENDING
+    # pending 列表能看到,且不含 token
+    p = c.pending()
+    assert len(p) == 1 and p[0]["device_id"] == "dev-1"
+    assert "token" not in p[0] and "_token" not in p[0]
+
+    # 批准 → 发 token
+    tok = c.approve(req.request_id)
+    assert tok, "批准应发放明文 token"
+    # 这个 token 在注册表里能校验通过(闭环)
+    assert reg.verify(tok) is not None
+    # 设备 claim 一次
+    claimed = c.claim(req.request_id)
+    assert claimed == tok
+    # 第二次 claim 拿不到(一次性)
+    assert c.claim(req.request_id) is None
+    assert c.get(req.request_id)["status"] == CLAIMED
+
+
+def test_deny(tmp_path):
+    c, reg = _coord(tmp_path)
+    req = c.submit_enrollment("dev-1")
+    assert c.deny(req.request_id, reason="不认识这台") is True
+    assert c.get(req.request_id)["status"] == DENIED
+    assert c.approve(req.request_id) is None, "已拒绝不能再批准"
+    assert c.claim(req.request_id) is None
+
+
+def test_token_absent_before_approval(tmp_path):
+    c, reg = _coord(tmp_path)
+    req = c.submit_enrollment("dev-1")
+    assert c.claim(req.request_id) is None, "未批准前不得有 token"
+
+
+def test_pairing_code_one_time_and_trust_signal(tmp_path):
+    c, reg = _coord(tmp_path)
+    code = c.create_pairing_code()["code"]
+    req = c.submit_enrollment("dev-1", pairing_code=code)
+    assert req.code_verified is True, "有效配对码应标记增强信任"
+    # 码是一次性的:再用同一个码提交,code_verified=False
+    req2 = c.submit_enrollment("dev-2", pairing_code=code)
+    assert req2.code_verified is False
+
+
+def test_bad_or_missing_code_does_not_block(tmp_path):
+    c, reg = _coord(tmp_path)
+    req = c.submit_enrollment("dev-1", pairing_code="ZZZZZZ")
+    assert req.status == PENDING and req.code_verified is False, "无效码不阻断,只是不加信任"
+
+
+def test_policy_suggests_but_not_binding(tmp_path):
+    # 智能体预判:有配对码就建议 approve
+    def policy(req):
+        return "approve" if req.code_verified else "deny"
+
+    c, reg = _coord(tmp_path, policy=policy)
+    code = c.create_pairing_code()["code"]
+    req = c.submit_enrollment("dev-1", pairing_code=code)
+    assert req.suggested_verdict == "approve"
+    # 但仍是 pending(建议非绑定,须显式终裁)
+    assert req.status == PENDING
+    req2 = c.submit_enrollment("dev-2")  # 无码
+    assert req2.suggested_verdict == "deny" and req2.status == PENDING
+
+
+def test_request_ttl_expiry(tmp_path):
+    c, reg = _coord(tmp_path, request_ttl=0.05)
+    req = c.submit_enrollment("dev-1")
+    time.sleep(0.08)
+    # 触发过期扫描
+    assert c.get(req.request_id)["status"] == EXPIRED
+    assert c.approve(req.request_id) is None, "过期请求不能批准"
+
+
+def test_pairing_code_ttl(tmp_path):
+    c, reg = _coord(tmp_path, code_ttl=0.05)
+    code = c.create_pairing_code()["code"]
+    time.sleep(0.08)
+    req = c.submit_enrollment("dev-1", pairing_code=code)
+    assert req.code_verified is False, "过期配对码不加信任"

--- a/tests/test_device_token_registry.py
+++ b/tests/test_device_token_registry.py
@@ -1,0 +1,95 @@
+"""每设备 token 注册表 + auth 集成的回归测试。
+
+锁死配对发放凭证底座的关键不变量:发放→校验通过、按设备吊销、只存摘要不存明文、
+落盘可跨"重启"(重建实例)复活、以及 core.auth.verify_api_token 会接受每设备 token。
+"""
+
+import json
+
+import pytest
+
+from core.device_token_registry import DeviceTokenRegistry, _hash_token
+
+
+def _reg(tmp_path):
+    return DeviceTokenRegistry(store_path=tmp_path / "device_tokens.json")
+
+
+def test_issue_then_verify(tmp_path):
+    r = _reg(tmp_path)
+    tok = r.issue("dev-1", device_type="android", name="小米17")
+    assert isinstance(tok, str) and len(tok) >= 20
+    rec = r.verify(tok)
+    assert rec is not None
+    assert rec["device_id"] == "dev-1"
+    assert rec["device_type"] == "android"
+    assert rec["last_seen"] is not None  # 校验命中刷新 last_seen
+
+
+def test_wrong_token_rejected(tmp_path):
+    r = _reg(tmp_path)
+    r.issue("dev-1")
+    assert r.verify("not-a-real-token") is None
+    assert r.verify("") is None
+
+
+def test_revoke_by_device(tmp_path):
+    r = _reg(tmp_path)
+    tok = r.issue("dev-1")
+    assert r.verify(tok) is not None
+    n = r.revoke_device("dev-1")
+    assert n == 1
+    assert r.verify(tok) is None, "吊销后必须拒绝"
+    # 其它设备不受影响
+    tok2 = r.issue("dev-2")
+    assert r.verify(tok2) is not None
+
+
+def test_only_hash_persisted_never_plaintext(tmp_path):
+    p = tmp_path / "device_tokens.json"
+    r = DeviceTokenRegistry(store_path=p)
+    tok = r.issue("dev-1", name="phone")
+    raw = p.read_text(encoding="utf-8")
+    assert tok not in raw, "明文 token 绝不能落盘!"
+    data = json.loads(raw)
+    assert data["tokens"][0]["token_sha256"] == _hash_token(tok)
+    # 元数据在,明文不在
+    assert data["tokens"][0]["device_id"] == "dev-1"
+
+
+def test_survives_restart(tmp_path):
+    p = tmp_path / "device_tokens.json"
+    tok = DeviceTokenRegistry(store_path=p).issue("dev-1")
+    # 模拟进程重启:用同一文件重建实例
+    r2 = DeviceTokenRegistry(store_path=p)
+    assert r2.verify(tok) is not None, "落盘应跨重启复活(env token 无持久化正是被修的洞)"
+
+
+def test_list_devices_has_no_secrets(tmp_path):
+    r = _reg(tmp_path)
+    r.issue("dev-1", device_type="wearos", name="watch")
+    lst = r.list_devices()
+    assert len(lst) == 1
+    row = lst[0]
+    assert row["device_id"] == "dev-1" and row["device_type"] == "wearos"
+    assert "token_sha256" not in row and "token" not in row, "枚举不得含任何凭证"
+
+
+def test_auth_verify_api_token_accepts_device_token(tmp_path, monkeypatch):
+    """core.auth.verify_api_token 应接受每设备 token(经单例注册表)。"""
+    import core.auth as auth
+    import core.device_token_registry as dtr
+
+    # 把注册表单例指到临时存储,避免碰到真实 ~/.galaxy
+    reg = DeviceTokenRegistry(store_path=tmp_path / "device_tokens.json")
+    monkeypatch.setattr(dtr, "_registry", reg)
+
+    tok = reg.issue("dev-1", device_type="android")
+    # 没有配任何 env 共享 token 时,每设备 token 也应通过
+    monkeypatch.delenv("GALAXY_API_TOKEN", raising=False)
+    monkeypatch.delenv("GALAXY_API_TOKENS", raising=False)
+    assert auth.verify_api_token(tok) is True
+
+    # 吊销后应被拒
+    reg.revoke_device("dev-1")
+    assert auth.verify_api_token(tok) is False

--- a/tests/test_llm_router_provider_wiring.py
+++ b/tests/test_llm_router_provider_wiring.py
@@ -1,0 +1,77 @@
+"""tests/test_llm_router_provider_wiring.py
+==============================================
+Provider-wiring regression guards for the "honest cloud fallback" change
+(2026-07-15).
+
+Covers four properties that were silently broken/incomplete before:
+
+  1. OpenRouter (OpenAI-compatible aggregator) is a real, fully-wired provider:
+     present in the env-key map, the adapter map, and the declarative
+     PROVIDER_REGISTRY (with an openrouter.ai base_url).
+  2. agnes / moonshot / openrouter are actually reachable by auto-routing —
+     i.e. each appears in at least one TASK_ROUTING_PREFERENCES list (they were
+     registered but absent from every preference list, so never auto-selected).
+  3. "hf_local" no longer pollutes the preference lists — its internal adapter
+     was never implemented, so it could never register, yet it sat 2nd in every
+     list. It must appear in NO TASK_ROUTING_PREFERENCES list.
+  4. The YAML routing policy is local-first: every task_routing priority list
+     starts with "ollama".
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+from core.multi_llm_router import (
+    _PROVIDER_ENV_KEY_MAP,
+    ADAPTER_MAP,
+    PROVIDER_REGISTRY,
+    TASK_ROUTING_PREFERENCES,
+)
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_POLICY_PATH = _REPO_ROOT / "config" / "llm_routing_policy.yaml"
+
+
+# ── 1. OpenRouter is a real, fully-wired provider ────────────────────────────
+def test_openrouter_in_env_key_map():
+    assert _PROVIDER_ENV_KEY_MAP.get("openrouter") == "OPENROUTER_API_KEY"
+
+
+def test_openrouter_in_adapter_map():
+    assert "openrouter" in ADAPTER_MAP
+
+
+def test_openrouter_registered_with_base_url():
+    entries = [e for e in PROVIDER_REGISTRY if e.get("name") == "openrouter"]
+    assert len(entries) == 1, "openrouter must have exactly one registry entry"
+    assert "openrouter.ai" in entries[0]["base_url"]
+
+
+# ── 2. agnes / moonshot / openrouter are reachable by auto-routing ───────────
+def test_new_providers_appear_in_some_preference_list():
+    all_prefs = {p for prefs in TASK_ROUTING_PREFERENCES.values() for p in prefs}
+    for provider in ("agnes", "moonshot", "openrouter"):
+        assert provider in all_prefs, f"{provider} unreachable by auto-routing"
+
+
+# ── 3. hf_local removed from all preference lists ────────────────────────────
+def test_hf_local_absent_from_all_preference_lists():
+    for task_type, prefs in TASK_ROUTING_PREFERENCES.items():
+        assert "hf_local" not in prefs, f"hf_local still in {task_type} preferences"
+
+
+# ── 4. YAML routing policy is local-first ────────────────────────────────────
+def test_yaml_task_routing_is_local_first():
+    with _POLICY_PATH.open("r", encoding="utf-8") as fh:
+        policy = yaml.safe_load(fh)
+
+    task_routing = policy["task_routing"]
+    assert task_routing, "task_routing section must not be empty"
+
+    for task_name, spec in task_routing.items():
+        priorities = spec["priorities"]
+        assert priorities, f"{task_name} priorities must not be empty"
+        assert priorities[0] == "ollama", f"{task_name} must be local-first (ollama at index 0)"

--- a/tests/test_llm_tools_failover.py
+++ b/tests/test_llm_tools_failover.py
@@ -1,0 +1,107 @@
+"""工具路径故障转移回归:chat_with_tools 必须沿策略顺序逐个兜底。
+
+此前 chat_with_tools 只取 provider_order[0] 强制成单一 provider,执行层 route()
+返回它时 alternatives 为空 → 中途失败无从兜底(用户干活时云端抽风即降级)。
+本测试锁死:首选软降级/抛异常时会换下一个候选;全失败时返回软结果而非抛。
+"""
+
+import pytest
+
+from core.unified.llm_router import UnifiedLLMRouter
+
+
+class _Resp:
+    def __init__(self, provider, content="ok", model="m"):
+        self.provider = provider
+        self.content = content
+        self.model = model
+        self.tool_calls = None
+
+
+class _FakeTelemetry:
+    def __init__(self):
+        self.calls = []
+
+    def record(self, *a, **k):
+        self.calls.append((a, k))
+
+
+def _router(backend_chat):
+    """构造一个只挂了必要桩的 UnifiedLLMRouter,避开 __init__ 的后端加载/网络探测。"""
+    r = UnifiedLLMRouter.__new__(UnifiedLLMRouter)
+
+    class _B:
+        async def chat(self, **kwargs):
+            return await backend_chat(**kwargs)
+
+    r._backend = _B()
+    r._telemetry = _FakeTelemetry()
+    # 桩掉 L1/L2/L3 与策略顺序,让候选就是 [p1, p2]
+    r._enrich_l3_context = lambda messages, task_type, tools: messages
+    r._consult_l1_route = lambda t, p: (None, None, None, None)
+    r._consult_l2_supply = lambda d: (None, None, False)
+    r._get_provider_order = lambda *a, **k: (["p1", "p2"], None)
+    return r
+
+
+@pytest.mark.asyncio
+async def test_failover_advances_on_soft_none():
+    """p1 软降级(provider='none')→ 自动换 p2 并成功。"""
+    seen = []
+
+    async def backend_chat(**kw):
+        p = kw["provider"]
+        seen.append(p)
+        if p == "p1":
+            return _Resp("none")  # 软降级
+        return _Resp("p2")
+
+    r = _router(backend_chat)
+    out = await r.chat_with_tools([{"role": "user", "content": "干活"}], tools=[{"x": 1}])
+    assert out.provider == "p2", "首选软降级后应兜底到 p2"
+    assert seen == ["p1", "p2"], "应按策略顺序逐个尝试"
+
+
+@pytest.mark.asyncio
+async def test_failover_advances_on_exception():
+    """p1 抛异常 → 换 p2 成功。"""
+    seen = []
+
+    async def backend_chat(**kw):
+        p = kw["provider"]
+        seen.append(p)
+        if p == "p1":
+            raise RuntimeError("p1 boom")
+        return _Resp("p2")
+
+    r = _router(backend_chat)
+    out = await r.chat_with_tools([{"role": "user", "content": "干活"}], tools=[{"x": 1}])
+    assert out.provider == "p2"
+    assert seen == ["p1", "p2"]
+
+
+@pytest.mark.asyncio
+async def test_all_fail_returns_soft_not_raise():
+    """全部软降级 → 返回软结果(契约统一),不抛给上层。"""
+
+    async def backend_chat(**kw):
+        return _Resp("none")
+
+    r = _router(backend_chat)
+    out = await r.chat_with_tools([{"role": "user", "content": "干活"}], tools=[{"x": 1}])
+    assert out is not None and str(out.provider).lower() == "none"
+
+
+@pytest.mark.asyncio
+async def test_first_success_short_circuits():
+    """首选就成功 → 不再尝试后续候选。"""
+    seen = []
+
+    async def backend_chat(**kw):
+        seen.append(kw["provider"])
+        return _Resp("p1")
+
+    r = _router(backend_chat)
+    out = await r.chat_with_tools([{"role": "user", "content": "hi"}], tools=[{"x": 1}])
+    assert out.provider == "p1"
+    assert seen == ["p1"], "首选成功不应再打后续候选"

--- a/tests/test_p3_discovery_and_wearos.py
+++ b/tests/test_p3_discovery_and_wearos.py
@@ -1,0 +1,35 @@
+"""P3 回归:wearos 设备类型解析 + /api/v1/config 发现信息。
+
+锁死:手表实发的 "wearos" 不再掉进 CUSTOM(归 ANDROID,与 android_wear 一致);
+config 端点吐出 mDNS/Tailscale/配对路径,让客户端【从服务端拿】而非硬编码。
+"""
+
+from core.device_types import DeviceType, resolve_device_type
+
+
+def test_wearos_resolves_to_android_not_custom():
+    assert resolve_device_type("wearos") == DeviceType.ANDROID
+    assert resolve_device_type("wear_os") == DeviceType.ANDROID
+    assert resolve_device_type("wear") == DeviceType.ANDROID
+    # 与规范 AIP 值一致
+    assert resolve_device_type("android_wear") == DeviceType.ANDROID
+
+
+def test_alias_does_not_break_known_types():
+    assert resolve_device_type("android_phone") == DeviceType.ANDROID
+    assert resolve_device_type("windows") == DeviceType.WINDOWS
+    assert resolve_device_type("linux_server") == DeviceType.LINUX
+    assert resolve_device_type("totally-unknown-xyz") == DeviceType.CUSTOM
+
+
+def test_client_config_exposes_discovery():
+    from galaxy_gateway.api.config import build_client_config
+
+    cfg = build_client_config()
+    disc = cfg["discovery"]
+    assert disc["mdns_service"] == "_galaxy._tcp"
+    assert "mdns_enabled" in disc
+    assert disc["tailscale"]["network_layer"] == "tailscale"
+    # 配对流程路径可被客户端直接使用(去硬编码)
+    assert disc["pairing"]["enroll_path"] == "/api/v1/pairing/enroll"
+    assert "{request_id}" in disc["pairing"]["claim_path"]

--- a/tests/test_pairing_endpoints.py
+++ b/tests/test_pairing_endpoints.py
@@ -1,0 +1,77 @@
+"""配对 REST 端点端到端回归:enroll → pending → approve → claim 全链路。
+
+用一个独立 FastAPI app 只挂 pairing 路由 + 临时存储的协调器单例,避免碰真实
+~/.galaxy 与整个网关 app 的重依赖。
+"""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    # 把协调器单例指到临时存储(注册表也随之在临时目录)
+    import core.device_enrollment as de
+    from core.device_enrollment import DeviceEnrollmentCoordinator
+    from core.device_token_registry import DeviceTokenRegistry
+
+    reg = DeviceTokenRegistry(store_path=tmp_path / "device_tokens.json")
+    monkeypatch.setattr(de, "_coordinator", DeviceEnrollmentCoordinator(registry=reg))
+
+    from galaxy_gateway.api.pairing import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_enroll_pending_approve_claim(client):
+    # 设备侧:提交入伙请求(开放,无需鉴权)
+    r = client.post("/api/v1/pairing/enroll", json={"device_id": "dev-1", "device_type": "android", "name": "小米17"})
+    assert r.status_code == 200 and r.json()["ok"] is True
+    rid = r.json()["request_id"]
+
+    # 信任侧:待批准列表(鉴权默认关 → 开放;返回不含 token)
+    r = client.get("/api/v1/pairing/pending")
+    assert r.status_code == 200
+    pend = r.json()["pending"]
+    assert any(x["device_id"] == "dev-1" for x in pend)
+    assert all("token" not in x for x in pend)
+
+    # 设备侧:批准前 claim 拿不到
+    r = client.post(f"/api/v1/pairing/claim/{rid}")
+    assert r.json()["ok"] is False
+
+    # 信任侧:批准(token 不在此返回)
+    r = client.post("/api/v1/pairing/approve", json={"request_id": rid})
+    assert r.status_code == 200 and r.json()["ok"] is True
+    assert "token" not in r.json()
+
+    # 设备侧:claim 领 token(一次性)
+    r = client.post(f"/api/v1/pairing/claim/{rid}")
+    assert r.json()["ok"] is True
+    tok = r.json()["token"]
+    assert isinstance(tok, str) and len(tok) >= 20
+    # 第二次 claim 拿不到
+    assert client.post(f"/api/v1/pairing/claim/{rid}").json()["ok"] is False
+
+    # 领到的 token 在协调器所用的注册表里可校验通过(闭环)——不改任何全局单例,
+    # 避免污染其它测试(auth.verify_api_token 走单例的路径已由
+    # tests/test_device_token_registry.py 覆盖)。
+    import core.device_enrollment as de
+
+    assert de._coordinator._registry.verify(tok) is not None
+
+
+def test_deny_blocks_claim(client):
+    rid = client.post("/api/v1/pairing/enroll", json={"device_id": "dev-x"}).json()["request_id"]
+    assert client.post("/api/v1/pairing/deny", json={"request_id": rid, "reason": "不认识"}).json()["ok"] is True
+    assert client.post(f"/api/v1/pairing/claim/{rid}").json()["ok"] is False
+    assert client.get(f"/api/v1/pairing/status/{rid}").json()["status"] == "denied"
+
+
+def test_status_unknown(client):
+    assert client.get("/api/v1/pairing/status/nope").json()["ok"] is False


### PR DESCRIPTION
V2 后端多项改进 + 设备配对/发放系统的**完整后端脊梁**。全部低风险、可单测、逐条比对 baseline 零回归(每次改动都 stash 对比过干净 main)。

## 一、可靠性修复
- **LLM 云端兜底**(360afab):工具路径故障转移 + OpenRouter 真接入 + agnes/moonshot 自动路由 + hf_local 清理 + YAML 本地优先 + 错误契约统一。
- **跨设备回包关联**(974a7be):`send_to_device` future 双键(message_id+task_id)登记,消除"设备回了却超时"。

## 二、设备配对系统(P3-1 后端,去账号 · 别处批准 · 智能体准入)
- **每设备 token 注册表**(e098614):可单独吊销、只存 sha256 摘要、原子落盘跨重启复活。填"只有共享 env token、无发放路径"的洞。
- **入伙协调器 + REST 端点**(114fd48 + 安全修复 12604f5):新设备零输入 → 请求 → 智能体预判(非绑定)→ 你 HITL 终裁 → 发专属 token → 设备一次性 claim。端点信任边界分明(设备侧开放 / 批准侧 require_auth)。CodeQL 信息泄漏已修。
- **发现/去硬编码 + bug**(b2766c2):`/api/v1/config` 吐 mDNS/Tailscale/配对路径;`wearos→CUSTOM` 解析 bug 修;mDNS 端口对齐 9000。
- **设备准入闸**(e99e411):`GALAXY_REQUIRE_DEVICE_APPROVAL`(默认关,opt-in)开启后未批准设备降为 `control_only`——posture 这根杠杆级联卡住派发资格(附着会话/参与档/delegated 硬闸),设备仍连着、批准后原地升级。已批准==持有效每设备 token,天然闭环。
- **质量自审**(f76dcb1):token 校验去掉每次落盘 + O(1) 查;清 mdns 存量 flake8。

## 验证
- 新增 **约 45 个测试全绿**(token 注册表/协调器/端点/发现/wearos/准入闸)
- 全量 `test` 门:57 failed == 改动前 baseline,**零新增**;`flake8 core/` = 0;改动均最小外科式

## P3-1 剩余(需真机,本机无 Android SDK)
- P4〔安卓/手表〕:Tailscale authkey 自入网搬进 app + 去账号配对 UI + 设置 Tailscale 开关与健康检查 + 清 release 硬编码 `galaxy.ufo.ai`/证书锁定
- P5:BLE 两端 UUID 统一(广播端建设归"设备扩展")
- 清理项:capability_report.py 第二条 enrollment 触发镜像准入闸(仅成员表观测富化,非派发安全必需)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b