### PR TITLE
fix: bug 复核批次 —— 补 AgentFactory.create_agent（/split 端点 500）

### DIFF
--- a/core/agent_factory.py
+++ b/core/agent_factory.py
@@ -437,6 +437,41 @@ class AgentFactory:
             logger.warning("Agent 状态加载失败，以全新状态启动: %s", _load_err)
         logger.info("AgentFactory 已初始化")
 
+    async def create_agent(
+        self,
+        name: Optional[str] = None,
+        task: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        **kwargs,
+    ) -> "TaskAgent":
+        """便捷统一创建入口：给定任务(可选名字/父 Agent)创建一个 Agent。
+
+        有 LLM Router → 动态生成(create_from_llm)；否则按任务匹配模板兜底(create_from_template)。
+        修复：routes/ai.py 的 /api/v1/agents/{id}/split 端点此前调用了不存在的
+        create_agent()，一走就 AttributeError→500；本方法补上该缺失入口。
+        """
+        task_desc = task or name or "generic task"
+        agent = None
+        if self.llm_router:
+            try:
+                agent = await self.create_from_llm(task_desc, parent_id=parent_id)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("create_agent: LLM 生成失败，回退模板兜底：%s", e)
+                agent = None
+        if agent is None:
+            template = self._match_template(task_desc)
+            overrides = {"name": name} if name else None
+            agent = self.create_from_template(template, parent_id=parent_id, overrides=overrides)
+        # 指定了 name 但生成路径未套用时补写（尽力而为，不因命名失败而中断创建）。
+        if name:
+            cfg = getattr(agent, "config", None)
+            if cfg is not None and getattr(cfg, "name", None) != name:
+                try:
+                    cfg.name = name
+                except Exception:
+                    pass
+        return agent
+
     # ─────── 模式 1: 模板创建 ─────────
 
     def create_from_template(


### PR DESCRIPTION
## 背景

对之前 BUG_REPORT 的问题逐个**在当前 main 上复核**（main 已比报告时前进 58+ 提交，多数已被后续提交修好）。本 PR 修复复核中确认**仍存在**的真 bug。

## 复核结果

| 原报告 bug | 当前 main 状态 |
|---|---|
| 重连 replay 不送达 / 结果缺 payload | ✅ 已修（回归测试现 2 passed） |
| android 跨设备回环丢 attachment id | ✅ 已修（e2e 23 passed） |
| `/ws/master` 死代码 | ✅ 已修（已注释拆除「幻影门」） |
| pydantic 老式 Config 弃用 | ✅ 已修（改 ConfigDict） |
| **AgentFactory.create_agent 缺失** | 🔴 **仍存在 → 本 PR 修** |

## 本次修复

`routes/ai.py` 的 `POST /api/v1/agents/{id}/split` 为每个子任务调 `factory.create_agent(name=, task=, parent_id=)`，但 `AgentFactory` 从无此方法 → `AttributeError` 被通用 `except` 折成 500，「手动分裂 Agent」端点整个不可用。

新增 `AgentFactory.create_agent()` 统一便捷入口：有 LLM Router → `create_from_llm` 动态生成；否则按任务 `_match_template` 模板兜底；支持 name/parent_id。

## 验证

本地实测 `create_agent(name, task, parent_id)` → 返回 `TaskAgent`、名字/父正确、已注册进工厂；`/split` 链不再 500。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_