### PR TITLE
复检修 6 个真 bug:配对后端(内存DoS/token绑定/TOCTOU) + 桌面语音(并发降级/中途卡住/误报)

### DIFF
--- a/core/device_enrollment.py
+++ b/core/device_enrollment.py
@@ -93,6 +93,8 @@ class DeviceEnrollmentCoordinator:
         code_ttl: float = 300.0,
         request_ttl: float = 600.0,
         claim_ttl: float = 300.0,
+        terminal_retention: float = 120.0,
+        max_requests: int = 4096,
         policy: Optional[AdmissionPolicy] = None,
     ) -> None:
         self._registry = registry or get_device_token_registry()
@@ -101,6 +103,11 @@ class DeviceEnrollmentCoordinator:
         # 批准后【领取窗口】:超过 claim_ttl 仍未 claim,则作废该请求并清掉暂存明文
         # token——request_id 是"一次性、短时效"能力凭据,批准却无人领取不应永久可领。
         self._claim_ttl = claim_ttl
+        # 终态(EXPIRED/DENIED/CLAIMED)保留窗口:留一小段供设备 /status 读到结果,过后清除,
+        # 避免 _requests 无限堆积(/enroll 无鉴权,否则是内存 DoS)。
+        self._terminal_retention = terminal_retention
+        # 硬上限(洪泛兜底):超过则按"终态优先、最旧优先"逐出,绝不无界增长。
+        self._max_requests = max_requests
         self._policy = policy
         self._lock = threading.RLock()
         self._codes: Dict[str, float] = {}  # code -> expiry_at(用完即删)
@@ -183,6 +190,7 @@ class DeviceEnrollmentCoordinator:
     # ── 终裁 ────────────────────────────────────────────────────────────
     def approve(self, request_id: str) -> Optional[str]:
         """批准(HITL 终裁):经注册表发放专属 token 并暂存,返回明文 token(供推回设备)。"""
+        self._expire_locked_free()  # 先扫过期:绝不批准一个已超 request_ttl 的陈旧请求(TOCTOU)
         with self._lock:
             r = self._requests.get(request_id)
             if r is None or r.status != PENDING:
@@ -195,6 +203,7 @@ class DeviceEnrollmentCoordinator:
         return token
 
     def deny(self, request_id: str, reason: Optional[str] = None) -> bool:
+        self._expire_locked_free()
         with self._lock:
             r = self._requests.get(request_id)
             if r is None or r.status != PENDING:
@@ -237,6 +246,21 @@ class DeviceEnrollmentCoordinator:
                 elif r.status == APPROVED and r.decided_at is not None and (now - r.decided_at) > self._claim_ttl:
                     r.status = EXPIRED
                     r._token = None
+            # 清除超过保留窗口的终态记录:防止 _requests 无限堆积(无鉴权 /enroll 的内存 DoS)。
+            _terminal = (EXPIRED, DENIED, CLAIMED)
+            for rid, r in list(self._requests.items()):
+                if r.status in _terminal:
+                    ref = r.decided_at if r.decided_at is not None else r.created_at
+                    if (now - ref) > self._terminal_retention:
+                        del self._requests[rid]
+            # 硬上限兜底(洪泛):超上限则逐出——终态优先、最旧优先。
+            if len(self._requests) > self._max_requests:
+                ordered = sorted(
+                    self._requests.items(),
+                    key=lambda kv: (kv[1].status == PENDING, kv[1].created_at),
+                )
+                for rid, _r in ordered[: len(self._requests) - self._max_requests]:
+                    del self._requests[rid]
 
 
 # ── 进程级单例 ────────────────────────────────────────────────────────────

--- a/core/routes/chat.py
+++ b/core/routes/chat.py
@@ -690,11 +690,19 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             # 播 → 把缓存补吐、其后 delta 直接逐字上屏(等价非锁步),文字绝不再憋成一大段。
             _ls_buf: list = []  # 已喂 TTS 但未露出的原始 delta(降级时补吐)
             _ls_first_t = None  # 首个 delta 时刻(判 TTS 是否真在播的宽限起点)
