### PR TITLE
feat(latency): monotonic append-only JIT tool loading for CPU local models

### DIFF
--- a/core/context_trim.py
+++ b/core/context_trim.py
@@ -35,6 +35,25 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _core_markers() -> tuple:
+    """热核工具名标记(每轮几乎必用的元能力)。可用 GALAXY_TOOLS_CORE 覆盖
+    (逗号分隔的名字子串);留空则用内置默认。"""
+    raw = os.environ.get("GALAXY_TOOLS_CORE", "").strip()
+    if raw:
+        markers = tuple(m.strip() for m in raw.split(",") if m.strip())
+        if markers:
+            return markers
+    return _CORE_TOOL_MARKERS
+
+
+def _tool_name(t: Dict[str, Any]) -> str:
+    return str((t.get("function") or {}).get("name", ""))
+
+
+def _is_core(name: str, markers: tuple) -> bool:
+    return any(m in name for m in markers)
+
+
 # ---------------------------------------------------------------------------
 # 1. 工具结果插入截断
 # ---------------------------------------------------------------------------
@@ -111,11 +130,18 @@ def slim_tools(
     tools: List[Dict[str, Any]],
     query: str,
     max_tools: int = 0,
+    *,
+    session_unlocked: List[str] | None = None,
 ) -> List[Dict[str, Any]]:
     """工具数 ≤ 阈值时原样返回(零行为变化);超了才挑 top-K。
 
     GALAXY_TOOLS_SLIM=auto(默认)|off;阈值 GALAXY_TOOLS_MAX=24。
     核心工具(memory__/ask_human__)始终入选。
+
+    session_unlocked: 调用方按 session 持有的【已解锁工具名】列表。传入且
+      GALAXY_TOOLS_JIT=on 时,改走单调追加式 JIT(见 select_tools_jit)——
+      热核以外的工具默认不下发、按需逐轮解锁,专治首轮 56s 预填。默认不传 →
+      沿用下面的粘滞/相关性逻辑,零行为变化。
 
     选取策略(GALAXY_TOOLS_STICKY=auto(默认)|on|off):
     - 粘滞(本地主脑场景):按【静态优先级】挑——核心工具 + 目录原序
@@ -130,6 +156,13 @@ def slim_tools(
     mode = os.environ.get("GALAXY_TOOLS_SLIM", "auto").strip().lower()
     if mode in ("0", "off", "false", "no"):
         return tools
+
+    # ── 单调追加式 JIT(会话级前缀缓存友好，见 select_tools_jit)──────────
+    # 调用方传入本会话持有的 unlocked 列表且开关开启时走这条:不受下面 24 阈值
+    # 约束(热核以外的工具默认不下发,按需逐轮解锁)。默认关闭,零行为变化。
+    if session_unlocked is not None and _jit_enabled():
+        return select_tools_jit(tools, query, session_unlocked, max_tools=max_tools)
+
     limit = max_tools or _env_int("GALAXY_TOOLS_MAX", 24)
     if limit <= 0 or len(tools) <= limit:
         return tools
@@ -163,3 +196,93 @@ def slim_tools(
     picked = sorted(scored, key=lambda x: (-x[0], x[1]))[:limit]
     picked.sort(key=lambda x: x[1])  # 恢复原始相对顺序(前缀字节稳定)
     return [t for _, _, t in picked]
+
+
+# ---------------------------------------------------------------------------
+# 4. 单调追加式 JIT 工具加载(会话级前缀缓存友好)
+# ---------------------------------------------------------------------------
+
+
+def _jit_enabled() -> bool:
+    """GALAXY_TOOLS_JIT=on|1|true|yes 开启;默认关闭(零行为变化)。"""
+    return os.environ.get("GALAXY_TOOLS_JIT", "off").strip().lower() in ("1", "on", "true", "yes")
+
+
+def select_tools_jit(
+    tools: List[Dict[str, Any]],
+    query: str,
+    unlocked: List[str],
+    max_tools: int = 0,
+) -> List[Dict[str, Any]]:
+    """单调追加式 JIT 工具选择 —— 专治 CPU 本地模型的首轮预填。
+
+    与 slim_tools 的"每轮重挑"不同:本函数维护一个【只增不减】的已解锁集合
+    ``unlocked``(调用方按 session 持有并复用,函数原地 mutate 它)。每轮:
+
+      1. 热核工具(``_core_markers()``)始终入选 —— 每轮几乎必用的元能力;
+      2. 本轮 ``query`` 词法命中的非核心工具 → 追加进 ``unlocked``(去重、保序,
+         只在末尾追加、从不删除或重排);
+      3. 输出 = ``[热核(目录序)] + [unlocked(解锁序)]``,映射回当前 ``tools``。
+
+    因为 ``unlocked`` 单调增长,跨轮的提示词工具前缀也单调增长 → 只有"解锁到
+    新工具的那一轮"付一次局部重预填,其余轮次(不解锁新工具)全命中 Ollama 的
+    KV 前缀缓存 → 首轮从"全量 24 个 ≈3.2k token"降到"热核几百 token",同时不像
+    naive JIT 那样每轮砸缓存。
+
+    参数
+    ----
+    unlocked:
+        有序、可变的【工具名】列表(调用方按 session 持有)。原地更新:
+        追加本轮命中的新工具名;顺带剔除已从目录消失的名字(能力下线)。
+    max_tools:
+        已解锁工具的总量上限(含热核),默认 ``GALAXY_TOOLS_MAX``。达上限即
+        冻结,不再解锁新工具(宁可漏召回也不无界膨胀/砸缓存)。
+
+    返回选中的 ``tools`` 子列表,可直接下发给模型。
+    """
+    limit = max_tools or _env_int("GALAXY_TOOLS_MAX", 24)
+    markers = _core_markers()
+
+    # 目录:名字 → 工具(去重,保留首个出现顺序)
+    by_name: Dict[str, Dict[str, Any]] = {}
+    order: Dict[str, int] = {}
+    for i, t in enumerate(tools):
+        nm = _tool_name(t)
+        if nm and nm not in by_name:
+            by_name[nm] = t
+            order[nm] = i
+
+    core_names = [nm for nm in by_name if _is_core(nm, markers)]
+    core_set = set(core_names)
+
+    # 剔除已消失/已被归类为核心的陈旧解锁项(原地,保持其余项的相对顺序)
+    unlocked[:] = [nm for nm in unlocked if nm in by_name and nm not in core_set]
+    # 去重(防御:调用方若重复传入)——保序保留首次
+    if len(set(unlocked)) != len(unlocked):
+        _seen: set = set()
+        unlocked[:] = [nm for nm in unlocked if not (nm in _seen or _seen.add(nm))]
+
+    unlocked_budget = max(0, limit - len(core_names))
+    q_terms = _terms_of(query)
+    if q_terms and len(unlocked) < unlocked_budget:
+        already = set(unlocked)
+        candidates = []
+        for nm, t in by_name.items():
+            if nm in core_set or nm in already:
+                continue
+            fn = t.get("function") or {}
+            blob = _terms_of(f"{nm} {fn.get('description', '')}")
+            score = len(q_terms & blob)
+            if score > 0:
+                candidates.append((score, order[nm], nm))
+        # 命中分高者优先解锁;同分按目录原序(确定性,便于测试与复现)
+        candidates.sort(key=lambda x: (-x[0], x[1]))
+        for _, _, nm in candidates:
+            if len(unlocked) >= unlocked_budget:
+                break
+            unlocked.append(nm)
+
+    # 输出:热核(目录序)+ 已解锁(解锁序)——前缀单调、字节稳定
+    picked = [by_name[nm] for nm in by_name if nm in core_set]
+    picked += [by_name[nm] for nm in unlocked]
+    return picked

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -931,6 +931,10 @@ class OpenClawd:
     def __init__(self):
         self._initialized = False
         self._session_memory: Dict[str, List[Dict]] = {}
+        # 单调追加式 JIT 工具加载(GALAXY_TOOLS_JIT=on 时启用):按 session 持有
+        # 的【已解锁工具名】有序列表,只增不减 → 跨轮工具前缀单调增长、前缀缓存
+        # 友好。见 core.context_trim.select_tools_jit。
+        self._session_jit_tools: Dict[str, List[str]] = {}
         self._request_count = 0
         self._error_count = 0
         self._start_time = time.time()
@@ -8228,11 +8232,14 @@ class OpenClawd:
             # 延迟优化(auto 档):工具定义是 prompt 预填的大头(实测 22 个
             # ≈3.2k tokens)。数量在阈值(默认 24)内**原样不动**——质量优先;
             # 超了才按与本次请求的词法相关性挑 top-K,核心工具永不裁。
+            # GALAXY_TOOLS_JIT=on 时改走单调追加式 JIT:热核以外按需逐轮解锁,
+            # 用本 session 的 _session_jit_tools 累加集合保持前缀缓存友好。
             try:
                 from core.context_trim import slim_tools
 
                 _n_before = len(tools)
-                tools = slim_tools(tools, message)
+                _unlocked = self._session_jit_tools.setdefault(session_id, []) if session_id else None
+                tools = slim_tools(tools, message, session_unlocked=_unlocked)
                 if len(tools) != _n_before:
                     logger.info(
                         "工具定义瘦身: %d → %d(GALAXY_TOOLS_SLIM=off 可关闭)",
@@ -9001,6 +9008,7 @@ class OpenClawd:
     async def clear_session(self, session_id: str):
         """清除会话记忆"""
         self._session_memory.pop(session_id, None)
+        self._session_jit_tools.pop(session_id, None)
         try:
             from core.ai_intent import get_conversation_memory
 

--- a/core/routes/models.py
+++ b/core/routes/models.py
@@ -480,6 +480,8 @@ async def latency_probe() -> Dict[str, Any]:
                     f"预填速度 {prefill_tps:.0f} tok/s → 满配代理回合首字约 {est:.0f}s。"
                     "这就是'怎么都慢'的主因:每回合重发全部工具定义。已启用工具粘滞"
                     "(GALAXY_TOOLS_STICKY)让前缀缓存生效——同一会话第二回合起应显著变快;"
+                    "若连【首轮】也想砍,开 GALAXY_TOOLS_JIT=on:热核以外的工具按需逐轮解锁、"
+                    "只增不减,首轮仅下发几百 token 而非全量;"
                     "语音实时体验建议叠加云端 API(如 Agnes 免费档)。"
                 )
             else:

--- a/tests/test_latency_ollama_tools_indextts.py
+++ b/tests/test_latency_ollama_tools_indextts.py
@@ -324,6 +324,102 @@ class TestContextTrim:
         tools = self._mk_tools(50)
         assert slim_tools(tools, "q", max_tools=5) is tools
 
+    # ── 单调追加式 JIT 工具加载 ──────────────────────────────────────────
+    def _mk_jit_tools(self):
+        tools = self._mk_tools(20)
+        tools.append(
+            {"type": "function", "function": {"name": "node__fs__截图屏幕", "description": "截取当前屏幕画面"}}
+        )
+        tools.append(
+            {"type": "function", "function": {"name": "node__web__搜索网页", "description": "联网搜索网页内容"}}
+        )
+        tools.append({"type": "function", "function": {"name": "memory__recall", "description": "记忆召回"}})
+        return tools
+
+    def test_jit_disabled_by_default_uses_legacy_path(self, monkeypatch):
+        """不设 GALAXY_TOOLS_JIT → 即便传 session_unlocked 也走旧逻辑(零行为变化)。"""
+        from core.context_trim import slim_tools
+
+        monkeypatch.delenv("GALAXY_TOOLS_JIT", raising=False)
+        monkeypatch.setenv("GALAXY_TOOLS_SLIM", "auto")
+        tools = self._mk_tools(10)
+        unlocked = []
+        assert slim_tools(tools, "问问", max_tools=24, session_unlocked=unlocked) is tools
+        assert unlocked == []  # 未启用 → 不动累加集合
+
+    def test_jit_first_turn_only_core_plus_matched(self, monkeypatch):
+        """首轮:只下发热核 + 本轮命中的工具,而非全量 23 个。"""
+        from core.context_trim import select_tools_jit, slim_tools
+
+        monkeypatch.setenv("GALAXY_TOOLS_JIT", "on")
+        monkeypatch.setenv("GALAXY_TOOLS_SLIM", "auto")
+        tools = self._mk_jit_tools()
+        unlocked = []
+        out = slim_tools(tools, "帮我截图屏幕看看", max_tools=24, session_unlocked=unlocked)
+        names = [t["function"]["name"] for t in out]
+        assert "memory__recall" in names  # 热核始终在
+        assert "node__fs__截图屏幕" in names  # 本轮命中被解锁
+        assert "node__web__搜索网页" not in names  # 未命中不下发
+        assert len(out) < len(tools)  # 远小于全量
+        assert unlocked == ["node__fs__截图屏幕"]
+        # select_tools_jit 直接调用应与经 slim_tools 一致
+        assert [t["function"]["name"] for t in select_tools_jit(tools, "x", list(unlocked))] == names
+
+    def test_jit_is_monotonic_and_prefix_stable(self, monkeypatch):
+        """跨轮:解锁集合只增不减,且输出是逐轮前缀扩展(前缀缓存友好)。"""
+        from core.context_trim import select_tools_jit
+
+        markers = None  # 用默认热核
+        assert markers is None
+        tools = self._mk_jit_tools()
+        unlocked = []
+        # 轮1:截图
+        r1 = [t["function"]["name"] for t in select_tools_jit(tools, "截图屏幕", unlocked)]
+        # 轮2:与工具无关的闲聊 → 不解锁新工具,输出应与轮1完全一致
+        r2 = [t["function"]["name"] for t in select_tools_jit(tools, "你好呀今天天气不错", unlocked)]
+        assert r2 == r1
+        # 轮3:搜索网页 → 追加解锁,前缀应为 r1 的扩展
+        r3 = [t["function"]["name"] for t in select_tools_jit(tools, "搜索网页找资料", unlocked)]
+        assert r3[: len(r1)] == r1  # 前缀单调扩展,老工具位置不变
+        assert "node__web__搜索网页" in r3
+        assert unlocked == ["node__fs__截图屏幕", "node__web__搜索网页"]  # 只增
+
+    def test_jit_budget_freezes_unlocking(self, monkeypatch):
+        """达 max_tools 上限后冻结,不再解锁新工具(不无界膨胀/不砸缓存)。"""
+        from core.context_trim import select_tools_jit
+
+        tools = self._mk_jit_tools()
+        unlocked = []
+        # 上限 = 2:热核占 1(memory__recall)→ 非核心预算仅 1
+        select_tools_jit(tools, "截图屏幕", unlocked, max_tools=2)
+        assert unlocked == ["node__fs__截图屏幕"]
+        select_tools_jit(tools, "搜索网页", unlocked, max_tools=2)  # 预算已满
+        assert unlocked == ["node__fs__截图屏幕"]  # 冻结,未解锁 web
+
+    def test_jit_drops_vanished_tool(self, monkeypatch):
+        """已解锁工具从目录消失(能力下线)→ 自动剔除,不下发不存在的 schema。"""
+        from core.context_trim import select_tools_jit
+
+        tools = self._mk_jit_tools()
+        unlocked = []
+        select_tools_jit(tools, "截图屏幕 搜索网页", unlocked)
+        assert "node__web__搜索网页" in unlocked
+        # 下一轮 web 工具下线
+        tools2 = [t for t in tools if t["function"]["name"] != "node__web__搜索网页"]
+        out = [t["function"]["name"] for t in select_tools_jit(tools2, "闲聊", unlocked)]
+        assert "node__web__搜索网页" not in out
+        assert "node__web__搜索网页" not in unlocked  # 陈旧项被剔除
+
+    def test_jit_custom_core_markers(self, monkeypatch):
+        """GALAXY_TOOLS_CORE 覆盖热核标记。"""
+        from core.context_trim import select_tools_jit
+
+        monkeypatch.setenv("GALAXY_TOOLS_CORE", "node__00__,node__01__")
+        tools = self._mk_jit_tools()
+        out = [t["function"]["name"] for t in select_tools_jit(tools, "无关", [])]
+        assert "node__00__act0" in out and "node__01__act1" in out
+        assert "memory__recall" not in out  # 默认热核被覆盖掉了
+
 
 # ---------------------------------------------------------------------------
 # 4. IndexTTS 质量档


### PR DESCRIPTION
## Problem

On CPU local models the ~56s first-turn time-to-first-token is dominated by **prefilling all tool schemas** (~24 tools ≈ 3.2k tokens). `GALAXY_TOOLS_STICKY` only helps turn 2+ (a byte-stable prefix keeps Ollama's KV cache warm) — it does **nothing for the first turn**. And the naive fix (retrieve relevant tools per turn) would change the prefix every turn and *break* the cache.

## Approach — resolve the tension by growing the tool set monotonically

Expose only a small **hot core** up front, then **unlock** tools on demand and **never remove them**, so the prompt's tool prefix only ever extends at the tail:

- Turn 1 "截图屏幕看看" → sends `[memory__recall] + [screenshot]` (~2 tools / few hundred tokens) instead of all 22.
- Turn 2 chit-chat → **identical prefix** → full KV-cache hit, fast.
- Turn 3 needs a new tool → it's **appended**; everything before it stays cached, so only that turn pays a small partial re-prefill.

No extra model round-trip: matching is done server-side with the existing lexical `_terms_of()` — important because small local models (Gemma 2-3B) are unreliable at meta-reasoning ("I should search for a tool").

## Changes

- **`core/context_trim.py`** — new `select_tools_jit(tools, query, unlocked)`: hot-core always in; the turn's lexically-matched non-core tools append to a per-session `unlocked` list (dedup, order-preserving, stale-entry pruning, budget cap at `GALAXY_TOOLS_MAX`). `slim_tools()` gains an optional `session_unlocked` kwarg and delegates to the JIT path when `GALAXY_TOOLS_JIT=on`. Hot-core markers overridable via `GALAXY_TOOLS_CORE`.
- **`core/openclawd.py`** — per-session `_session_jit_tools` store, wired into the `handle_chat` tool-slimming call site, cleared in `clear_session`.
- **`core/routes/models.py`** — the local speed-test verdict now points users at `GALAXY_TOOLS_JIT` for cutting first-turn latency.
- **tests** — 6 new cases: default-off passthrough (zero behavior change), first-turn core+match only, cross-turn monotonicity + prefix stability, budget freeze, vanished-tool pruning, custom core markers.

## Safety / rollout

- **Default OFF** (`GALAXY_TOOLS_JIT=off`) — opt-in only, zero behavior change until enabled. Meant for the user to A/B measure on their machine.
- Honest tradeoff: JIT trades a bit of recall reliability (the model can't call a tool whose schema was never surfaced) for speed. The hot core + monotonic accumulation + `GALAXY_TOOLS_CORE` knob mitigate; sticky-full remains the default for max reliability.

## Env knobs

| Var | Default | Effect |
|-----|---------|--------|
| `GALAXY_TOOLS_JIT` | `off` | `on` → enable monotonic append-only JIT |
| `GALAXY_TOOLS_CORE` | `memory__,ask_human__` | comma-separated hot-core name markers |
| `GALAXY_TOOLS_MAX` | `24` | cap on total unlocked tools (freezes when hit) |

## Verification

`py_compile` + `flake8 --max-line-length=120` clean on all touched files; `TestContextTrim` 13/13 pass; end-to-end call-site simulation confirms turn-1 = 2/22 tools, turn-2 chit-chat = identical prefix, monotonic accumulator, `clear_session` cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_