### PR TITLE
加固(配对):批准后领取窗口设 TTL —— 一次性能力凭据不再永久可领

### DIFF
--- a/core/device_enrollment.py
+++ b/core/device_enrollment.py
@@ -234,11 +234,7 @@ class DeviceEnrollmentCoordinator:
                     r.decided_at = now
                 # 批准但迟迟未领:超过领取窗口即作废,并清掉暂存明文 token(防止
                 # 一次性能力凭据永久可领;不吊销注册表记录,以免误伤该设备其它有效 token)。
-                elif (
-                    r.status == APPROVED
-                    and r.decided_at is not None
-                    and (now - r.decided_at) > self._claim_ttl
-                ):
+                elif r.status == APPROVED and r.decided_at is not None and (now - r.decided_at) > self._claim_ttl:
                     r.status = EXPIRED
                     r._token = None
 

--- a/core/device_enrollment.py
+++ b/core/device_enrollment.py
@@ -92,11 +92,15 @@ class DeviceEnrollmentCoordinator:
         *,
         code_ttl: float = 300.0,
         request_ttl: float = 600.0,
+        claim_ttl: float = 300.0,
         policy: Optional[AdmissionPolicy] = None,
     ) -> None:
         self._registry = registry or get_device_token_registry()
         self._code_ttl = code_ttl
         self._request_ttl = request_ttl
+        # 批准后【领取窗口】:超过 claim_ttl 仍未 claim,则作废该请求并清掉暂存明文
+        # token——request_id 是"一次性、短时效"能力凭据,批准却无人领取不应永久可领。
+        self._claim_ttl = claim_ttl
         self._policy = policy
         self._lock = threading.RLock()
         self._codes: Dict[str, float] = {}  # code -> expiry_at(用完即删)
@@ -202,7 +206,12 @@ class DeviceEnrollmentCoordinator:
         return True
 
     def claim(self, request_id: str) -> Optional[str]:
-        """设备侧领取 token:仅当已批准且未领过,返回一次明文 token,随后清空转 CLAIMED。"""
+        """设备侧领取 token:仅当已批准且未领过,返回一次明文 token,随后清空转 CLAIMED。
+
+        领取前先跑一次过期清理:批准后超过 claim_ttl 未领的请求已被作废(EXPIRED),
+        这里就取不到 token —— 确保"过期领取窗口"在 claim 热路径上也权威生效。
+        """
+        self._expire_locked_free()
         with self._lock:
             r = self._requests.get(request_id)
             if r is None or r.status != APPROVED or r._token is None:
@@ -223,6 +232,15 @@ class DeviceEnrollmentCoordinator:
                 if r.status == PENDING and (now - r.created_at) > self._request_ttl:
                     r.status = EXPIRED
                     r.decided_at = now
+                # 批准但迟迟未领:超过领取窗口即作废,并清掉暂存明文 token(防止
+                # 一次性能力凭据永久可领;不吊销注册表记录,以免误伤该设备其它有效 token)。
+                elif (
+                    r.status == APPROVED
+                    and r.decided_at is not None
+                    and (now - r.decided_at) > self._claim_ttl
+                ):
+                    r.status = EXPIRED
+                    r._token = None
 
 
 # ── 进程级单例 ────────────────────────────────────────────────────────────

--- a/tests/test_device_enrollment.py
+++ b/tests/test_device_enrollment.py
@@ -98,6 +98,32 @@ def test_request_ttl_expiry(tmp_path):
     assert c.approve(req.request_id) is None, "过期请求不能批准"
 
 
+def test_approved_but_unclaimed_expires_claim_window(tmp_path):
+    """批准后迟迟不领:超过 claim_ttl 即作废,token 领不到、也不留暂存明文。
+
+    request_id 是"一次性、短时效"能力凭据;批准却无人领取不应永久可领。
+    """
+    c, reg = _coord(tmp_path, claim_ttl=0.05)
+    req = c.submit_enrollment("dev-late")
+    tok = c.approve(req.request_id)
+    assert tok, "批准应发放 token"
+    time.sleep(0.08)
+    # 过了领取窗口 → 请求作废,claim 拿不到
+    assert c.claim(req.request_id) is None, "过期领取窗口后不得再领"
+    assert c.get(req.request_id)["status"] == EXPIRED
+    # 暂存明文 token 已清(不残留在内存)
+    with c._lock:
+        assert c._requests[req.request_id]._token is None
+
+
+def test_claim_within_window_still_works(tmp_path):
+    """回归:领取窗口内 claim 正常(过期逻辑不误伤及时领取)。"""
+    c, reg = _coord(tmp_path, claim_ttl=5.0)
+    req = c.submit_enrollment("dev-prompt")
+    tok = c.approve(req.request_id)
+    assert c.claim(req.request_id) == tok, "窗口内应能正常领取"
+
+
 def test_pairing_code_ttl(tmp_path):
     c, reg = _coord(tmp_path, code_ttl=0.05)
     code = c.create_pairing_code()["code"]


### PR DESCRIPTION
## 背景

#1496(配对后端脊梁)合并后,应所有者"全部排查 再修复一遍"要求,把配对系统按真机验证清单(A 正常配对 / B 诚实兜底 / C 回归)整条链逐段审计。结论:**流程对三种场景都正确**,只发现一处实打实该收紧的点,本 PR 就修这一处。

## 修复:批准后领取窗口设 TTL

此前"批准但设备迟迟未 claim"的请求**永不过期** —— `request_id` 这个文档自称"一次性、短时效"的能力凭据会一直可领,暂存明文 token 也长驻内存。

- `DeviceEnrollmentCoordinator` 增 `claim_ttl`(默认 300s);`_expire_locked_free` 里把批准后超窗未领的请求转 `EXPIRED` 并清空暂存 `_token`;`claim()` 热路径先跑一次清理,使窗口权威生效。
- **不吊销注册表记录**:`revoke_device` 是按 `device_id` 全吊,会误伤该设备其它有效 token;只作废这一次领取凭据即可,安全且不误伤。

## 审计确认无需改(带证据)

- **A 正常**:`/api/v1/pairing/*` 已在 `galaxy_gateway/app.py` 挂载;`core/auth.py:verify_api_token` 已优先查 `device_token_registry`(配对发的 token → `token_valid=True`),`registration.py` 准入闸据此天然放行 → 闭环。
- **B 诚实**:deny/expired/claim 失败/超时,客户端都如实回原因,**无一伪装成功**。
- **C 回归**:准入闸 `GALAXY_REQUIRE_DEVICE_APPROVAL` 默认关 → 注册逐字节不变;配对入口是设置页独立按钮,不碰自动连接。

## 验证

- `pytest tests/test_device_token_registry.py tests/test_device_enrollment.py tests/test_pairing_endpoints.py tests/test_device_approval_gate.py -q` → **32 passed**(含新增 2 测:超窗领取被拒且明文已清 / 窗口内领取照常)。
- `flake8 core/device_enrollment.py` → 0。
- 存量红门(57 test baseline / File Complexity / Governance / ssot-udm / Capability)与本改动无关,核实后跳过。

## 关键文件
- `core/device_enrollment.py`(claim_ttl 加固)
- `tests/test_device_enrollment.py`(+2 测)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_