+            _ls_last_reveal_t = None  # 最近一次逐句露出的时刻(判中途卡住)
+            _ls_fed_chars = 0  # 累计喂入原始字符数(与 revealed_chars 比较判有无未露出)
             _ls_degraded = False  # 锁步已降级为逐字直出
             try:
                 _ls_grace = float(os.environ.get("GALAXY_LOCKSTEP_GRACE_S", "2.0") or "2.0")
             except (TypeError, ValueError):
                 _ls_grace = 2.0
+            try:
+                # 中途卡住的宽限(比首句宽限更长,免把"念一句长句"误判卡死;即便偶尔误判,
+                # 后果只是文字提前于语音、优雅不破)。
+                _ls_stall_grace = float(os.environ.get("GALAXY_LOCKSTEP_STALL_S", "8.0") or "8.0")
+            except (TypeError, ValueError):
+                _ls_stall_grace = 8.0
             try:
                 # 消费循环:增量帧即到即转;runtime 任务完成且队列排空后出循环。
                 while True:
@@ -712,6 +720,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                             # 锁步(未降级):喂 TTS + 缓存,暂不上屏;文字随语音逐句露出。
                             speaker.feed(payload)
                             _ls_buf.append(payload)
+                            _ls_fed_chars += len(payload)
                             if _ls_first_t is None:
                                 _ls_first_t = asyncio.get_running_loop().time()
                         else:
@@ -730,6 +739,8 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                             revealed_chars = 0
                             _ls_buf.clear()
                             _ls_first_t = None
+                            _ls_last_reveal_t = None
+                            _ls_fed_chars = 0
                         streamed_chars = 0
                         yield _sse({"type": "reset"})
                         if speaker is not None:
@@ -743,18 +754,32 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                                 yield _sse({"type": "phase", "phase": "manifest"})
                             revealed_chars += len(sent)
                             streamed_chars += len(sent)
+                            _ls_last_reveal_t = asyncio.get_running_loop().time()
                             yield _sse({"type": "delta", "text": sent})
-                        # 有界降级:首 delta 起宽限内【一句都没开口念】(revealed_chars==0)→
-                        # 判 TTS 没在播,把已缓存文字补吐、转逐字直出(其后 delta 走 else 分支,
-                        # 仍继续喂 speaker 让语音尽力跟随)。文字自此绝不再憋成一大段。
-                        if (
-                            not _ls_degraded
-                            and revealed_chars == 0
-                            and _ls_buf
-                            and _ls_first_t is not None
-                            and (asyncio.get_running_loop().time() - _ls_first_t) > _ls_grace
-                        ):
+                        # 有界降级:两种"TTS 没在推进"都转逐字直出,文字绝不再憋成一大段。
+                        #  ① 一句都没开口念(revealed_chars==0)→ 首句宽限 _ls_grace。
+                        #  ② 念了一部分后中途卡住(有未露出内容、且 _ls_stall_grace 内无新露出)。
+                        # 降级后其后 delta 走 else 分支直出,仍继续喂 speaker 让语音尽力跟随。
+                        _now = asyncio.get_running_loop().time()
+                        _idle_ref = _ls_last_reveal_t if _ls_last_reveal_t is not None else _ls_first_t
+                        _total_fail = (
+                            revealed_chars == 0 and _ls_first_t is not None and (_now - _ls_first_t) > _ls_grace
+                        )
+                        _mid_stall = (
+                            revealed_chars > 0
+                            and (_ls_fed_chars - revealed_chars) > 8
+                            and _idle_ref is not None
+                            and (_now - _idle_ref) > _ls_stall_grace
+                        )
+                        if not _ls_degraded and _ls_buf and (_total_fail or _mid_stall):
                             _ls_degraded = True
+                            if revealed_chars > 0:
+                                # 已露出过一部分:先 reset 前端文字(不动语音,让其继续尾随),
+                                # 再把【原始全量】补吐,规避与已露出内容重复(露出经 strip 归一,
+                                # 与原始 delta 不字字对齐,无法安全切片,故整段 reset 重放最稳)。
+                                yield _sse({"type": "reset"})
+                                revealed_chars = 0
+                                streamed_chars = 0
                             if not manifested:
                                 manifested = True
                                 yield _sse({"type": "phase", "phase": "manifest"})
@@ -764,8 +789,8 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                                 streamed_chars += len(_catchup)
                                 yield _sse({"type": "delta", "text": _catchup})
                             logger.info(
-                                "文字/语音锁步降级:%.1fs 内一句未念出,转逐字流式" "(TTS 疑不可用);语音继续尽力跟随。",
-                                _ls_grace,
+                                "文字/语音锁步降级(%s):转逐字流式,语音继续尽力跟随。",
+                                "一句未念出" if _total_fail else "中途卡住",
                             )
 
                 result = task.result()  # 异常在此抛出,统一走下面的 except

--- a/core/speech_output.py
+++ b/core/speech_output.py
@@ -204,6 +204,12 @@ def _note_engine_choice(eng: Any) -> None:
     不再"无声降级成机器人音、用户不知为何"(所有者反馈的"语音太僵")。"""
     global _tts_degraded_reason
     if eng is None:
+        # 整条链解析到 None = 所有引擎(含 SAPI)都不可用 = 完全无声。绝不能让
+        # get_tts_degraded_reason() 保持 None(那被定义为"自然音"),否则面板误报"正常"。
+        _tts_degraded_reason = (
+            "语音输出完全不可用:所有 TTS 引擎(edge/kokoro/melo/piper/SAPI)均不可用,"
+            "当前无声。装一个可用引擎(如 pip install edge-tts / kokoro-onnx)后重启。"
+        )
         return
     if type(eng).__name__ == "SapiTTSEngine":
         if _tts_degraded_reason is None:  # 一次性,避免刷屏
@@ -218,20 +224,29 @@ def _note_engine_choice(eng: Any) -> None:
         _tts_degraded_reason = None
 
 
-def demote_current_engine(reason: str = "") -> Optional[Any]:
-    """当前引擎【运行期】失败(合成/网络):拉黑其类型并重选下一个可用引擎。
+def demote_current_engine(reason: str = "", failed_engine: Any = None) -> Optional[Any]:
+    """某个引擎【运行期】失败(合成/网络):拉黑【确实失败的那个】并重选下一个可用引擎。
 
     返回新引擎(None=链上已无可用)。选择期探不出的失败(edge 构造成功但云端
     不可达)靠这里自愈:第一句失败 → 换引擎 → 同句重试,用户最多丢一拍。
+
+    failed_engine:调用方【实际失败的那个引擎实例】。并发朗读(chat 增量 + voice/ambient
+    整段)共用同一全局引擎缓存:若 A 路已把 edge 降级成健康的 kokoro,B 路(还握着旧
+    edge)再失败时【不能】按全局 _engine 去拉黑——那会误拉黑健康的 kokoro,一路拉到
+    SAPI/静默。故传入失败实例:它已不是现役引擎时,直接返回现役,绝不重复/误拉黑。
+    不传(旧调用/测试)则保持旧行为(按全局 _engine)。
     """
     global _engine, _engine_failed
-    cur = _engine
-    if cur is None:
-        return None
-    _failed_engine_types.add(type(cur).__name__)
+    target = failed_engine if failed_engine is not None else _engine
+    if target is None:
+        return _engine
+    # 并发保护:显式传了失败实例、而它已不是现役全局引擎 → 别人已降级过,返回现役健康引擎。
+    if failed_engine is not None and _engine is not None and target is not _engine:
+        return _engine
+    _failed_engine_types.add(type(target).__name__)
     logger.warning(
         "TTS 引擎 %s 运行期失败(%s),拉黑并降级到下一引擎",
-        type(cur).__name__,
+        type(target).__name__,
         (reason or "")[:120],
     )
     _engine = None
@@ -288,7 +303,7 @@ def speak_response(text: str, *, source: str = "") -> None:
                 try:
                     return await holder["engine"].synthesize(chunk)
                 except Exception as exc:  # noqa: BLE001
-                    new_engine = demote_current_engine(str(exc))
+                    new_engine = demote_current_engine(str(exc), failed_engine=holder["engine"])
                     if new_engine is None:
                         raise
                     holder["engine"] = new_engine
@@ -343,7 +358,7 @@ def speak_response(text: str, *, source: str = "") -> None:
         try:
             await engine.synthesize_and_play(spoken)
         except Exception as exc:  # noqa: BLE001
-            new_engine = demote_current_engine(str(exc))
+            new_engine = demote_current_engine(str(exc), failed_engine=engine)
             if new_engine is None:
                 _log_speak_failure("语音输出", exc)
             else:
@@ -411,7 +426,7 @@ def begin_incremental_speech(
         try:
             return await holder["engine"].synthesize(chunk)
         except Exception as exc:  # noqa: BLE001
-            new_engine = demote_current_engine(str(exc))
+            new_engine = demote_current_engine(str(exc), failed_engine=holder["engine"])
             if new_engine is None:
                 raise
             holder["engine"] = new_engine

--- a/galaxy_gateway/android/handlers/registration.py
+++ b/galaxy_gateway/android/handlers/registration.py
@@ -655,11 +655,30 @@ def _evaluate_ingress_authentication(message: Dict[str, Any]) -> Dict[str, Any]:
             state = "token_invalid_compat"
             reason = "Invalid token provided in compatibility mode"
 
+    # 设备准入绑定:每设备 token 必须【发放给本 device_id】才算"本设备已批准",否则一枚
+    # 泄露的 token 换个 device_id 就能冒充接入,击穿"别处批准 · 每设备"模型。共享/环境
+    # 管理员 token(非每设备)则按 token_valid 视为管理员放行。查询失败回退 token_valid,
+    # 不因注册表异常把所有设备锁死。
+    device_approved = token_valid
+    try:
+        from core.device_token_registry import verify_device_token
+
+        if token:
+            per_device_rec = verify_device_token(token)
+            if per_device_rec is not None:
+                msg_device_id = str(message.get("device_id") or "").strip()
+                device_approved = bool(msg_device_id) and per_device_rec.get("device_id") == msg_device_id
+            else:
+                device_approved = token_valid  # 环境/共享管理员 token(或无效→False)
+    except Exception:  # noqa: BLE001  注册表不可用不应把设备锁死
+        device_approved = token_valid
+
     return {
         "enforced": auth_enforced,
         "token_present": token_present,
         "token_source": token_source,
         "token_valid": token_valid,
+        "device_approved": device_approved,
         "active_token_count": active_token_count,
         "state": state,
         "reason": reason,
@@ -672,9 +691,10 @@ def _should_gate_unapproved(auth_outcome: Dict[str, Any]) -> bool:
     仅当环境开关 GALAXY_REQUIRE_DEVICE_APPROVAL 打开、且设备【未批准】时返回 True。
     默认关 → 恒 False → 注册行为与现状逐字节一致(opt-in)。
 
-    "已批准" == auth_outcome["token_valid"]:core.auth.verify_api_token 已【优先】校验
-    每设备 token(core/device_token_registry),故设备持有效每设备 token 时 token_valid
-    即 True——即便处于默认开放模式;配对批准发放的正是这种 token,天然闭环。
+    "已批准" == auth_outcome["device_approved"]:每设备 token 必须【发放给本 device_id】
+    才算本设备已批准(见 _evaluate_ingress_authentication 的绑定校验),否则一枚泄露 token
+    换个 device_id 就能冒充接入。共享/环境管理员 token 仍按 token_valid 放行。配对批准
+    发放的正是绑定本设备的 token,天然闭环。
     """
     require = os.environ.get("GALAXY_REQUIRE_DEVICE_APPROVAL", "").strip().lower() in (
         "1",
@@ -682,7 +702,7 @@ def _should_gate_unapproved(auth_outcome: Dict[str, Any]) -> bool:
         "yes",
         "on",
     )
-    return require and not bool(auth_outcome.get("token_valid"))
+    return require and not bool(auth_outcome.get("device_approved"))
 
 
 def _evaluate_ingress_identity(

--- a/tests/test_device_approval_gate.py
+++ b/tests/test_device_approval_gate.py
@@ -1,8 +1,12 @@
 """设备准入闸(P3-1 阶段二收尾)决策回归。
 
 锁死 opt-in 语义:GALAXY_REQUIRE_DEVICE_APPROVAL 默认关 → 恒不拦(注册行为与现状
-逐字节一致);开启后只拦【未批准】设备(token_valid=False)降为 control_only,
-已批准(持有效每设备 token → token_valid=True)放行。
+逐字节一致);开启后只拦【未批准】设备(device_approved=False)降为 control_only,
+已批准(每设备 token 绑定本 device_id → device_approved=True)放行。
+
+安全要点:approved 判据是 device_approved(token 须发放给本设备),不是裸 token_valid——
+一枚泄露的每设备 token 换个 device_id 呈递,token_valid 仍为 True,但 device_approved 为
+False,照样被拦。
 
 注:handle_device_register 整条链路依赖 UDM/mesh/session 等重组件,无法纯单测;
 此处直击安全相关的【决策】助手 _should_gate_unapproved(承重的 posture 降级即由它驱动)。
@@ -22,8 +26,8 @@ def _clean_env(monkeypatch):
 def test_default_off_never_gates(monkeypatch):
     monkeypatch.delenv("GALAXY_REQUIRE_DEVICE_APPROVAL", raising=False)
     # 默认关:无论批准与否都不拦 → 现状行为
-    assert _should_gate_unapproved({"token_valid": False}) is False
-    assert _should_gate_unapproved({"token_valid": True}) is False
+    assert _should_gate_unapproved({"device_approved": False}) is False
+    assert _should_gate_unapproved({"device_approved": True}) is False
     assert _should_gate_unapproved({}) is False
 
 
@@ -31,13 +35,40 @@ def test_default_off_never_gates(monkeypatch):
 def test_on_gates_only_unapproved(monkeypatch, flag):
     monkeypatch.setenv("GALAXY_REQUIRE_DEVICE_APPROVAL", flag)
     # 未批准 → 拦(降 control_only)
-    assert _should_gate_unapproved({"token_valid": False}) is True
+    assert _should_gate_unapproved({"device_approved": False}) is True
     assert _should_gate_unapproved({}) is True
-    # 已批准(持有效每设备 token)→ 放行
-    assert _should_gate_unapproved({"token_valid": True}) is False
+    # 安全:仅 token_valid 但未绑定本设备(device_approved 缺/False)→ 仍拦
+    assert _should_gate_unapproved({"token_valid": True, "device_approved": False}) is True
+    # 已批准(每设备 token 绑定本设备)→ 放行
+    assert _should_gate_unapproved({"device_approved": True}) is False
 
 
 @pytest.mark.parametrize("flag", ["0", "false", "no", "off", ""])
 def test_falsey_flag_values_off(monkeypatch, flag):
     monkeypatch.setenv("GALAXY_REQUIRE_DEVICE_APPROVAL", flag)
-    assert _should_gate_unapproved({"token_valid": False}) is False
+    assert _should_gate_unapproved({"device_approved": False}) is False
+
+
+def test_device_approved_binds_per_device_token_to_device_id(monkeypatch):
+    """安全核心:每设备 token 只在【发放给本 device_id】时算已批准;换个 device_id 冒充不算。"""
+    import core.auth as auth
+    import core.device_token_registry as dtr
+    from galaxy_gateway.android.handlers.registration import _evaluate_ingress_authentication
+
+    monkeypatch.setattr(auth, "is_auth_enabled", lambda: False)
+    monkeypatch.setattr(auth, "get_active_tokens", lambda: [])
+    monkeypatch.setattr(auth, "verify_api_token", lambda t: True)  # 任何 token 都"有效"
+    # 每设备 token "TKN" 发放给 phone-A;"ENVADMIN" 非每设备(注册表查不到)
+    monkeypatch.setattr(dtr, "verify_device_token", lambda t: {"device_id": "phone-A"} if t == "TKN" else None)
+
+    # 本设备就是 phone-A → 绑定通过 → device_approved
+    ok = _evaluate_ingress_authentication({"device_id": "phone-A", "token": "TKN"})
+    assert ok["token_valid"] is True and ok["device_approved"] is True
+
+    # 泄露 token 换个 device_id 冒充 → token_valid 仍 True,但绑定不过 → device_approved False
+    bad = _evaluate_ingress_authentication({"device_id": "evil", "token": "TKN"})
+    assert bad["token_valid"] is True and bad["device_approved"] is False
+
+    # 共享/环境管理员 token(非每设备)→ 按 token_valid 放行
+    admin = _evaluate_ingress_authentication({"device_id": "whatever", "token": "ENVADMIN"})
+    assert admin["device_approved"] is True

--- a/tests/test_device_enrollment.py
+++ b/tests/test_device_enrollment.py
@@ -124,6 +124,39 @@ def test_claim_within_window_still_works(tmp_path):
     assert c.claim(req.request_id) == tok, "窗口内应能正常领取"
 
 
+def test_approve_rejects_expired_request_without_prior_scan(tmp_path):
+    """approve() 本身先扫过期:即使没有别的调用触发过清理,超 request_ttl 的请求也不能被批准(TOCTOU)。"""
+    c, reg = _coord(tmp_path, request_ttl=0.05)
+    req = c.submit_enrollment("dev-x")
+    time.sleep(0.08)
+    # 不先调用 get()/pending();直接 approve —— 修复前会成功发 token,修复后应拒。
+    assert c.approve(req.request_id) is None, "过期请求不得被批准"
+    assert c.get(req.request_id)["status"] == EXPIRED
+
+
+def test_terminal_requests_are_purged_after_retention(tmp_path):
+    """终态(denied 等)记录过保留窗口后被清除,防止 _requests 无限堆积(无鉴权 /enroll 的内存 DoS)。"""
+    c, reg = _coord(tmp_path, terminal_retention=0.05)
+    req = c.submit_enrollment("dev-purge")
+    assert c.deny(req.request_id) is True
+    time.sleep(0.08)
+    c._expire_locked_free()  # 触发清理
+    assert c.get(req.request_id) is None, "过保留窗口的终态记录应被清除"
+    with c._lock:
+        assert req.request_id not in c._requests
+
+
+def test_requests_dict_is_hard_capped(tmp_path):
+    """洪泛兜底:_requests 超过 max_requests 即逐出,绝不无界增长。"""
+    c, reg = _coord(tmp_path, max_requests=5, terminal_retention=9999)
+    for i in range(50):
+        c.submit_enrollment(f"dev-{i}")
+    with c._lock:
+        # 逐出在 submit 开头的 _expire 里执行,故稳态为 max+1(刚插入的这条);关键是【有界】,
+        # 绝不随 /enroll 次数无限增长。
+        assert len(c._requests) <= 6, f"_requests 必须被硬上限约束(有界); got {len(c._requests)}"
+
+
 def test_pairing_code_ttl(tmp_path):
     c, reg = _coord(tmp_path, code_ttl=0.05)
     code = c.create_pairing_code()["code"]

--- a/tests/test_lockstep_degrades_when_tts_dead.py
+++ b/tests/test_lockstep_degrades_when_tts_dead.py
@@ -109,6 +109,58 @@ def test_lockstep_degrades_to_streaming_when_tts_dead(monkeypatch):
     assert done.get("response") == full
 
 
+def test_lockstep_degrades_on_midstream_stall(monkeypatch):
+    """TTS 念了第一句后【中途卡住】(不再开口)→ 不能挂到收尾再一次性冒出;
+    应在 stall 宽限后 reset 前端文字并把全文逐字直出(语音继续尾随)。"""
+    monkeypatch.setenv("GALAXY_TEXT_VOICE_LOCKSTEP", "1")
+    monkeypatch.setenv("GALAXY_LOCKSTEP_GRACE_S", "5.0")  # 首句宽限设大,确保走的是"中途卡住"分支
+    monkeypatch.setenv("GALAXY_LOCKSTEP_STALL_S", "0.15")
+    monkeypatch.setenv("GALAXY_CHAT_TIMEOUT_S", "10")
+
+    class _StallSpeaker:
+        # 只在第一句开口回调一次,其后永远卡住(不再 reveal),chunks_spoken 停在 1。
+        def __init__(self, on_sentence_start):
+            self._cb = on_sentence_start
+            self._buf = ""
+            self._revealed_once = False
+            self.chunks_spoken = 0
+            self._player_task = None
+
+        def feed(self, t):
+            self._buf += t
+            if not self._revealed_once and self._buf and self._buf[-1] in "。!?！?.":
+                self._revealed_once = True
+                sent = self._buf
+                self._buf = ""
+                self.chunks_spoken = 1
+                if self._cb is not None:
+                    self._cb(sent)
+
+        def reset(self):
+            self._buf = ""
+
+        def finish(self):
+            pass
+
+    tokens = ["你好呀。", "第二句", "较长", "内容", "还有", "第三句", "结尾。"]
+    frames, full = _run_stream(
+        monkeypatch,
+        lambda on_sentence_start=None, **k: _StallSpeaker(on_sentence_start),
+        tokens,
+    )
+
+    types = [f.get("type") for f in frames]
+    assert "done" in types
+    # 中途卡住应触发一次 reset(清掉已露出的第一句),随后把全文逐字直出。
+    assert "reset" in types, f"中途卡住应 reset 前端文字再全量重放; got {types}"
+    # reset 之后拼起来的文字 == 权威全文(无重复、无丢失)。
+    last_reset = len(types) - 1 - types[::-1].index("reset")
+    after_reset = "".join(f.get("text", "") for f in frames[last_reset + 1 :] if f.get("type") == "delta")
+    assert after_reset == full, f"reset 后重放的文字应等于全文; got {after_reset!r} vs {full!r}"
+    # delta 必须早于 done(不是憋到收尾)。
+    assert types.index("delta") < types.index("done")
+
+
 def test_lockstep_stays_synced_when_tts_alive(monkeypatch):
     """TTS 正常(每凑满一句即"开口")→ 仍逐句同步露出,不误触降级。"""
     monkeypatch.setenv("GALAXY_TEXT_VOICE_LOCKSTEP", "1")

--- a/tests/test_tts_degraded_surfacing.py
+++ b/tests/test_tts_degraded_surfacing.py
@@ -41,7 +41,9 @@ def test_neural_engine_clears_degraded_reason():
     assert so.get_tts_degraded_reason() is None, "用上神经引擎(edge/kokoro)后应清除降级态"
 
 
-def test_none_engine_is_noop():
+def test_none_engine_reports_fully_unavailable():
+    """整条链解析到 None(所有引擎不可用=完全无声)必须置降级原因,不能误报"自然音"。"""
     _reset()
     so._note_engine_choice(None)
-    assert so.get_tts_degraded_reason() is None
+    reason = so.get_tts_degraded_reason()
+    assert reason and "完全不可用" in reason, "无任何引擎=无声时必须如实报降级,不能保持 None"

--- a/tests/test_tts_demote_concurrency.py
+++ b/tests/test_tts_demote_concurrency.py
@@ -1,0 +1,58 @@
+"""tests/test_tts_demote_concurrency.py
+=========================================
+并发朗读下 demote 误拉黑健康引擎的回归防护。
+
+根因:demote_current_engine 原来只按【全局 _engine】拉黑,不管调用方实际失败的是哪个。
+两路朗读(chat 增量 + voice/ambient 整段)共用同一全局引擎缓存:A 路把 edge 降级成健康
+的 kokoro 后,B 路(还握着旧 edge)再失败时会按全局 _engine=kokoro 去拉黑,把【健康的
+kokoro】误拉黑,一路拉到 SAPI/静默。修复让调用方传入【实际失败的引擎实例】,它已不是
+现役引擎时直接返回现役,绝不误拉黑。
+"""
+
+from __future__ import annotations
+
+import core.speech_output as so
+
+
+class _EngA:
+    pass
+
+
+class _EngB:
+    pass
+
+
+def test_demote_does_not_blacklist_healthy_current_when_stale_engine_fails():
+    old_engine = so._engine
+    old_failed = set(so._failed_engine_types)
+    try:
+        healthy = _EngB()
+        so._engine = healthy  # 现役=健康引擎(模拟 A 路已降级到它)
+        so._failed_engine_types = set()
+        stale = _EngA()  # B 路仍握着的旧引擎(已失败)
+
+        result = so.demote_current_engine("stale failed", failed_engine=stale)
+
+        # 现役健康引擎【不能】被拉黑,且应原样返回
+        assert result is healthy, "传入陈旧失败引擎时应返回现役健康引擎,不重选"
+        assert "_EngB" not in so._failed_engine_types, "绝不能误拉黑健康的现役引擎"
+        assert so._engine is healthy
+    finally:
+        so._engine = old_engine
+        so._failed_engine_types = old_failed
+
+
+def test_demote_blacklists_the_actually_failed_engine_when_it_is_current():
+    old_engine = so._engine
+    old_failed = set(so._failed_engine_types)
+    try:
+        cur = _EngA()
+        so._engine = cur
+        so._failed_engine_types = set()
+
+        # 失败的就是现役引擎 → 应拉黑它并重选(重选会走 _get_engine,可能得 None,无妨)
+        so.demote_current_engine("cur failed", failed_engine=cur)
+        assert "_EngA" in so._failed_engine_types, "失败的现役引擎应被拉黑"
+    finally:
+        so._engine = old_engine
+        so._failed_engine_types = old_failed

--- a/tests/test_tts_fallback_and_verify.py
+++ b/tests/test_tts_fallback_and_verify.py
@@ -167,7 +167,7 @@ class TestIncrementalSynthFailover:
         monkeypatch.setattr(
             so,
             "demote_current_engine",
-            lambda reason="": _WorkingSapi(),
+            lambda reason="", failed_engine=None: _WorkingSapi(),
         )
         # os.remove 对假句柄(非真实文件)静默
         monkeypatch.setattr(so.os, "remove", lambda p: None)


### PR DESCRIPTION
## 背景

对最近合并的配对(#1496/#1499)与桌面语音(#1502)做**对抗式复检**(三路独立 review 子代理 + 自审),找出并修掉 **6 个真 bug**(附带确认多处"看着可疑其实没问题",如 claim_ttl 不误伤 token、锁步无重复/丢失、verify 不 fail-open)。

## 配对后端(3)

- **【高】`_requests` 无界增长 → 内存 DoS**:`_expire_locked_free` 只改状态从不删除,而 `/enroll` 无鉴权。改:终态记录过保留窗口即清除 + 硬上限逐出(终态优先、最旧优先),绝不无界。
- **【中·安全】准入闸未把 token 绑定到 `device_id`**:原按裸 `token_valid` 判已批准 → 一枚泄露的每设备 token 换个 `device_id` 即可冒充接入,击穿"别处批准·每设备"模型。改:新增 `device_approved`——每设备 token 须发放给本 `device_id` 才算已批准(共享/环境管理员 token 仍放行);闸改用它。
- **【低】`approve()/deny()` 跳过过期扫描(TOCTOU)**:超 `request_ttl` 未被清理的陈旧 PENDING 仍可被批准。改:两者先跑过期。

## 桌面语音(3)

- **【高】`demote_current_engine` 误拉黑健康引擎**:原按全局 `_engine` 拉黑,不管实际失败的是哪个。并发朗读下,A 路把 edge 降级成健康 kokoro 后,B 路再失败会误拉黑 kokoro，一路拉到 SAPI/静默。改:传入实际失败的引擎实例,已非现役则不动。
- **【中】中途卡住不降级**:有界锁步只在"一句未念"(全失败)降级;念了第一句后卡住则余下文字憋到收尾 + finish 空等 20~180s 再一次性冒出。改:加"中途卡住"判据 → reset 前端后全文逐字重放（规避重复）。
- **【低】完全无声误报"自然音"**:引擎解析到 None 时 `get_tts_degraded_reason()` 保持 None（被定义为自然音）。改:置"完全不可用"降级原因。

## 验证
- 新增 8 测(并发 demote 不误拉黑 / 中途卡住重放 / 完全无声报降级 / 终态清除 / 硬上限有界 / 过期不可批准 / token 绑定 device_id）。
- **affected-area 68 测全绿**;`flake8 core/` = 0;`black --check core/ tests/` clean。
- 存量红门(57 baseline / File Complexity / Governance / ssot-udm / Capability)与本改动无关,核实后跳过。

## 未改(记录):多 worker 下注册表/协调器为内存态会有跨进程陈旧——桌面网关单进程部署,列为部署约束,不在本 PR 引入分布式存储。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_