### PR TITLE
feat/fix: desktop+launcher+voice+config fixes, and durable-exec + idempotency + OTel reliability set

### DIFF
--- a/core/config_preflight.py
+++ b/core/config_preflight.py
@@ -145,21 +145,14 @@ _CHECKS: List[EnvCheck] = [
         var="OPENAI_API_KEY",
         severity=Severity.WARNING,
         description="OpenAI API key for LLM inference.",
-        hint=(
-            "Set OPENAI_API_KEY in .env or export it in the shell.\n"
-            "  Example: OPENAI_API_KEY=sk-...\n"
-            "  At least one LLM provider key is required to run agents."
-        ),
+        hint="Set OPENAI_API_KEY=sk-… in .env (≥1 LLM provider key required to run agents).",
         groups=["core", "all"],
     ),
     EnvCheck(
         var="ANTHROPIC_API_KEY",
         severity=Severity.WARNING,
         description="Anthropic Claude API key (optional if OpenAI is set).",
-        hint=(
-            "Set ANTHROPIC_API_KEY=sk-ant-... in .env if you want to use Claude.\n"
-            "  Required when GALAXY_LLM_PROVIDER=anthropic."
-        ),
+        hint="Set ANTHROPIC_API_KEY=sk-ant-… in .env to use Claude (required when GALAXY_LLM_PROVIDER=anthropic).",
         groups=["core", "all"],
     ),
     # ── Core: auth / security ────────────────────────────────────────────
@@ -168,12 +161,10 @@ _CHECKS: List[EnvCheck] = [
         severity=Severity.CRITICAL,
         description="Bearer token used to authenticate REST + WebSocket endpoints.",
         hint=(
-            "Generate a random token and set it in .env:\n"
-            '  GALAXY_API_TOKEN=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")\n'
-            "  Also set GALAXY_AUTH_ENABLED=true to enforce it.\n"
-            "  Or set GALAXY_REQUIRE_API_TOKEN=true to treat a missing token as CRITICAL "
-            "even when Bearer auth is disabled (staging hardening).\n"
-            "  Without this token any client can send commands to the API when auth is off."
+            'Set GALAXY_API_TOKEN=$(python3 -c "import secrets;print(secrets.token_urlsafe(32))") '
+            "in .env + GALAXY_AUTH_ENABLED=true to enforce.\n"
+            "GALAXY_REQUIRE_API_TOKEN=true makes a missing token CRITICAL even with auth off "
+            "(staging). Without it, any client can command the API when auth is off."
         ),
         groups=["core", "gateway", "all"],
     ),
@@ -183,10 +174,8 @@ _CHECKS: List[EnvCheck] = [
         severity=Severity.WARNING,
         description="Master encryption key for Node_03 SecretVault.",
         hint=(
-            "Generate and set SECRETVAULT_MASTER_KEY in .env:\n"
-            "  SECRETVAULT_MASTER_KEY=$(python3 -c 'from cryptography.fernet import Fernet;"
-            " print(Fernet.generate_key().decode())')\n"
-            "  Required when GALAXY_SECRET_BACKEND=vault."
+            "Set SECRETVAULT_MASTER_KEY=$(python3 -c 'from cryptography.fernet import Fernet;"
+            "print(Fernet.generate_key().decode())') in .env (required when GALAXY_SECRET_BACKEND=vault)."
         ),
         groups=["vault", "all"],
     ),
@@ -197,9 +186,8 @@ _CHECKS: List[EnvCheck] = [
         severity=Severity.INFO,
         description="System startup/fabric mode (default: desktop-local).",
         hint=(
-            "Set GALAXY_SYSTEM_MODE=desktop-local for first-start / single-machine use.\n"
-            "  Set to desktop-cross-device when the cross-device fabric should be active.\n"
-            "  See docs/SYSTEM_MODE_CONFIG.md for details."
+            "desktop-local for single-machine (default); desktop-cross-device to activate the "
+            "cross-device fabric. See docs/SYSTEM_MODE_CONFIG.md."
         ),
         groups=["core", "gateway", "all"],
     ),
@@ -207,10 +195,7 @@ _CHECKS: List[EnvCheck] = [
         var="GALAXY_NATS_ENABLED",
         severity=Severity.INFO,
         description="Enable the NATS bus (default: derived from GALAXY_SYSTEM_MODE).",
-        hint=(
-            "Set GALAXY_NATS_ENABLED=true to activate NATS regardless of mode.\n"
-            "  Defaults to false in desktop-local mode, true in desktop-cross-device mode."
-        ),
+        hint="true to force-enable NATS regardless of mode (default: off desktop-local, on cross-device).",
         groups=["gateway", "all"],
     ),
     EnvCheck(
@@ -218,9 +203,8 @@ _CHECKS: List[EnvCheck] = [
         severity=Severity.INFO,
         description="Treat missing fabric dependencies as hard startup failures (default: false).",
         hint=(
-            "Set GALAXY_FABRIC_STRICT=true only in desktop-cross-device mode when NATS\n"
-            "  must be available for the system to function.  Leave false (default) for\n"
-            "  graceful degradation."
+            "true only in desktop-cross-device mode when NATS is mandatory; leave false "
+            "(default) for graceful degradation."
         ),
         groups=["gateway", "all"],
     ),
@@ -228,11 +212,7 @@ _CHECKS: List[EnvCheck] = [
         var="GALAXY_NETWORK_MODE",
         severity=Severity.INFO,
         description="Network topology mode: local | lan | tailscale | relay (default: local).",
-        hint=(
-            "Set GALAXY_NETWORK_MODE=lan for LAN-only deployments.\n"
-            "  Set to tailscale when Tailscale is the primary network fabric.\n"
-            "  Set to relay when using a public relay server."
-        ),
+        hint="local (default) | lan (LAN-only) | tailscale (Tailscale fabric) | relay (public relay server).",
         groups=["gateway", "all"],
     ),
     EnvCheck(
@@ -240,9 +220,8 @@ _CHECKS: List[EnvCheck] = [
         severity=Severity.INFO,
         description="Enable/disable cross-device routing (default: derived from GALAXY_SYSTEM_MODE).",
         hint=(
-            "Set GALAXY_CROSS_DEVICE_ENABLED=true to enable cross-device routing.\n"
-            "  Set to false to disable (safe default for single-device deployments).\n"
-            "  When GALAXY_SYSTEM_MODE is set, this value is derived automatically."
+            "true/false to force cross-device routing (false = safe single-device default); "
+            "auto-derived from GALAXY_SYSTEM_MODE when that is set."
         ),
         groups=["gateway", "all"],
     ),
@@ -251,10 +230,7 @@ _CHECKS: List[EnvCheck] = [
         var="GALAXY_SIGNALING_TIMEOUT_S",
         severity=Severity.INFO,
         description="WebRTC signaling timeout in seconds (default: 30).",
-        hint=(
-            "Set GALAXY_SIGNALING_TIMEOUT_S=30 (or another positive integer).\n"
-            "  Increase to 60 on high-latency networks."
-        ),
+        hint="Positive int seconds (default 30; raise to 60 on high-latency networks).",
         groups=["ws", "all"],
     ),
     # ── Android bridge ───────────────────────────────────────────────────
@@ -262,11 +238,7 @@ _CHECKS: List[EnvCheck] = [
         var="GALAXY_AUTH_ENABLED",
         severity=Severity.WARNING,
         description="Enforce Bearer-token auth on all endpoints (default: false).",
-        hint=(
-            "Set GALAXY_AUTH_ENABLED=true in production.\n"
-            "  Requires GALAXY_API_TOKEN to also be set.\n"
-            "  Without this, Android clients can connect without authentication."
-        ),
+        hint="true in production (also needs GALAXY_API_TOKEN); without it Android clients connect unauthenticated.",
         groups=["android", "gateway", "all"],
     ),
     # ── TLS ─────────────────────────────────────────────────────────────
@@ -275,8 +247,8 @@ _CHECKS: List[EnvCheck] = [
         severity=Severity.INFO,
         description="Path to TLS certificate file (enables HTTPS when set with GALAXY_TLS_KEY).",
         hint=(
-            "Set GALAXY_TLS_CERT=/path/to/cert.pem and GALAXY_TLS_KEY=/path/to/key.pem\n"
-            "  to enable HTTPS.  Leave blank for plain HTTP (development only)."
+            "Set GALAXY_TLS_CERT=/path/cert.pem + GALAXY_TLS_KEY=/path/key.pem for HTTPS; "
+            "blank = plain HTTP (dev only)."
         ),
         groups=["gateway", "ws", "all"],
     ),
@@ -285,10 +257,7 @@ _CHECKS: List[EnvCheck] = [
         var="GALAXY_NATS_URL",
         severity=Severity.INFO,
         description="NATS control-plane URL (default: nats://localhost:4222).",
-        hint=(
-            "Set GALAXY_NATS_URL=nats://localhost:4222 if using the NATS control plane.\n"
-            "  Leave unset to disable NATS (all NATS paths become no-ops)."
-        ),
+        hint="nats://localhost:4222 to use the NATS control plane; unset disables NATS (paths become no-ops).",
         groups=["gateway", "all"],
     ),
     # ── Runtime bridge (optional) ────────────────────────────────────────
@@ -296,10 +265,7 @@ _CHECKS: List[EnvCheck] = [
         var="GALAXY_RUNTIME_URL",
         severity=Severity.INFO,
         description="URL of the Galaxy Agent Runtime (for AgentBridge).",
-        hint=(
-            "Set GALAXY_RUNTIME_URL=http://localhost:8200 if running the agent runtime.\n"
-            "  Leave unset to disable the agent bridge (GALAXY_RUNTIME_ENABLED=0)."
-        ),
+        hint="http://localhost:8200 if running the agent runtime; unset disables the agent bridge.",
         groups=["gateway", "all"],
     ),
 ]
@@ -344,6 +310,24 @@ class PreflightReport:
     # ── display ──────────────────────────────────────────────────────────
 
     def format(self, verbose: bool = True) -> str:
+        # 颜色/字体与启动界面其余部分统一:走 core.cli_render 的 _use_color() 门闸
+        # + core.ascii_art.Colors 同一套配色(标题 CYAN 粗体、✗ 红、⚠ 黄、✓ 绿、
+        # 变量名粗体、描述与提示 DIM)。非 TTY / 不支持色彩时自动退化为纯文本
+        # (故 assertIn 一类测试不受影响)。任何导入失败都安全回退为无色。
+        try:
+            from core import cli_render as _r
+            from core.ascii_art import Colors as _Co
+
+            _use = _r._use_color()
+        except Exception:  # noqa: BLE001 — 渲染增强失败绝不影响预检本身
+            _use = False
+
+            class _Co:  # type: ignore
+                BOLD = CYAN = DIM = GREEN = YELLOW = RED = ENDC = ""
+
+        def _c(t: str, color: str) -> str:
+            return f"{color}{t}{_Co.ENDC}" if _use else t
+
         # 盒子标题按盒宽【居中计算】,不再手写空格——真机复现过标题行内宽 57、
         # 上下边框内宽 58,导致标题右侧 ║ 比边框的 ╗ 缩进一格(整个白框歪一行)。
         # 盒宽 58 与启动 banner(core.ascii_art)一致,两个白框从此完全对齐。
@@ -352,44 +336,43 @@ class PreflightReport:
         _pad = max(0, _box_inner - len(_title))
         _left = _pad // 2
         _right = _pad - _left
+        _summary = (
+            f"  {_c('Mode', _Co.DIM)}  : {self.mode}   "
+            f"{_c('passed', _Co.DIM)} {_c(str(len(self.passed)), _Co.GREEN)}  "
+            f"{_c('warn', _Co.DIM)} {_c(str(len(self.warnings)), _Co.YELLOW)}  "
+            f"{_c('crit', _Co.DIM)} {_c(str(len(self.criticals)), _Co.RED)}"
+            f"   {_c(f'/ {len(self.findings)} checks', _Co.DIM)}"
+        )
         lines: List[str] = [
             "",
-            "╔" + "═" * _box_inner + "╗",
-            "║" + " " * _left + _title + " " * _right + "║",
-            "╚" + "═" * _box_inner + "╝",
-            f"  Mode  : {self.mode}",
-            f"  Checks: {len(self.findings)}  "
-            f"passed={len(self.passed)}  "
-            f"warnings={len(self.warnings)}  "
-            f"criticals={len(self.criticals)}",
+            _c("╔" + "═" * _box_inner + "╗", _Co.CYAN),
+            _c("║" + " " * _left, _Co.CYAN) + _c(_title, _Co.BOLD + _Co.CYAN) + _c(" " * _right + "║", _Co.CYAN),
+            _c("╚" + "═" * _box_inner + "╝", _Co.CYAN),
+            _summary,
             "",
         ]
 
         # 符号与 core.cli_render 统一(✓/⚠/✗,均为 1 显示格),不再混用 emoji
         # ✅/⚠️/❌(带变体选择符、多数终端渲染成 2 格),避免整个克隆界面对号列
-        # 因图标宽度不一而错位——真机反馈"绿色对号没对齐成一列"根因之一。
+        # 因图标宽度不一而错位。每条:`• VAR — 描述`(变量名与描述并作一行,省一行),
+        # 提示首行带 💡、续行只缩进不再重复 💡,条目间不留空行 → 更紧凑。
+        def _emit_section(header: str, color: str, findings: List["Finding"]) -> None:
+            lines.append("  " + _c(header, color))
+            lines.append("  " + _c("─" * 56, _Co.DIM))
+            for f in findings:
+                _desc = _c("— " + f.check.description, _Co.DIM)
+                lines.append(f"  {_c('•', color)} {_c(f.check.var, _Co.BOLD)} {_desc}")
+                hint_lines = f.check.hint.splitlines()
+                for i, hint_line in enumerate(hint_lines):
+                    prefix = "💡 " if i == 0 else "   "
+                    lines.append("    " + _c(prefix + hint_line.strip(), _Co.DIM))
+
         if self.criticals:
-            lines.append("  ✗  CRITICAL — startup blocked")
-            lines.append("  " + "─" * 56)
-            for f in self.criticals:
-                lines.append(f"  • {f.check.var}")
-                lines.append(f"    {f.check.description}")
-                for hint_line in f.check.hint.splitlines():
-                    lines.append(f"    💡 {hint_line}")
-                lines.append("")
-
+            _emit_section("✗  CRITICAL — startup blocked", _Co.RED, self.criticals)
         if self.warnings and verbose:
-            lines.append("  ⚠  WARNING — degraded functionality")
-            lines.append("  " + "─" * 56)
-            for f in self.warnings:
-                lines.append(f"  • {f.check.var}")
-                lines.append(f"    {f.check.description}")
-                for hint_line in f.check.hint.splitlines():
-                    lines.append(f"    💡 {hint_line}")
-                lines.append("")
-
+            _emit_section("⚠  WARNING — degraded functionality", _Co.YELLOW, self.warnings)
         if self.ok:
-            lines.append("  ✓  All CRITICAL checks passed.")
+            lines.append("  " + _c("✓  All CRITICAL checks passed.", _Co.GREEN))
 
         lines.append("")
         return "\n".join(lines)

--- a/core/container_runtime.py
+++ b/core/container_runtime.py
@@ -33,10 +33,21 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _CHOICE_FILE = PROJECT_ROOT / ".galaxy_runtime"
 
 _RUNTIMES = ("docker", "podman")
+# 交互菜单里【推荐】的运行时:Podman 无守护、rootless、更轻,Windows 上一条 winget
+# 就能装(Docker Desktop 太重、还要单独装/开守护)。仅影响用户实际看到的选择菜单的
+# 默认项与排序;非交互/headless 路径仍保持 docker 优先(见 available_runtimes)。
+_RECOMMENDED = "podman"
 _LABELS: Dict[str, str] = {
-    "docker": "Docker —— 最广泛;Docker Desktop / Engine + docker compose",
-    "podman": "Podman —— 无守护进程、rootless、更轻;podman / podman-compose",
+    "docker": "Docker —— 最广泛;需 Docker Desktop / Engine + 守护进程(较重)",
+    "podman": "Podman —— 无守护、rootless、更轻,一条 winget 即可装(推荐)",
 }
+
+
+def _prefer_recommended(runtimes: List[str]) -> List[str]:
+    """把推荐运行时(Podman)排到最前,其余保持原相对顺序。用于交互菜单的展示与默认项。"""
+    rec = [rt for rt in runtimes if rt == _RECOMMENDED]
+    rest = [rt for rt in runtimes if rt != _RECOMMENDED]
+    return rec + rest
 
 
 def detect_runtimes() -> Dict[str, Optional[str]]:
@@ -85,6 +96,9 @@ def interactive_select(avail: List[str]) -> str:
     if not (sys.stdin and sys.stdin.isatty()):
         return avail[0]
 
+    # 展示与默认项把推荐运行时(Podman·更轻)排到最前;回车即用它。
+    avail = _prefer_recommended(avail)
+
     from core import cli_render as r
     from core.ascii_art import Colors
 
@@ -99,7 +113,7 @@ def interactive_select(avail: List[str]) -> str:
         marker = _c("▸", Colors.GREEN) if is_first else " "
         num = _c(f"[{i}]", Colors.BOLD if is_first else Colors.DIM)
         name = r.pad_display(rt.capitalize(), 10)
-        tail = _c("  ← 默认", Colors.GREEN) if is_first else ""
+        tail = _c("  ← 推荐" if rt == _RECOMMENDED else "  ← 默认", Colors.GREEN) if is_first else ""
         print(f"  {marker} {num} {name}{tail}")
         print(f"         {_c(_LABELS.get(rt, ''), Colors.DIM)}")
     r.rule()
@@ -223,6 +237,8 @@ def interactive_install_guide() -> str:
     def _c(t, color):
         return f"{color}{t}{Colors.ENDC}" if r._use_color() else t
 
+    # 推荐运行时(Podman·更轻)排最前、作默认;Docker 仍可选。
+    _menu = _prefer_recommended(list(_RUNTIMES))
     print()
     print(
         "  "
@@ -230,25 +246,25 @@ def interactive_install_guide() -> str:
         + _c("  (节点基础设施需要;两者都未检测到,先选一个偏好并安装)", Colors.DIM)
     )
     r.rule()
-    for i, rt in enumerate(_RUNTIMES, 1):
+    for i, rt in enumerate(_menu, 1):
         marker = _c("▸", Colors.GREEN) if i == 1 else " "
         num = _c(f"[{i}]", Colors.BOLD if i == 1 else Colors.DIM)
         name = r.pad_display(rt.capitalize(), 10)
-        tail = _c("  ← 默认", Colors.GREEN) if i == 1 else ""
+        tail = _c("  ← 推荐" if rt == _RECOMMENDED else "  ← 默认", Colors.GREEN) if i == 1 else ""
         print(f"  {marker} {num} {name}{tail}")
         print(f"         {_c(_LABELS.get(rt, ''), Colors.DIM)}")
         print(f"         {_c('安装: ' + _INSTALL_HINTS.get(rt, ''), Colors.DIM)}")
     r.rule()
-    print("  " + _c("回车=记住默认(Docker) · 数字=记住偏好 · s=跳过(桌面照常运行)", Colors.DIM))
+    print("  " + _c(f"回车=记住默认({_RECOMMENDED.capitalize()}·更轻) · 数字=记住偏好 · s=跳过(桌面照常运行)", Colors.DIM))
     try:
-        choice = input(f"  选择偏好运行时 [1-{len(_RUNTIMES)} / 回车 / s]: ").strip().lower()
+        choice = input(f"  选择偏好运行时 [1-{len(_menu)} / 回车 / s]: ").strip().lower()
     except (EOFError, KeyboardInterrupt):
         return ""
     if choice == "s":
         return ""
-    pick = _RUNTIMES[0]
-    if choice.isdigit() and 1 <= int(choice) <= len(_RUNTIMES):
-        pick = _RUNTIMES[int(choice) - 1]
+    pick = _menu[0]  # 回车 → 推荐(Podman)
+    if choice.isdigit() and 1 <= int(choice) <= len(_menu):
+        pick = _menu[int(choice) - 1]
     elif choice in _RUNTIMES:
         pick = choice
     save_choice(pick)  # 记住偏好;装好后下次即自动采用

--- a/core/durable_dispatch_idempotency.py
+++ b/core/durable_dispatch_idempotency.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+core/durable_dispatch_idempotency.py
+====================================
+Durable, file-backed **dispatch-side** idempotency for V2 — prevents a
+side-effectful node/device action from being executed twice.
+
+Why this exists (distinct from durable_result_idempotency)
+----------------------------------------------------------
+``core.durable_result_idempotency`` dedups **inbound results** — it stops the
+same *result* from being ingested twice on restart/replay. It does NOT stop the
+same *action* from being **executed** twice.
+
+NATS worker dispatch is at-least-once: ``nats_bus._subscribe`` acks a message
+only *after* the consumer callback runs, and the worker executes the effect
+inside that callback (``worker_runtime.execute_dispatch`` → ``invoke_node``).
+So if a worker executes an android-tap / desktop-control and then dies before
+ack — or the callback raises after the effect — JetStream redelivers the same
+dispatch and the effect runs a **second time**. For a system that drives real
+devices, a double-tap is a real defect.
+
+This module provides a durable guard that runs **before** the effect executes:
+
+    key = dispatch idempotency key (idempotency_key or task_id)
+    if seen(key):  -> short-circuit, do NOT execute again
+    else: mark(key) pessimistically, execute; on exception remove(key) so a
+          genuine transient failure can be retried.
+
+Semantics (pessimistic, side-effect-safe)
+------------------------------------------
+- Mark **before** executing → a redelivery never re-runs the effect (we err
+  toward "don't double-tap"). This is the correct bias for real-device control.
+- A terminal return (success OR node-reported failure) means the effect was
+  attempted → the key is kept so further redeliveries stay deduped.
+- Only an **exception** from the executor (the effect did not run cleanly)
+  rolls the key back, so a fresh delivery can retry.
+- Genuine higher-level retries must carry a NEW task_id / idempotency_key;
+  redelivery of the SAME dispatch (same key) is what gets deduped.
+
+Not exactly-once
+----------------
+No purely client-side scheme can be exactly-once for an *external* side effect
+(a crash strictly between "effect done" and "mark done" is unobservable). This
+closes the dominant, common failure — JetStream redelivery / re-publish — which
+is the actual source of double-execution in practice.
+
+Enable / disable
+----------------
+Active by default; ``GALAXY_DISPATCH_IDEMPOTENCY=0`` disables it (falls back to
+the prior always-execute behavior). The guard is a no-op when the dispatch has
+no usable key. The whole worker path is itself gated by
+``GALAXY_MASTER_BRAIN_ENABLED``, so on a single-machine default this never runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from collections import OrderedDict
+from typing import Optional
+
+logger = logging.getLogger("Galaxy.DurableDispatchIdempotency")
+
+_DEFAULT_DISPATCH_ID_STORE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data",
+    "dispatch_idempotency_set.json",
+)
+
+DURABLE_DISPATCH_IDEMPOTENCY_IS_AUTHORITY: str = (
+    "DURABLE_DISPATCH_IDEMPOTENCY::FILE_BACKED_PRE_EXECUTE_DEDUP_V1"
+)
+
+
+def dispatch_idempotency_enabled() -> bool:
+    """Whether the dispatch-side guard is active (default on)."""
+    return str(os.getenv("GALAXY_DISPATCH_IDEMPOTENCY", "1")).strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+class DurableDispatchIdSet:
+    """Thread-safe, file-backed set of dispatch idempotency keys.
+
+    Atomic writes (write-temp-then-rename) so a partial write never corrupts the
+    previous good state. Bounded (oldest evicted) to cap disk growth. Lazy load.
+    """
+
+    _DEFAULT_MAX = 100_000
+
+    def __init__(self, store_path: Optional[str] = None, *, max_entries: int = _DEFAULT_MAX) -> None:
+        self._store_path = store_path or _DEFAULT_DISPATCH_ID_STORE_PATH
+        self._max_entries = max_entries
+        self._lock = threading.Lock()
+        self._loaded = False
+        self._ids: OrderedDict = OrderedDict()
+        try:
+            os.makedirs(os.path.dirname(os.path.abspath(self._store_path)), exist_ok=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("DurableDispatchIdSet: could not create store directory: %s", exc)
+
+    # ------------------------------------------------------------------ API
+    def contains(self, key: str) -> bool:
+        with self._lock:
+            self._ensure_loaded()
+            return key in self._ids
+
+    def add(self, key: str) -> bool:
+        """Record *key* and durably persist. Returns True if newly added, False if already present."""
+        with self._lock:
+            self._ensure_loaded()
+            if key in self._ids:
+                return False
+            self._ids[key] = time.time()
+            self._evict_if_needed()
+            self._flush_locked()
+            return True
+
+    def remove(self, key: str) -> bool:
+        """Remove *key* (used to roll back a pessimistic mark when the effect threw)."""
+        with self._lock:
+            self._ensure_loaded()
+            if key not in self._ids:
+                return False
+            del self._ids[key]
+            self._flush_locked()
+            return True
+
+    def size(self) -> int:
+        with self._lock:
+            self._ensure_loaded()
+            return len(self._ids)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._ids.clear()
+            self._loaded = True
+            try:
+                if os.path.exists(self._store_path):
+                    os.unlink(self._store_path)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("DurableDispatchIdSet: clear failed to unlink: %s", exc)
+
+    @property
+    def store_path(self) -> str:
+        return self._store_path
+
+    # ------------------------------------------------------------- internal
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        if not os.path.exists(self._store_path):
+            return
+        try:
+            with open(self._store_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            for entry in data.get("dispatch_ids", []):
+                if isinstance(entry, list) and len(entry) == 2:
+                    self._ids[str(entry[0])] = float(entry[1])
+                elif isinstance(entry, str):
+                    self._ids[entry] = 0.0
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("DurableDispatchIdSet: failed to load from %s: %s", self._store_path, exc)
+
+    def _evict_if_needed(self) -> None:
+        while len(self._ids) > self._max_entries:
+            self._ids.popitem(last=False)
+
+    def _flush_locked(self) -> None:
+        try:
+            payload = json.dumps(
+                {
+                    "schema": "dispatch_idempotency_set_v1",
+                    "count": len(self._ids),
+                    "dispatch_ids": [[k, ts] for k, ts in self._ids.items()],
+                },
+                ensure_ascii=False,
+            )
+            store_dir = os.path.dirname(os.path.abspath(self._store_path))
+            fd, tmp_path = tempfile.mkstemp(dir=store_dir, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(payload)
+                os.replace(tmp_path, self._store_path)
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("DurableDispatchIdSet: failed to flush to %s: %s", self._store_path, exc)
+
+
+# --------------------------------------------------------------- singleton
+_store_instance: Optional[DurableDispatchIdSet] = None
+_store_lock = threading.Lock()
+
+
+def get_durable_dispatch_id_store(store_path: Optional[str] = None) -> DurableDispatchIdSet:
+    """Return (or create) the process-level :class:`DurableDispatchIdSet` singleton."""
+    global _store_instance
+    if _store_instance is None:
+        with _store_lock:
+            if _store_instance is None:
+                _store_instance = DurableDispatchIdSet(store_path=store_path)
+    return _store_instance
+
+
+def reset_durable_dispatch_id_store() -> None:
+    """Reset the process-level singleton (for test isolation)."""
+    global _store_instance
+    with _store_lock:
+        _store_instance = None
+
+
+# ----------------------------------------------------- convenience helpers
+def dispatch_key_for(msg: dict) -> str:
+    """Derive the dispatch idempotency key from a dispatch dict.
+
+    Priority: explicit ``idempotency_key`` → ``task_id`` → ``request_id``.
+    Returns "" when none present (caller treats as "no guard possible").
+    """
+    if not isinstance(msg, dict):
+        return ""
+    for k in ("idempotency_key", "task_id", "request_id"):
+        v = msg.get(k)
+        if v:
+            return str(v)
+    return ""
+
+
+def already_dispatched(key: str) -> bool:
+    """True if *key* was already marked as dispatched (should NOT execute again)."""
+    return bool(key) and get_durable_dispatch_id_store().contains(key)
+
+
+def mark_dispatched(key: str) -> bool:
+    """Pessimistically mark *key* as dispatched (call BEFORE executing the effect)."""
+    if not key:
+        return False
+    return get_durable_dispatch_id_store().add(key)
+
+
+def unmark_dispatched(key: str) -> bool:
+    """Roll back a mark (call only when the executor raised — effect did not run cleanly)."""
+    if not key:
+        return False
+    return get_durable_dispatch_id_store().remove(key)
+
+
+__all__ = [
+    "DURABLE_DISPATCH_IDEMPOTENCY_IS_AUTHORITY",
+    "DurableDispatchIdSet",
+    "dispatch_idempotency_enabled",
+    "get_durable_dispatch_id_store",
+    "reset_durable_dispatch_id_store",
+    "dispatch_key_for",
+    "already_dispatched",
+    "mark_dispatched",
+    "unmark_dispatched",
+]

--- a/core/electron_launch_guard.py
+++ b/core/electron_launch_guard.py
@@ -32,14 +32,20 @@ _logger = logging.getLogger(__name__)
 
 
 def _log(msg: str) -> None:
-    """打印一条进度信息。有 logging handler 就走 logging，否则退化为 print，
-    确保 Windows 自动安装 MSVC 这类耗时步骤对用户可见。"""
+    """打印一条【必须对用户可见】的进度信息。
+
+    Windows 自动装 MSVC / 注入链接器 PATH / 回退提示都是一次性的关键交互步骤,
+    可能耗时数分钟。控制台常把 logger 级别设在 WARNING,单纯 logger.info 会被
+    吞掉(真机复现:自动安装像个黑盒,用户啥也看不到)。故这里【始终 print】保证
+    可见,同时照常写一份到日志文件。"""
     try:
         _logger.info(msg)
     except Exception:
         pass
-    if not _logger.handlers and not logging.getLogger().handlers:
+    try:
         print(msg, flush=True)
+    except Exception:
+        pass
 
 
 def _project_root() -> str:
@@ -167,37 +173,74 @@ def tauri_build_prereqs_hint():
     return None
 
 
-def _windows_msvc_present(shutil, subprocess):
-    """True 当 MSVC C++ 链接器已就位（PATH 上有 link.exe/cl.exe，或已装含
-    VC.Tools 组件的 VS/Build Tools —— 后者 cargo 可经 vcvars 自行找到链接器）。"""
-    # 1) 链接器已在 PATH（native tools 环境或已配置）
-    if shutil.which("link.exe") or shutil.which("cl.exe"):
-        return True
-    # 2) vswhere 探测已安装的 VC.Tools 组件
+def _prepend_path(d: str) -> None:
+    """把目录 d 前插进本进程 PATH（去重），使随后 fork 的 cargo 子进程能继承到。"""
+    if not d:
+        return
+    cur = os.environ.get("PATH", "")
+    if d not in cur.split(os.pathsep):
+        os.environ["PATH"] = d + os.pathsep + cur if cur else d
+
+
+def _link_on_path_is_msvc(shutil) -> bool:
+    """PATH 上是否有【确为 MSVC】的编译器/链接器。
+
+    只认 cl.exe:它是 MSVC 独有的编译器名(GNU/其他工具链没有),在 PATH 上即可
+    确定处于 MSVC 开发环境(如 x64 Native Tools 命令行)。
+    【不】单凭 link.exe 判定 —— 真机踩过:PATH 上可能有非 MSVC 的 link.exe(某些
+    工具链/GnuWin 也叫 link),它会让预检假阳性、放行构建、编译数分钟后才在链接
+    阶段崩。link.exe 的真伪改由 _windows_msvc_linker_dir 在磁盘上核实。"""
+    return bool(shutil.which("cl.exe"))
+
+
+def _windows_msvc_linker_dir(subprocess):
+    """返回一个【磁盘上真实存在 link.exe】的 MSVC 工具链 bin 目录;找不到返回 None。
+
+    经 VS 官方定位器 vswhere.exe 找到装了 VC.Tools 组件的 VS/Build Tools 安装路径,
+    再在其下 glob ``VC\\Tools\\MSVC\\<ver>\\bin\\Host<arch>\\<tgt>\\link.exe``。
+    关键:仅"组件已注册"不算数(残缺/损坏安装会注册组件却没真正落地二进制,正是
+    这次真机假阳性的根因)—— 必须磁盘上真有 link.exe 才认。返回其所在目录,供调用
+    方注入 PATH 让 cargo/rustc 一定找得到。"""
+    import glob as _glob
+
     program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
     vswhere = os.path.join(program_files_x86, "Microsoft Visual Studio", "Installer", "vswhere.exe")
-    if os.path.isfile(vswhere):
-        try:
-            out = subprocess.run(
-                [
-                    vswhere,
-                    "-latest",
-                    "-products",
-                    "*",
-                    "-requires",
-                    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-                    "-property",
-                    "installationPath",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=20,
-            )
-            if out.returncode == 0 and out.stdout.strip():
-                return True
-        except Exception:
-            pass
-    return False
+    if not os.path.isfile(vswhere):
+        return None
+    try:
+        out = subprocess.run(
+            [
+                vswhere,
+                "-latest",
+                "-products",
+                "*",
+                "-requires",
+                "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                "-property",
+                "installationPath",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0 or not out.stdout.strip():
+        return None
+    install = out.stdout.strip().splitlines()[0].strip()
+    pattern = os.path.join(install, "VC", "Tools", "MSVC", "*", "bin", "Host*", "*", "link.exe")
+    hits = _glob.glob(pattern)
+    if not hits:
+        return None
+    hits.sort()  # 版本号目录名字符串排序,末尾 ≈ 最新工具集
+    return os.path.dirname(hits[-1])
+
+
+def _windows_msvc_present(shutil, subprocess):
+    """True 当 MSVC C++ 链接器【确实可用】——PATH 上有 cl.exe(必是 MSVC),或
+    磁盘上 vswhere 定位到的 VS 安装里真有 link.exe 二进制。故意不轻信裸 link.exe
+    或"组件已注册",避免放行后编译半天才在链接崩。"""
+    return _link_on_path_is_msvc(shutil) or _windows_msvc_linker_dir(subprocess) is not None
 
 
 def _windows_try_install_msvc(shutil, subprocess):
@@ -242,16 +285,33 @@ def _windows_msvc_hint(shutil, subprocess):
     就位（或成功自动装上）返回 None 让构建继续；否则返回一句可直接执行的安装
     提示，供上层打印后回退 Electron。默认会在缺失时先用 winget 自动拉取最新版
     VS Build Tools 装上，可用 GALAXY_TAURI_AUTO_INSTALL_MSVC=0 关掉。
+
+    关键:当链接器已装在磁盘上但不在当前 PATH(最常见——用户从普通终端而非
+    "x64 Native Tools" 命令行启动)时,把它的 bin 目录注入 PATH,让随后的 cargo
+    子进程一定找得到 link.exe,而不是编译数分钟后才崩。
     """
-    if _windows_msvc_present(shutil, subprocess):
+    # cl.exe 已在 PATH(处于 MSVC 开发环境)→ 直接就位
+    if _link_on_path_is_msvc(shutil):
+        return None
+    # 磁盘上有真实 MSVC 链接器但不在 PATH → 注入 PATH,构建即可继续
+    bindir = _windows_msvc_linker_dir(subprocess)
+    if bindir:
+        _prepend_path(bindir)
+        _log(f"检测到 MSVC 链接器于 {bindir}，已注入本次构建的 PATH → 继续构建 Tauri。")
         return None
 
     # 默认自动安装（用户要求：让它自己去装、直接拉最新适配版）
     if os.environ.get("GALAXY_TAURI_AUTO_INSTALL_MSVC", "1").strip().lower() not in ("0", "false", "no"):
         _windows_try_install_msvc(shutil, subprocess)
-        if _windows_msvc_present(shutil, subprocess):
+        if _link_on_path_is_msvc(shutil):
             _log("MSVC C++ 生成工具已就位 → 继续构建 Tauri。")
             return None
+        bindir = _windows_msvc_linker_dir(subprocess)
+        if bindir:
+            _prepend_path(bindir)
+            _log(f"MSVC 安装完成，链接器于 {bindir}，已注入 PATH → 继续构建 Tauri。")
+            return None
+        _log("自动安装后仍未探测到 MSVC 链接器 → 回退 Electron（详见下方手动安装提示）。")
 
     winget = (
         "  winget install --id Microsoft.VisualStudio.2022.BuildTools -e "

--- a/core/multimodal/audio_ingest.py
+++ b/core/multimodal/audio_ingest.py
@@ -34,6 +34,35 @@ except Exception as exc:
     logger.debug("Suppressed: %s", exc)
 
 
+def _resolve_input_device(sd, configured, sample_rate: int, channels: int):
+    """选一个【真的能以目标参数打开】的输入设备,专治"默认录音设备被改/被拔/被独占
+    → 之前能录、现在 device=None 直接打不开"这一最常见的麦克风失灵根因。
+
+    顺序:显式 configured → 系统默认(None)→ 枚举里所有有输入通道的设备;每个候选
+    用 sd.check_input_settings 实测能否以目标 sr/通道打开,第一个通过的即采用。全都
+    不通过 → 返回 configured(维持原行为,让下面的 InputStream 抛错并打完整诊断)。
+    仅在默认设备确实打不开时才改选别的,不打扰正常情形。
+    """
+    def _ok(dev) -> bool:
+        try:
+            sd.check_input_settings(device=dev, samplerate=sample_rate, channels=channels, dtype="float32")
+            return True
+        except Exception:
+            return False
+
+    candidates: List = [configured] if configured is not None else [None]  # 先试显式/系统默认
+    try:
+        for idx, dev in enumerate(sd.query_devices()):
+            if dev.get("max_input_channels", 0) > 0 and idx not in candidates:
+                candidates.append(idx)
+    except Exception:
+        pass
+    for dev in candidates:
+        if _ok(dev):
+            return dev
+    return configured
+
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -122,6 +151,17 @@ class AudioIngestPipeline:
 
         import sounddevice as sd  # deferred to avoid import-time failure
 
+        # 默认录音设备可能被改/被拔/被独占 → device=None 直接打不开(经典"之前能录现在
+        # 不行")。这里先挑一个实测能打开的输入设备,默认可用就原样用,不可用才回退。
+        _device = _resolve_input_device(sd, self.config.device, self.config.sample_rate, self.config.channels)
+        if _device != self.config.device:
+            logger.warning(
+                "默认录音设备不可用,已回退到输入设备 index=%s(原 device=%s)。"
+                "如非预期,Windows 声音设置→录制里确认默认麦克风。",
+                _device,
+                self.config.device,
+            )
+
         chunk_size = max(
             1,
             int(self.config.sample_rate * self.config.chunk_duration_ms / 1000),
@@ -167,7 +207,7 @@ class AudioIngestPipeline:
                 channels=self.config.channels,
                 dtype="float32",
                 blocksize=chunk_size,
-                device=self.config.device,
+                device=_device,
                 callback=_sd_callback,
             ):
                 logger.info(

--- a/core/node_invocation.py
+++ b/core/node_invocation.py
@@ -821,4 +821,27 @@ async def invoke_node(
     # 关键:此前这里是个【裸 return】(返回 None)——invoke_node 号称"所有本地节点
     # 执行的唯一首选入口",却对每一次调用都返回 None(REST /nodes/call、命令路由、
     # OpenClawd 工具派发、能力分发器全部拿到 None)。补上真正的委派。
-    return await get_unified_node_executor().execute(envelope)
+    #
+    # 观测(默认零成本 no-op):invoke_node 是【所有】本地节点执行的唯一入口(in-process
+    # ReAct / REST / 命令路由 / worker 都经此),故在此开一个 span 即覆盖全路径,把 bespoke
+    # trace_id 作为属性带上以便在 OTel 后端关联。GALAXY_OTEL_ENABLED=1 才真正启用;未装
+    # opentelemetry 或未开时是纯 no-op、零开销。
+    from core.otel_tracing import record_exception, set_attribute, start_span
+
+    with start_span(
+        "galaxy.node.invoke",
+        {
+            "galaxy.trace_id": envelope.trace_id,
+            "galaxy.task_id": envelope.task_id,
+            "galaxy.node_id": node_id,
+            "galaxy.action": action,
+            "galaxy.invocation_source": getattr(invocation_source, "value", str(invocation_source)),
+        },
+    ) as _span:
+        try:
+            _res = await get_unified_node_executor().execute(envelope)
+            set_attribute(_span, "galaxy.success", bool(getattr(_res, "success", False)))
+            return _res
+        except Exception as _exc:  # noqa: BLE001 — 追踪不改变异常传播语义
+            record_exception(_span, _exc)
+            raise

--- a/core/otel_tracing.py
+++ b/core/otel_tracing.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+core/otel_tracing.py
+====================
+Feature ③ of the reliability set — OpenTelemetry distributed tracing, wrapped so
+it is **safe by default** and **zero-cost when off**.
+
+Why a wrapper (and not raw OpenTelemetry calls)
+-----------------------------------------------
+Today ``trace_id`` is a bespoke string threaded through envelopes
+(node_invocation / canonical_task / aip_v3), correlated only by string match.
+It never enters a real span context, so it can't be viewed in an OTel backend
+(Jaeger / Tempo / any OTLP collector).
+
+OpenTelemetry is intentionally **not** a hard dependency of Galaxy — adding a
+heavy tracing SDK to the default install risks breaking constrained/offline
+setups. So this module:
+
+- imports OpenTelemetry **lazily**, inside try/except;
+- is a **no-op** (yields ``None`` spans, never raises) when OTel is not
+  installed OR ``GALAXY_OTEL_ENABLED`` is off (the default);
+- keeps the existing bespoke ``trace_id`` as a first-class span attribute
+  (``galaxy.trace_id``) so both correlation schemes line up.
+
+This means callers can wrap the hot path in ``with start_span(...)`` **always**,
+with no runtime cost and no import risk when tracing is disabled.
+
+Enable
+------
+``GALAXY_OTEL_ENABLED=1`` turns it on (requires ``opentelemetry-sdk`` installed).
+Exporter selection:
+- ``GALAXY_OTEL_EXPORTER=otlp`` + ``OTEL_EXPORTER_OTLP_ENDPOINT`` → OTLP export.
+- ``GALAXY_OTEL_EXPORTER=console`` → console span exporter (debug).
+- unset / anything else → provider with no exporter (spans created, not shipped;
+  still useful for in-process assertions and future exporters).
+
+Public API
+----------
+otel_enabled() -> bool
+init_tracing() -> bool          # idempotent; True when a real tracer is active
+is_active() -> bool
+start_span(name, attributes=None) -> contextmanager  # yields span or None
+set_attribute(span, key, value) -> None              # no-op if span is None
+record_exception(span, exc) -> None                  # no-op if span is None
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Galaxy.OtelTracing")
+
+OTEL_TRACING_AUTHORITY: str = "OTEL_TRACING::NOOP_SAFE_LAZY_OPENTELEMETRY_V1"
+
+# Process-level tracer state. `_tracer` is the OpenTelemetry Tracer (or a
+# test-injected stand-in); `_active` gates all span work.
+_state: Dict[str, Any] = {"initialized": False, "active": False, "tracer": None}
+
+
+def otel_enabled() -> bool:
+    """Whether OTel tracing is requested via env (default OFF)."""
+    return str(os.getenv("GALAXY_OTEL_ENABLED", "")).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _build_exporter():
+    """Return a span processor for the configured exporter, or None."""
+    choice = str(os.getenv("GALAXY_OTEL_EXPORTER", "")).strip().lower()
+    try:
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+    except Exception:
+        return None
+    if choice == "otlp":
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+            return BatchSpanProcessor(OTLPSpanExporter())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("OTLP exporter unavailable (%s); spans created but not shipped", exc)
+            return None
+    if choice == "console":
+        try:
+            from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+            return SimpleSpanProcessor(ConsoleSpanExporter())
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+def init_tracing() -> bool:
+    """Initialise the tracer provider once. Returns True iff a real tracer is active.
+
+    Idempotent and never raises. When OTel is absent or ``GALAXY_OTEL_ENABLED`` is
+    off, leaves the module in no-op mode and returns False.
+    """
+    if _state["initialized"]:
+        return bool(_state["active"])
+    _state["initialized"] = True
+    if not otel_enabled():
+        return False
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+
+        provider = TracerProvider(
+            resource=Resource.create(
+                {
+                    "service.name": os.getenv("GALAXY_OTEL_SERVICE_NAME", "galaxy-v2"),
+                    "service.namespace": "galaxy",
+                }
+            )
+        )
+        processor = _build_exporter()
+        if processor is not None:
+            provider.add_span_processor(processor)
+        trace.set_tracer_provider(provider)
+        _state["tracer"] = trace.get_tracer("galaxy.v2")
+        _state["active"] = True
+        logger.info("OpenTelemetry tracing active (exporter=%s)", os.getenv("GALAXY_OTEL_EXPORTER", "none"))
+    except Exception as exc:  # noqa: BLE001 — 观测增强绝不影响主流程
+        logger.warning("OpenTelemetry unavailable, tracing stays no-op: %s", exc)
+        _state["active"] = False
+    return bool(_state["active"])
+
+
+def is_active() -> bool:
+    """True when a real tracer is installed and tracing is on."""
+    return bool(_state["active"] and _state["tracer"] is not None)
+
+
+@contextmanager
+def start_span(name: str, attributes: Optional[Dict[str, Any]] = None):
+    """Context manager that starts a span, or a zero-cost no-op yielding ``None``.
+
+    Safe to wrap the hot path unconditionally: when tracing is off/absent this is
+    a bare ``yield None`` with no allocation of OTel objects.
+    """
+    # Lazy init on first use so callers don't have to remember to init_tracing().
+    if not _state["initialized"]:
+        init_tracing()
+    tracer = _state["tracer"] if _state["active"] else None
+    if tracer is None:
+        yield None
+        return
+    # 只保护【建 span 本身】的失败(OTel 内部异常 → 退化成 no-op),绝不吞掉调用方
+    # 主体的异常——主体异常必须原样通过 OTel 自己的 span 上下文传播(OTel 会自动记录
+    # 并重抛),否则会破坏 contextmanager"只 yield 一次"的契约、也会掩盖真实错误。
+    try:
+        cm = tracer.start_as_current_span(name)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("start_span create suppressed: %s", exc)
+        yield None
+        return
+    with cm as span:
+        if attributes:
+            for k, v in attributes.items():
+                try:
+                    span.set_attribute(k, v)
+                except Exception:  # noqa: BLE001
+                    pass
+        yield span
+
+
+def set_attribute(span: Any, key: str, value: Any) -> None:
+    """Set a span attribute; no-op when span is None or setting fails."""
+    if span is None:
+        return
+    try:
+        span.set_attribute(key, value)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def record_exception(span: Any, exc: BaseException) -> None:
+    """Record an exception on the span; no-op when span is None."""
+    if span is None:
+        return
+    try:
+        span.record_exception(exc)
+        try:
+            from opentelemetry.trace import Status, StatusCode
+
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+        except Exception:  # noqa: BLE001
+            pass
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _reset_for_test() -> None:
+    """Test hook: clear tracer state so a test can re-init or inject a fake."""
+    _state["initialized"] = False
+    _state["active"] = False
+    _state["tracer"] = None
+
+
+def _install_tracer_for_test(tracer: Any) -> None:
+    """Test hook: inject a stand-in tracer and mark active (bypasses OTel import)."""
+    _state["initialized"] = True
+    _state["active"] = True
+    _state["tracer"] = tracer
+
+
+__all__ = [
+    "OTEL_TRACING_AUTHORITY",
+    "otel_enabled",
+    "init_tracing",
+    "is_active",
+    "start_span",
+    "set_attribute",
+    "record_exception",
+]

--- a/core/routes/chat.py
+++ b/core/routes/chat.py
@@ -629,10 +629,11 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                 on_delta=lambda t: frames.put_nowait(("delta", t)),
                 on_reset=lambda: frames.put_nowait(("reset", None)),
             )
-            # 文字/语音锁步:每句在【被念出的那一刻】才逐句上屏,文字与语音同刻对齐。
-            # reveal_q 收集"刚开口念的句子文本";speaker 的 on_sentence_start 往里塞。
-            # GALAXY_TEXT_VOICE_LOCKSTEP=0 可关(桌面默认开);关或无 TTS 时退回
-            # "文字逐 token 快流、语音按句松散跟随"。
+            # 文字/语音锁步:开启时每句在【被念出的那一刻】才逐句上屏,文字与语音
+            # 同刻对齐——但代价是面板文字变成"一句一句蹦"、不再逐字平滑(真机反馈"一大段
+            # 蹦一段又一段")。所有者要的是"实时语音+字符一起"= 文字逐 token 平滑流、
+            # 语音按句松散跟随,正是【关闭锁步】的行为(下面 else 分支逐字 yield + 并行
+            # speaker.feed)。故默认【关】;想要严格逐句同步再设 GALAXY_TEXT_VOICE_LOCKSTEP=1。
             reveal_q: "asyncio.Queue" = asyncio.Queue()
 
             # 边生成边念:能建则建;建成后在请求上下文里抑制收尾的整段重念。
@@ -650,7 +651,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             except Exception as exc:  # noqa: BLE001
                 logger.debug("增量朗读建立失败(退回整段): %s", exc)
 
-            _lockstep = speaker is not None and os.environ.get("GALAXY_TEXT_VOICE_LOCKSTEP", "1").strip().lower() in (
+            _lockstep = speaker is not None and os.environ.get("GALAXY_TEXT_VOICE_LOCKSTEP", "0").strip().lower() in (
                 "1",
                 "true",
                 "yes",

--- a/core/routes/config.py
+++ b/core/routes/config.py
@@ -648,33 +648,38 @@ async def update_config(req: ConfigUpdateRequest):
             detail=f"Unknown config key(s): {', '.join(unknown_keys)}",
         )
 
+    # ── 计算最终值(url 补协议头),此刻【先不碰 os.environ】────────────────
+    # 真机复现过:用户填 url 类字段(OLLAMA_URL/ONEAPI_URL 等)时只填 host:port
+    # (如 "localhost:11434")没带协议头,原样落盘后 httpx 才炸「missing 'http://'
+    # protocol」。在写入这一步就补全,不指望每个消费端自己校验。
+    final: Dict[str, str] = {}
     for key, value in req.config.items():
         value = str(value)
-        # 真机复现过:用户在面板填 url 类字段(OLLAMA_URL/ONEAPI_URL 等)时只填了
-        # host:port(如 "localhost:11434"),没带协议头。这个值原样落进 .env,
-        # 直到真正发起请求时 httpx 才会炸「missing 'http://' or 'https://'
-        # protocol」——用户看到的只是笼统的"LLM 调用失败"。在写入这一步就
-        # 补全协议头,而不是指望每个读它的消费端都记得自己校验。
         if CONFIG_SCHEMA[key]["type"] == "url":
             stripped = value.strip()
             if stripped and not stripped.startswith(("http://", "https://")):
                 value = f"http://{stripped}"
-        os.environ[key] = value
+        final[key] = value
 
-    # 密钥收敛到【唯一密钥库】:API key / token 等敏感项走 ConfigService.set_secret
-    # → runtime/secrets.env(canonical 密钥库),不再明文落进 .env。
-    # 关键的重启正确性:main.py 顶部先把 .env 灌进 os.environ,config_preflight 再以
-    # `key not in os.environ` 的门读 secrets.env——所以 .env 里若残留同名旧值会【盖住】
-    # secrets.env(正是历史上"重启丢 key"的根因)。因此:成功写进 secrets.env 的密钥
-    # 必须从 .env 排除(_write_env_file 全量重写时自动清掉旧明文行);写 secrets.env 失败
-    # 的仍回落 .env,不丢持久化。os.environ 上面已设,当次即时生效。
+    # ── 【先落盘、成功才应用到 os.environ】────────────────────────────────
+    # 修复"显示已配置、却又保存失败"的自相矛盾:此前是先写 os.environ(前端 GET
+    # /api/config 据 os.getenv 判定"已配置")、再写盘,一旦写盘失败(Windows 上
+    # .env 被杀毒/编辑器占用、目录只读),就成了"明明已配置、却报保存失败",
+    # 用户根本分不清到底存没存、生没生效。现在颠倒顺序:
+    #   落盘成功 → 才把值应用进 os.environ(当次即时生效)、"已配置"随之如实为真;
+    #   落盘失败 → os.environ 原封不动、"已配置"保持原状,错误如实说明原因。
+    # 于是"已配置"与"保存成功"永远一致:存了就是存了、生效了;没存就没存、没生效。
+    #
+    # 密钥收敛到唯一密钥库:敏感项走 ConfigService.set_secret → runtime/secrets.env,
+    # 不明文落 .env(否则重启时 .env 旧值会盖住 secrets.env,历史"重启丢 key"根因);
+    # 写 secrets.env 失败的密钥回落 .env(不丢持久化)。
     _secrets_persisted: set = set()
     try:
         from core.config_schema import classify_key as _classify
         from core.config_service import ConfigService as _CS
 
         _cs = None
-        for _k, _v in req.config.items():
+        for _k, _v in final.items():
             if _classify(_k) == "secret" and str(_v).strip():
                 try:
                     if _cs is None:
@@ -686,24 +691,31 @@ async def update_config(req: ConfigUpdateRequest):
     except Exception as exc:  # noqa: BLE001 — ConfigService 不可用 → 全部回落 .env
         logger.debug("密钥收敛不可用(降级为 .env 持久化): %s", exc)
 
+    try:
+        _write_env_file_with(final, exclude=_secrets_persisted)
+    except OSError as exc:
+        # 落盘失败 → os.environ 一个字没动,"已配置"如实保持原状,不制造矛盾。
+        raise HTTPException(
+            status_code=500,
+            detail=f"写入 .env 失败: {exc}(检查文件是否被占用/只读，或目录权限）；本次未改动任何配置",
+        ) from exc
+
+    # ── 落盘成功 → 应用到 os.environ(当次即时生效),并做即时联动 ──────────
+    os.environ.update(final)
+
     # 模型选择收敛到唯一门:model_catalog.save_tier 把【档位 + 主脑】写进同一条
-    # 记录(runtime/model_state.json)并派生 OLLAMA_MODEL —— 不再各写 .galaxy_model /
-    # .galaxy_tier / OLLAMA_MODEL 三处。按模型反推档位并联动,消除档位↔主脑分叉
-    # (否则 active_effective_io() 读的档位与实际主脑不符,modality_bridge 会误判听/说通路)。
-    # 上面 .env 里也已写了 OLLAMA_MODEL(env 层持久化,归配置域);二者一致。
-    if "OLLAMA_MODEL" in req.config:
+    # 记录(runtime/model_state.json)并派生 OLLAMA_MODEL,按模型反推档位并联动。
+    if "OLLAMA_MODEL" in final:
         try:
             from core import model_catalog as _mc
 
-            _tag = req.config["OLLAMA_MODEL"]
+            _tag = final["OLLAMA_MODEL"]
             _mc.save_tier(_mc.infer_tier_from_model(_tag), main_brain=_tag)
         except Exception as exc:  # noqa: BLE001
             logger.debug("模型状态联动写入失败(非致命): %s", exc)
 
-    # 自发在场开关改动 → 立刻生效(启动/停止常驻循环),不必重启。GALAXY_SPEAK/
-    # TTS_STREAMING/NATIVE_AUDIO 都是每次用时现读 os.environ,上面已写入即时生效,
-    # 唯独 ambient 循环是常驻后台任务,需在这里显式拉起/收起。
-    if "GALAXY_AMBIENT_LOOP" in req.config:
+    # 自发在场开关改动 → 立刻生效(启动/停止常驻循环),不必重启。
+    if "GALAXY_AMBIENT_LOOP" in final:
         try:
             from core.ambient_attention_loop import ambient_loop_enabled, get_ambient_loop
 
@@ -714,18 +726,6 @@ async def update_config(req: ConfigUpdateRequest):
                 await _loop.stop()
         except Exception as exc:  # noqa: BLE001
             logger.debug("ambient 循环即时开关失败(非致命): %s", exc)
-
-    # 修复:_write_env_file() 之前完全没有 try/except——Windows 上 .env 若被
-    # 杀毒软件/编辑器占用锁定,或所在目录权限不足,write_text() 会抛
-    # PermissionError,FastAPI 缺省转成裸 500、无任何 detail,前端只能显示
-    # "保存失败"四个字,排查全靠猜。这里显式捕获并把真实原因透传出去。
-    try:
-        _write_env_file(exclude=_secrets_persisted)
-    except OSError as exc:
-        raise HTTPException(
-            status_code=500,
-            detail=f"写入 .env 失败: {exc}(检查文件是否被占用/只读，或目录权限）",
-        ) from exc
 
     # UnifiedConfig 是进程启动时读一次 .env 就不再变的单例("Dashboard 优先级"
     # 那一层实际读的是它)——本函数只写了 os.environ/.env,从没告诉过它内容
@@ -742,7 +742,7 @@ async def update_config(req: ConfigUpdateRequest):
 
     # 若改动涉及模型 API（llm 类），热刷新 LLM 路由器，让新填的 key 即时生效（无需重启）。
     refreshed = None
-    if any(CONFIG_SCHEMA.get(k, {}).get("category") == "llm" for k in req.config):
+    if any(CONFIG_SCHEMA.get(k, {}).get("category") == "llm" for k in final):
         try:
             from core.multi_llm_router import refresh_llm_router
 
@@ -750,7 +750,7 @@ async def update_config(req: ConfigUpdateRequest):
         except Exception:
             refreshed = None
 
-    return {"success": True, "updated": list(req.config.keys()), "router_refreshed": refreshed}
+    return {"success": True, "updated": list(final.keys()), "router_refreshed": refreshed}
 
 
 @router.post("/save")
@@ -824,7 +824,15 @@ async def probe_config_urls(req: ProbeRequest):
 
 
 def _write_env_file(exclude=None):
-    """将所有【非空】配置写入 .env 文件。
+    """将所有【非空】配置写入 .env 文件(读 os.environ 现值)。"""
+    return _write_env_file_with(None, exclude=exclude)
+
+
+def _write_env_file_with(overrides=None, exclude=None):
+    """将所有【非空】配置写入 .env 文件;overrides 里的键用其新值(而非 os.environ)。
+
+    overrides: {key: 新值} —— 允许在【尚未写入 os.environ】时就把新值落盘,从而做到
+    "先落盘、成功再应用 os.environ"(见 update_config)。None 时退化为读 os.environ 现值。
 
     exclude: 已写进 canonical 密钥库(runtime/secrets.env)的密钥名集合——这些
     不再明文落进 .env(否则重启时 .env 旧值会盖住 secrets.env),全量重写即清掉旧行。
@@ -843,10 +851,11 @@ def _write_env_file(exclude=None):
     # 按类别分组
     current_category = ""
     _exclude = exclude or set()
+    _overrides = overrides or {}
     for key, meta in sorted(CONFIG_SCHEMA.items(), key=lambda x: x[1]["category"]):
         if key in _exclude:
             continue  # 已入 canonical 密钥库,不再明文写 .env
-        value = os.environ.get(key, meta["default"])
+        value = _overrides.get(key, os.environ.get(key, meta["default"]))
         if not str(value).strip():
             continue  # 空值不落盘——否则会把代码默认值顶掉
         if meta["category"] != current_category:

--- a/core/runtime_restart_recovery.py
+++ b/core/runtime_restart_recovery.py
@@ -429,6 +429,9 @@ class RuntimeRecoveryReport:
     # Holds a TaskContinuityReport instance when the InFlightTaskContinuityContract
     # module is available.  None if the module could not be loaded.
     continuity_report: Optional[Any] = None
+    # Feature ①: 可持久化 DAG 续跑视图(GALAXY_DURABLE_EXEC 开时填充;否则 None)。
+    # 记录重启后 task graph 从盘上重建出的 completed/resumable/blocked 分类。
+    task_graph_resume: Optional[Dict[str, Any]] = None
     errors: List[str] = field(default_factory=list)
     non_goals: List[str] = field(default_factory=list)
 
@@ -466,6 +469,7 @@ class RuntimeRecoveryReport:
             "durable_truth_converged": self.durable_truth_converged,
             "participants_consolidated": dict(self.participants_consolidated),
             "result_continuity_guard_active": self.result_continuity_guard_active,
+            "task_graph_resume": self.task_graph_resume,
             "errors": list(self.errors),
             "non_goals": list(self.non_goals),
         }
@@ -767,6 +771,32 @@ class RuntimeRestartRecoveryCoordinator:
             err = f"In-flight task continuity evaluation failed: {exc}"
             logger.warning("RuntimeRestartRecovery: %s", err)
             report.errors.append(err)
+
+        # ----------------------------------------------------------------
+        # Step 12: Feature ① — 可持久化 DAG 续跑视图。
+        #          仅在 GALAXY_DURABLE_EXEC 开时:task graph 单例在构造时已从盘上
+        #          重建(完成步/未完成步都在),这里把它的续跑分类(completed /
+        #          resumable / blocked)记进报告并落日志——把"步级检查点"正式接入
+        #          规范的重启恢复流程。实际重派由启动序列注入 dispatch_fn 调用
+        #          TaskGraphRuntime.resume_pending_dispatch 完成(见其文档)。
+        # ----------------------------------------------------------------
+        try:
+            from core.task_graph_runtime import durable_exec_enabled, get_task_graph_runtime
+
+            if durable_exec_enabled():
+                snap = get_task_graph_runtime().resume_snapshot()
+                report.task_graph_resume = snap
+                logger.info(
+                    "RuntimeRestartRecovery: 可持久化 DAG 续跑 — 共 %d 节点,"
+                    "已完成 %d、可续跑 %d、依赖阻塞 %d(state=%s)",
+                    snap.get("total_nodes", 0),
+                    len(snap.get("completed", [])),
+                    len(snap.get("resumable", [])),
+                    len(snap.get("blocked", [])),
+                    snap.get("state_path", ""),
+                )
+        except Exception as exc:  # noqa: BLE001 — 续跑视图失败不影响其余恢复
+            logger.debug("durable task-graph resume snapshot skipped: %s", exc)
 
         report.completed_at = time.time()
         logger.info(

--- a/core/startup.py
+++ b/core/startup.py
@@ -251,6 +251,17 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
     results = {}
     t0 = time.monotonic()
 
+    # Step 0a: 观测追踪(OpenTelemetry)一次性初始化 —— 默认关(GALAXY_OTEL_ENABLED=1
+    # 才启用)、未装 opentelemetry 时纯 no-op,绝不影响启动。放在最前,使随后所有
+    # span 都在 provider 就绪后创建。
+    try:
+        from core.otel_tracing import init_tracing
+
+        results["otel_tracing_active"] = init_tracing()
+    except Exception as _e:  # noqa: BLE001 — 观测初始化绝不阻断启动
+        logger.debug("OTel 追踪初始化跳过: %s", _e)
+        results["otel_tracing_active"] = False
+
     # Step 0: pip 依赖可用性检查
     try:
         dep_report = _check_pip_dependencies()

--- a/core/system_orchestrator.py
+++ b/core/system_orchestrator.py
@@ -606,7 +606,15 @@ class SystemOrchestrator:
                     status=PhaseStatus.DEGRADED,
                     detail="Electron GUI skipped (npm not in PATH — Node.js installed but npm missing)",
                 )
-            logger.warning("[启动·桌面壳] Electron 依赖缺失或不完整 -- running npm install ...")
+            # 首次(或依赖不完整)先【安静地装】,不要在装之前就抛一条像"报错"的
+            # WARNING —— 真机反馈:启动一上来先喊"依赖缺失或不完整"、把用户吓一跳,
+            # 紧接着 npm 却报 "up to date"(其实好好的)。这里降为中性 INFO、措辞改成
+            # "正在准备/补齐",只有 npm install 真失败(下面的分支)才升级为告警。
+            _first_install = not os.path.isdir(node_modules)
+            logger.info(
+                "[启动·桌面壳] %s桌面前端依赖(npm install，首次可能数分钟)…",
+                "首次准备" if _first_install else "补齐",
+            )
             try:
                 # Windows 子进程默认按 cp1252 解码,npm 的 UTF-8 输出会让读线程
                 # UnicodeDecodeError 崩掉、stderr 变 None——显式 UTF-8 + replace。

--- a/core/task_graph_runtime.py
+++ b/core/task_graph_runtime.py
@@ -115,7 +115,11 @@ Class:
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import tempfile
+import threading
 import time
 import uuid
 from collections import deque
@@ -124,6 +128,24 @@ from enum import Enum
 from typing import Any, Deque, Dict, List, Optional, Sequence
 
 logger = logging.getLogger("Galaxy.TaskGraphRuntime")
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def durable_exec_enabled() -> bool:
+    """Feature ①: 是否启用【DAG 步级检查点 + 断点续跑】的可持久化。默认关。
+
+    仅在跨设备分布式编排(本就 opt-in)下才有意义;开启后 task graph 的每步状态变更
+    会原子落盘,进程重启即从盘上重建、跳过已完成步、把未完成步交给恢复协调器重派。
+    单机默认关 → 零行为变化、零额外 IO。
+    """
+    return str(os.getenv("GALAXY_DURABLE_EXEC", "")).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _task_graph_state_path() -> str:
+    p = str(os.getenv("GALAXY_TASK_GRAPH_STATE_PATH", "")).strip()
+    return p or os.path.join(_REPO_ROOT, "runtime", "task_graph_state.json")
+
 
 __all__ = [
     # Authority sentinels
@@ -253,6 +275,32 @@ class GraphNodeState(str, Enum):
     CANCELLED = "cancelled"
     DEGRADED = "degraded"
     REPLAYED = "replayed"
+
+
+# Feature ① 续跑分类:
+#  - 终态:已了结,重启后【跳过】,不重派。
+#  - 已执行态:拿到结果、等定案,别重派(否则重复副作用)。
+#  - 待执行态:尚未真正执行,重启后可重新派发(RUNNING=崩时在途,靠 ② 幂等守卫防重复)。
+_TERMINAL_GRAPH_STATES = frozenset(
+    {
+        GraphNodeState.COMPLETED,
+        GraphNodeState.FAILED,
+        GraphNodeState.CANCELLED,
+        GraphNodeState.DEGRADED,
+        GraphNodeState.REPLAYED,
+    }
+)
+_EXECUTED_GRAPH_STATES = frozenset({GraphNodeState.RESULT, GraphNodeState.PARTIAL_RESULT})
+_PENDING_GRAPH_STATES = frozenset(
+    {
+        GraphNodeState.QUEUED,
+        GraphNodeState.ADMITTED,
+        GraphNodeState.PLANNED,
+        GraphNodeState.ROUTED,
+        GraphNodeState.DISPATCH,
+        GraphNodeState.RUNNING,
+    }
+)
 
 
 class GraphEdgeKind(str, Enum):
@@ -391,6 +439,41 @@ class GraphNode:
             "metadata": dict(self.metadata),
         }
 
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "GraphNode":
+        """Rehydrate a ``GraphNode`` from :meth:`to_dict` output (durable resume)."""
+        def _state(v: str) -> GraphNodeState:
+            try:
+                return GraphNodeState(v)
+            except Exception:
+                return GraphNodeState.QUEUED
+
+        def _contrib(v: str) -> WorkflowContributorKind:
+            try:
+                return WorkflowContributorKind(v)
+            except Exception:
+                return WorkflowContributorKind.UNKNOWN
+
+        return cls(
+            node_id=str(d.get("node_id") or f"gn_{uuid.uuid4().hex[:16]}"),
+            task_id=str(d.get("task_id") or ""),
+            trace_id=str(d.get("trace_id") or ""),
+            session_id=str(d.get("session_id") or ""),
+            tool_name=str(d.get("tool_name") or ""),
+            device_id=str(d.get("device_id") or ""),
+            state=_state(str(d.get("state") or "queued")),
+            contributor=_contrib(str(d.get("contributor") or "unknown")),
+            depends_on=list(d.get("depends_on") or []),
+            queued_at=float(d.get("queued_at") or time.time()),
+            dispatch_at=d.get("dispatch_at"),
+            running_at=d.get("running_at"),
+            result_at=d.get("result_at"),
+            completed_at=d.get("completed_at"),
+            result_summary=str(d.get("result_summary") or ""),
+            error=str(d.get("error") or ""),
+            metadata=dict(d.get("metadata") or {}),
+        )
+
 
 @dataclass
 class GraphEdge:
@@ -431,6 +514,23 @@ class GraphEdge:
             "created_at": self.created_at,
             "metadata": dict(self.metadata),
         }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "GraphEdge":
+        """Rehydrate a ``GraphEdge`` from :meth:`to_dict` output (durable resume)."""
+        try:
+            kind = GraphEdgeKind(str(d.get("kind") or "dependency_edge"))
+        except Exception:
+            kind = GraphEdgeKind.DEPENDENCY
+        return cls(
+            edge_id=str(d.get("edge_id") or f"ge_{uuid.uuid4().hex[:12]}"),
+            kind=kind,
+            source_node_id=str(d.get("source_node_id") or ""),
+            target_node_id=str(d.get("target_node_id") or ""),
+            transport_path=str(d.get("transport_path") or ""),
+            created_at=float(d.get("created_at") or time.time()),
+            metadata=dict(d.get("metadata") or {}),
+        )
 
 
 @dataclass
@@ -743,6 +843,157 @@ class TaskGraphRuntime:
         self._fallback_records: Deque[FallbackRecord] = deque(maxlen=self._RING_BUFFER_SIZE)
         self._fanout_records: Deque[FanoutRecord] = deque(maxlen=self._RING_BUFFER_SIZE)
 
+        # Feature ①: DAG 步级检查点(默认关)。开启则每次 register/transition 后原子落盘,
+        # 构造时从盘上重建 → 支持"重启即续跑"。持久化只在 durable-exec 开时发生。
+        self._durable: bool = durable_exec_enabled()
+        self._state_path: str = _task_graph_state_path()
+        self._persist_lock = threading.Lock()
+        if self._durable:
+            try:
+                os.makedirs(os.path.dirname(os.path.abspath(self._state_path)), exist_ok=True)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("task_graph_runtime: 无法创建状态目录: %s", exc)
+            self._load_checkpoint()
+
+    # ── Durable checkpoint / resume (Feature ①) ──────────────────────────────
+
+    def _checkpoint(self) -> None:
+        """把当前 DAG(节点+边)原子落盘。仅 durable-exec 开时生效;失败不影响主流程。"""
+        if not self._durable:
+            return
+        with self._persist_lock:
+            try:
+                payload = json.dumps(
+                    {
+                        "schema": "task_graph_state_v1",
+                        "saved_at": time.time(),
+                        "nodes": [n.to_dict() for n in self._nodes.values()],
+                        "edges": [e.to_dict() for e in self._edges.values()],
+                    },
+                    ensure_ascii=False,
+                )
+                state_dir = os.path.dirname(os.path.abspath(self._state_path))
+                fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                        fh.write(payload)
+                    os.replace(tmp_path, self._state_path)
+                except Exception:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+                    raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("task_graph_runtime: 检查点落盘失败 %s: %s", self._state_path, exc)
+
+    def _load_checkpoint(self) -> None:
+        """从盘上重建 DAG(进程重启后的续跑基础)。best-effort。"""
+        if not os.path.exists(self._state_path):
+            return
+        try:
+            with open(self._state_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("task_graph_runtime: 读取检查点失败 %s: %s", self._state_path, exc)
+            return
+        n_loaded = 0
+        for nd in data.get("nodes", []) or []:
+            try:
+                node = GraphNode.from_dict(nd)
+                if not node.task_id:
+                    continue
+                self._nodes[node.task_id] = node
+                self._nodes_by_node_id[node.node_id] = node
+                n_loaded += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("task_graph_runtime: 跳过损坏节点记录: %s", exc)
+        for ed in data.get("edges", []) or []:
+            try:
+                edge = GraphEdge.from_dict(ed) if hasattr(GraphEdge, "from_dict") else None
+                if edge is not None and edge.edge_id:
+                    self._edges[edge.edge_id] = edge
+            except Exception:  # noqa: BLE001
+                pass
+        if n_loaded:
+            logger.info("task_graph_runtime: 从检查点重建 %d 个节点(续跑基础) ← %s", n_loaded, self._state_path)
+
+    def completed_task_ids(self) -> List[str]:
+        """已到终态且成功(COMPLETED)的 task_id —— 续跑时应跳过。"""
+        return [tid for tid, n in self._nodes.items() if n.state == GraphNodeState.COMPLETED]
+
+    def resumable_nodes(self) -> List[GraphNode]:
+        """重启后【应重新派发】的节点:处于待执行态、且其所有依赖都已 COMPLETED。
+
+        终态/已执行态节点不返回(不重复副作用);依赖未满足的待执行节点暂不返回
+        (等依赖完成后的下一轮再取)。RUNNING(崩时在途)也在内,靠 ② 派发幂等守卫
+        保证重派不会二次触发副作用。
+        """
+        completed = {tid for tid, n in self._nodes.items() if n.state == GraphNodeState.COMPLETED}
+        out: List[GraphNode] = []
+        for node in self._nodes.values():
+            if node.state not in _PENDING_GRAPH_STATES:
+                continue
+            if all(dep in completed for dep in (node.depends_on or [])):
+                out.append(node)
+        return out
+
+    def resume_snapshot(self) -> Dict[str, Any]:
+        """续跑视图:已完成 / 可重派 / 阻塞(依赖未满足)/ 已执行待定案 —— 供恢复协调器
+        与操作台消费。"""
+        completed = self.completed_task_ids()
+        completed_set = set(completed)
+        resumable = [n.task_id for n in self.resumable_nodes()]
+        resumable_set = set(resumable)
+        blocked = [
+            n.task_id
+            for n in self._nodes.values()
+            if n.state in _PENDING_GRAPH_STATES and n.task_id not in resumable_set
+        ]
+        executed_pending = [n.task_id for n in self._nodes.values() if n.state in _EXECUTED_GRAPH_STATES]
+        terminal_failed = [
+            n.task_id
+            for n in self._nodes.values()
+            if n.state in _TERMINAL_GRAPH_STATES and n.task_id not in completed_set
+        ]
+        return {
+            "state_path": self._state_path,
+            "durable": self._durable,
+            "total_nodes": len(self._nodes),
+            "completed": completed,
+            "resumable": resumable,
+            "blocked": blocked,
+            "executed_pending_finalization": executed_pending,
+            "terminal_non_success": terminal_failed,
+        }
+
+    async def resume_pending_dispatch(self, dispatch_fn) -> Dict[str, Any]:
+        """重启续跑的执行入口:对每个可续跑节点调用 ``dispatch_fn(node)`` 重新派发,
+        并把节点置回 DISPATCH。dispatch_fn 由恢复协调器/主脑注入(它知道怎么真正派发)。
+
+        - 只处理 resumable_nodes()(待执行态 + 依赖已满足);已完成/已执行不碰。
+        - 重派本身靠 ② 派发幂等守卫防二次副作用(RUNNING 在途节点尤其依赖它)。
+        - dispatch_fn 可为普通函数或协程函数;单个失败不拖垮其余。
+        返回 {resumed:[task_id], failed:[(task_id, err)]}。
+        """
+        import inspect
+
+        resumed: List[str] = []
+        failed: List[Any] = []
+        for node in self.resumable_nodes():
+            try:
+                res = dispatch_fn(node)
+                if inspect.isawaitable(res):
+                    await res
+                self.transition(node.task_id, GraphNodeState.DISPATCH, reason="resumed_after_restart")
+                resumed.append(node.task_id)
+            except Exception as exc:  # noqa: BLE001 — 单节点重派失败不影响其余
+                logger.warning("task_graph_runtime: 续跑重派失败 task=%s: %s", node.task_id, exc)
+                failed.append([node.task_id, str(exc)])
+        if resumed:
+            logger.info("task_graph_runtime: 重启续跑重派 %d 个节点: %s", len(resumed), resumed)
+        return {"resumed": resumed, "failed": failed}
+
     # ── Node management ──────────────────────────────────────────────────────
 
     def register_node(self, node: GraphNode) -> GraphNode:
@@ -775,6 +1026,7 @@ class TaskGraphRuntime:
             node.task_id,
             node.state.value,
         )
+        self._checkpoint()  # Feature ①: 新节点入图即落盘(含 depends_on,续跑基础)
         return node
 
     def register_node_raw(
@@ -911,6 +1163,7 @@ class TaskGraphRuntime:
             new_state.value,
             reason,
         )
+        self._checkpoint()  # Feature ①: 每步状态变更即落盘 → 重启可续跑(跳过已完成步)
         return node
 
     # ── Edge management ──────────────────────────────────────────────────────

--- a/core/worker_runtime.py
+++ b/core/worker_runtime.py
@@ -73,6 +73,36 @@ class WorkerRuntime:
                 status="failed",
                 error="worker: 派发缺 node_id/action",
             )
+
+        # 派发侧幂等守卫(默认开):NATS 是 at-least-once,ack 在回调之后(nats_bus
+        # ._subscribe),worker 执行副作用后若崩在 ack 前 → JetStream 重投 → 同一动作
+        # (安卓点按/桌面控制)被执行第二次。这里在【执行副作用之前】用可持久化的
+        # 键(idempotency_key/task_id)判重:已派发过就直接短路返回"去重"结果、绝不
+        # 二次执行;否则悲观地先记键、再执行,只有执行器抛异常(没干净跑成)才回滚
+        # 键以便重投重试。GALAXY_DISPATCH_IDEMPOTENCY=0 可关。见
+        # core.durable_dispatch_idempotency 的完整语义说明。
+        from core.durable_dispatch_idempotency import (
+            already_dispatched,
+            dispatch_idempotency_enabled,
+            dispatch_key_for,
+            mark_dispatched,
+            unmark_dispatched,
+        )
+
+        _idem_on = dispatch_idempotency_enabled()
+        _idem_key = dispatch_key_for(msg) if _idem_on else ""
+        if _idem_key and already_dispatched(_idem_key):
+            logger.info("worker: 派发已执行过(幂等去重,不二次执行) task=%s key=%s", task_id, _idem_key)
+            return TaskResultMsg(
+                device_id=self.worker_id,
+                task_id=task_id,
+                trace_id=trace_id,
+                status="completed",
+                result={"deduplicated": True, "reason": "dispatch already executed (idempotency guard)"},
+            )
+        if _idem_key:
+            mark_dispatched(_idem_key)  # 悲观:执行前先记,重投永不二次触发副作用
+
         try:
             result = await invoke_node(
                 node_id,
@@ -97,6 +127,10 @@ class WorkerRuntime:
                 duration_ms=int(getattr(result, "duration_ms", 0)),
             )
         except Exception as exc:  # noqa: BLE001 — 单个任务失败不拖垮 worker
+            # 执行器抛异常 = 副作用没干净跑成 → 回滚幂等键,允许重投重试(不留"标了
+            # 已做、其实没做"的空洞)。节点【返回】失败(非抛异常)则视为已尝试、保留键。
+            if _idem_key:
+                unmark_dispatched(_idem_key)
             logger.warning("worker 执行派发失败 task=%s: %s", task_id, exc)
             return TaskResultMsg(
                 device_id=self.worker_id,

--- a/core/worker_runtime.py
+++ b/core/worker_runtime.py
@@ -103,42 +103,57 @@ class WorkerRuntime:
         if _idem_key:
             mark_dispatched(_idem_key)  # 悲观:执行前先记,重投永不二次触发副作用
 
-        try:
-            result = await invoke_node(
-                node_id,
-                action,
-                params,
-                invocation_source=InvocationSource.UNKNOWN,
-                task_id=task_id,
-                trace_id=trace_id,
-                ui_graph=ui_graph,
-            )
-            return TaskResultMsg(
-                device_id=self.worker_id,
-                task_id=task_id,
-                trace_id=trace_id,
-                status="completed" if getattr(result, "success", False) else "failed",
-                result=(
-                    getattr(result, "result", None)
-                    if isinstance(getattr(result, "result", None), dict)
-                    else {"value": getattr(result, "result", None)}
-                ),
-                error=getattr(result, "error", "") or "",
-                duration_ms=int(getattr(result, "duration_ms", 0)),
-            )
-        except Exception as exc:  # noqa: BLE001 — 单个任务失败不拖垮 worker
-            # 执行器抛异常 = 副作用没干净跑成 → 回滚幂等键,允许重投重试(不留"标了
-            # 已做、其实没做"的空洞)。节点【返回】失败(非抛异常)则视为已尝试、保留键。
-            if _idem_key:
-                unmark_dispatched(_idem_key)
-            logger.warning("worker 执行派发失败 task=%s: %s", task_id, exc)
-            return TaskResultMsg(
-                device_id=self.worker_id,
-                task_id=task_id,
-                trace_id=trace_id,
-                status="failed",
-                error=f"worker 执行异常: {exc}",
-            )
+        # 观测(默认零成本 no-op):给 worker 执行开一个 span,把 bespoke trace_id 作为
+        # 属性带上,使跨设备派发在 OTel 后端可关联。GALAXY_OTEL_ENABLED=1 才真正启用。
+        from core.otel_tracing import record_exception, start_span
+
+        with start_span(
+            "galaxy.worker.execute_dispatch",
+            {
+                "galaxy.trace_id": trace_id,
+                "galaxy.task_id": task_id,
+                "galaxy.node_id": node_id,
+                "galaxy.action": action,
+                "galaxy.worker_id": self.worker_id,
+            },
+        ) as _span:
+            try:
+                result = await invoke_node(
+                    node_id,
+                    action,
+                    params,
+                    invocation_source=InvocationSource.UNKNOWN,
+                    task_id=task_id,
+                    trace_id=trace_id,
+                    ui_graph=ui_graph,
+                )
+                return TaskResultMsg(
+                    device_id=self.worker_id,
+                    task_id=task_id,
+                    trace_id=trace_id,
+                    status="completed" if getattr(result, "success", False) else "failed",
+                    result=(
+                        getattr(result, "result", None)
+                        if isinstance(getattr(result, "result", None), dict)
+                        else {"value": getattr(result, "result", None)}
+                    ),
+                    error=getattr(result, "error", "") or "",
+                    duration_ms=int(getattr(result, "duration_ms", 0)),
+                )
+            except Exception as exc:  # noqa: BLE001 — 单个任务失败不拖垮 worker
+                # 执行器抛异常 = 副作用没干净跑成 → 回滚幂等键,允许重投重试(不留"标了
+                # 已做、其实没做"的空洞)。节点【返回】失败(非抛异常)则视为已尝试、保留键。
+                if _idem_key:
+                    unmark_dispatched(_idem_key)
+                record_exception(_span, exc)
+                logger.warning("worker 执行派发失败 task=%s: %s", task_id, exc)
+                return TaskResultMsg(
+                    device_id=self.worker_id,
+                    task_id=task_id,
+                    trace_id=trace_id,
+                    status="failed",
+                    error=f"worker 执行异常: {exc}",
+                )
 
     async def _on_dispatch(self, msg: Dict[str, Any]) -> None:
         """NATS 回调:执行派发并把结果回传主脑。"""

--- a/main.py
+++ b/main.py
@@ -800,7 +800,11 @@ def phase2_ensure_deps(env_status: dict) -> bool:
 
     # 2.6 Voice dependencies (REQUIRED)
     print_item("检查语音依赖...", "ok")
+    # sounddevice 是"对它说话它就回应"这条主路径(VoiceLoop→麦克风采集)的关键依赖,
+    # 之前这份清单漏了它 → 明明麦克风采集打不开,横幅却报"语音依赖 ✓",误导排查。
+    # 注:import sounddevice 会一并加载 PortAudio 原生库,故它失败也能兜住"PortAudio 缺失"。
     voice_deps = {
+        "sounddevice": "sounddevice",
         "pvporcupine": "pvporcupine",
         "webrtcvad": "webrtcvad",
         "faster_whisper": "faster-whisper",
@@ -813,7 +817,7 @@ def phase2_ensure_deps(env_status: dict) -> bool:
             voice_missing.append(pip_name)
 
     if not voice_missing:
-        print_item("语音依赖", "ok", "pvporcupine, webrtcvad, faster-whisper")
+        print_item("语音依赖", "ok", "sounddevice, pvporcupine, webrtcvad, faster-whisper")
     else:
         print_item(f"语音依赖缺失: {', '.join(voice_missing)}", "warn")
         print_item("正在自动安装语音依赖...", "ok")

--- a/tests/test_audio_ingest.py
+++ b/tests/test_audio_ingest.py
@@ -249,3 +249,56 @@ class TestAudioIngestPipeline:
         pipeline.add_callback(bad_cb)
         # Should not raise
         await pipeline._process_chunk(_make_loud())
+
+
+class _FakeSd:
+    """假 sounddevice:openable = 能通过 check_input_settings 的设备索引集合(None=系统默认)。"""
+
+    def __init__(self, devices, openable):
+        self._devices = devices  # list[dict(max_input_channels=...)]
+        self._openable = set(openable)
+
+    def query_devices(self):
+        return self._devices
+
+    def check_input_settings(self, device=None, samplerate=None, channels=None, dtype=None):
+        if device not in self._openable:
+            raise RuntimeError(f"device {device} cannot open")
+
+
+class TestResolveInputDevice:
+    """麦克风设备回退:默认设备被改/被拔时,自动挑一个能打开的输入设备。"""
+
+    def _devs(self):
+        # index 0: 输出设备(无输入); 1,2: 有输入通道
+        return [
+            {"max_input_channels": 0},
+            {"max_input_channels": 2},
+            {"max_input_channels": 1},
+        ]
+
+    def test_default_ok_keeps_default(self):
+        from core.multimodal.audio_ingest import _resolve_input_device
+
+        sd = _FakeSd(self._devs(), openable={None})  # 系统默认可用
+        assert _resolve_input_device(sd, None, 16000, 1) is None
+
+    def test_default_broken_falls_back_to_first_working_input(self):
+        from core.multimodal.audio_ingest import _resolve_input_device
+
+        # 默认(None)打不开,枚举里 index 1 可开 → 回退到 1(跳过无输入的 index 0)
+        sd = _FakeSd(self._devs(), openable={1, 2})
+        assert _resolve_input_device(sd, None, 16000, 1) == 1
+
+    def test_configured_device_preferred_when_openable(self):
+        from core.multimodal.audio_ingest import _resolve_input_device
+
+        sd = _FakeSd(self._devs(), openable={2})
+        assert _resolve_input_device(sd, 2, 16000, 1) == 2
+
+    def test_nothing_openable_returns_configured(self):
+        from core.multimodal.audio_ingest import _resolve_input_device
+
+        # 全打不开 → 返回 configured(None),维持原行为让 InputStream 抛错+打诊断
+        sd = _FakeSd(self._devs(), openable=set())
+        assert _resolve_input_device(sd, None, 16000, 1) is None

--- a/tests/test_config_secret_routing.py
+++ b/tests/test_config_secret_routing.py
@@ -42,6 +42,28 @@ def _iso(tmp_path, monkeypatch):
         os.environ.pop(k, None)
 
 
+def test_persist_failure_leaves_os_environ_untouched(monkeypatch):
+    """落盘失败 → os.environ 一个字不动,消除"显示已配置却又保存失败"的自相矛盾。
+
+    前端 GET /api/config 用 os.getenv 判"已配置";过去先写 os.environ 再落盘,落盘
+    失败就成了"已配置↔保存失败"并存、无法判断到底存没存。现在先落盘、成功才应用,
+    落盘失败则 os.environ 原封不动,"已配置"保持原状、错误如实报出。
+    """
+    from fastapi import HTTPException
+
+    def _boom(*a, **k):
+        raise OSError(".env locked by antivirus")
+
+    monkeypatch.setattr(cfg, "_write_env_file_with", _boom)
+    assert "GALAXY_SPEAK" not in os.environ
+    with pytest.raises(HTTPException) as ei:
+        _run({"GALAXY_SPEAK": "1"})
+    assert ei.value.status_code == 500
+    assert "未改动任何配置" in str(ei.value.detail)
+    # 关键:未改动 os.environ → "已配置"如实保持 false,不与"保存失败"矛盾
+    assert "GALAXY_SPEAK" not in os.environ
+
+
 def test_secret_goes_to_canonical_store_not_plaintext_dotenv():
     _run({"DEEPSEEK_API_KEY": "sk-secret-xyz", "GALAXY_SPEAK": "1"})
     # 密钥进 canonical 密钥库

--- a/tests/test_container_runtime_selection.py
+++ b/tests/test_container_runtime_selection.py
@@ -43,6 +43,14 @@ def test_both_installed_noninteractive_defaults_to_docker_first(monkeypatch):
     assert cr.resolve_runtime(interactive=False) == "docker"
 
 
+def test_prefer_recommended_puts_podman_first():
+    # 交互菜单的展示/默认把推荐运行时(Podman·更轻)排到最前,其余保持原序
+    assert cr._prefer_recommended(["docker", "podman"]) == ["podman", "docker"]
+    assert cr._prefer_recommended(["podman", "docker"]) == ["podman", "docker"]
+    assert cr._prefer_recommended(["docker"]) == ["docker"]  # 无 podman → 不变
+    assert cr._RECOMMENDED == "podman"
+
+
 def test_saved_choice_used_when_no_env(monkeypatch, tmp_path):
     monkeypatch.setattr(cr.shutil, "which", lambda name: f"/usr/bin/{name}" if name in ("docker", "podman") else None)
     (tmp_path / ".galaxy_runtime").write_text("podman", encoding="utf-8")

--- a/tests/test_durable_dispatch_idempotency.py
+++ b/tests/test_durable_dispatch_idempotency.py
@@ -1,0 +1,75 @@
+"""tests/test_durable_dispatch_idempotency.py
+================================================
+派发侧可持久化幂等库(core.durable_dispatch_idempotency):file-backed、原子写、
+有界、跨"重启"存活。区别于结果侧去重(durable_result_idempotency)——这个防的是
+【副作用被执行第二次】,不是结果被摄取第二次。
+"""
+
+from __future__ import annotations
+
+import core.durable_dispatch_idempotency as ddi
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _iso(tmp_path):
+    ddi.reset_durable_dispatch_id_store()
+    yield
+    ddi.reset_durable_dispatch_id_store()
+
+
+def test_add_contains_remove(tmp_path):
+    s = ddi.DurableDispatchIdSet(str(tmp_path / "d.json"))
+    assert s.add("k1") is True
+    assert s.add("k1") is False  # 重复
+    assert s.contains("k1")
+    assert s.remove("k1") is True
+    assert not s.contains("k1")
+
+
+def test_survives_restart(tmp_path):
+    p = str(tmp_path / "d.json")
+    ddi.DurableDispatchIdSet(p).add("kX")
+    # 新实例 = 模拟进程重启,应从盘上读回
+    assert ddi.DurableDispatchIdSet(p).contains("kX")
+
+
+def test_atomic_write_leaves_no_tmp(tmp_path):
+    s = ddi.DurableDispatchIdSet(str(tmp_path / "d.json"))
+    s.add("a")
+    s.add("b")
+    leftovers = [f for f in tmp_path.iterdir() if f.suffix == ".tmp"]
+    assert leftovers == []  # 写-临时-改名,不留 .tmp 残渣
+
+
+def test_bounded_eviction(tmp_path):
+    s = ddi.DurableDispatchIdSet(str(tmp_path / "d.json"), max_entries=3)
+    for k in ("a", "b", "c", "d"):
+        s.add(k)
+    assert s.size() == 3
+    assert not s.contains("a")  # 最旧被逐出
+    assert s.contains("d")
+
+
+def test_dispatch_key_priority():
+    assert ddi.dispatch_key_for({"idempotency_key": "ik", "task_id": "t"}) == "ik"
+    assert ddi.dispatch_key_for({"task_id": "t", "request_id": "r"}) == "t"
+    assert ddi.dispatch_key_for({"request_id": "r"}) == "r"
+    assert ddi.dispatch_key_for({}) == ""
+    assert ddi.dispatch_key_for(None) == ""
+
+
+def test_enabled_flag(monkeypatch):
+    monkeypatch.delenv("GALAXY_DISPATCH_IDEMPOTENCY", raising=False)
+    assert ddi.dispatch_idempotency_enabled() is True  # 默认开
+    monkeypatch.setenv("GALAXY_DISPATCH_IDEMPOTENCY", "0")
+    assert ddi.dispatch_idempotency_enabled() is False
+
+
+def test_helpers_noop_on_empty_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(ddi, "_DEFAULT_DISPATCH_ID_STORE_PATH", str(tmp_path / "d.json"))
+    assert ddi.already_dispatched("") is False
+    assert ddi.mark_dispatched("") is False
+    assert ddi.unmark_dispatched("") is False
+    assert ddi.mark_dispatched("real") is True
+    assert ddi.already_dispatched("real") is True

--- a/tests/test_electron_launch_guard.py
+++ b/tests/test_electron_launch_guard.py
@@ -81,3 +81,84 @@ class TestResolveGatewayPort:
         monkeypatch.delenv("GALAXY_UNIFIED_LAUNCHER_PORT", raising=False)
         # 默认配置里 unified_launcher 端口是 9000(见 core/port_config.py)。
         assert resolve_gateway_port() == 9000
+
+
+class _FakeShutil:
+    """假 shutil：按预置名单回答 which()。"""
+
+    def __init__(self, on_path):
+        self._on_path = set(on_path)
+
+    def which(self, name):
+        return f"C:\\fake\\{name}" if name in self._on_path else None
+
+
+class TestWindowsMsvcPrecheck:
+    """Windows MSVC 链接器预检：只认 cl.exe / 磁盘上真实存在的 link.exe，
+    杜绝"裸 link.exe 或组件已注册"的假阳性(真机踩过：放行后编译数分钟才崩)。"""
+
+    def test_cl_on_path_is_msvc(self):
+        from core.electron_launch_guard import _link_on_path_is_msvc
+
+        assert _link_on_path_is_msvc(_FakeShutil(["cl.exe"])) is True
+
+    def test_bare_link_on_path_not_trusted(self):
+        # 只有 link.exe(可能是非 MSVC 的)→ 不认，交由磁盘核实
+        from core.electron_launch_guard import _link_on_path_is_msvc
+
+        assert _link_on_path_is_msvc(_FakeShutil(["link.exe"])) is False
+        assert _link_on_path_is_msvc(_FakeShutil([])) is False
+
+    def test_present_true_when_cl_on_path(self, monkeypatch):
+        import core.electron_launch_guard as g
+
+        # cl 在 PATH → 无需 vswhere 即判就位（且不应调用 vswhere 探测）
+        monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: (_ for _ in ()).throw(AssertionError("不该调用")))
+        assert g._windows_msvc_present(_FakeShutil(["cl.exe"]), None) is True
+
+    def test_present_true_when_disk_linker_found(self, monkeypatch):
+        import core.electron_launch_guard as g
+
+        monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: r"C:\VS\VC\Tools\MSVC\14.4\bin\Hostx64\x64")
+        assert g._windows_msvc_present(_FakeShutil([]), None) is True
+
+    def test_present_false_when_registered_but_no_binary(self, monkeypatch):
+        import core.electron_launch_guard as g
+
+        # 组件"已注册"但磁盘无 link.exe → linker_dir 返回 None → 判为不就位
+        monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: None)
+        assert g._windows_msvc_present(_FakeShutil([]), None) is False
+
+    def test_prepend_path_dedups(self, monkeypatch):
+        # 用不含 os.pathsep 的目录名，使 dedup 逻辑在任意平台可测
+        # (真实 Windows 盘符路径含 ':'，但那里 pathsep 是 ';'，不会误切)
+        import core.electron_launch_guard as g
+
+        monkeypatch.setenv("PATH", "dirA" + os.pathsep + "dirB")
+        g._prepend_path("msvcbin")
+        assert os.environ["PATH"].startswith("msvcbin" + os.pathsep)
+        # 再插一次不重复
+        g._prepend_path("msvcbin")
+        assert os.environ["PATH"].count("msvcbin") == 1
+
+    def test_hint_injects_path_and_proceeds_when_linker_on_disk(self, monkeypatch):
+        import core.electron_launch_guard as g
+
+        monkeypatch.setenv("PATH", "C:\\a")
+        monkeypatch.setattr(g, "_link_on_path_is_msvc", lambda sh: False)
+        monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: r"C:\VS\...\Hostx64\x64")
+        # 磁盘有链接器 → 注入 PATH、返回 None（放行构建），不触发自动安装
+        monkeypatch.setattr(
+            g, "_windows_try_install_msvc", lambda *a: (_ for _ in ()).throw(AssertionError("不该装"))
+        )
+        assert g._windows_msvc_hint(_FakeShutil([]), None) is None
+        assert r"C:\VS\...\Hostx64\x64" in os.environ["PATH"]
+
+    def test_hint_returns_manual_msg_when_absent_and_autoinstall_off(self, monkeypatch):
+        import core.electron_launch_guard as g
+
+        monkeypatch.setenv("GALAXY_TAURI_AUTO_INSTALL_MSVC", "0")
+        monkeypatch.setattr(g, "_link_on_path_is_msvc", lambda sh: False)
+        monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: None)
+        out = g._windows_msvc_hint(_FakeShutil([]), None)
+        assert out is not None and "MSVC" in out and "BuildTools" in out

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -1,0 +1,105 @@
+"""tests/test_otel_tracing.py
+================================
+Feature ③ — OpenTelemetry 追踪包装:默认关、未装 opentelemetry 时是零成本 no-op、
+绝不抛异常;注入假 tracer 时能正确开 span/带属性/记异常。追踪失败绝不打断被追踪
+的真实工作。
+"""
+
+from __future__ import annotations
+
+import core.otel_tracing as ot
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _iso(monkeypatch):
+    monkeypatch.delenv("GALAXY_OTEL_ENABLED", raising=False)
+    ot._reset_for_test()
+    yield
+    ot._reset_for_test()
+
+
+def test_disabled_by_default_is_noop():
+    assert ot.otel_enabled() is False
+    assert ot.init_tracing() is False
+    assert ot.is_active() is False
+    with ot.start_span("x", {"a": 1}) as span:
+        assert span is None  # no-op → 无 span
+    # 对 None span 的辅助调用不抛
+    ot.set_attribute(None, "k", "v")
+    ot.record_exception(None, RuntimeError("nope"))
+
+
+def test_enabled_but_otel_absent_stays_noop(monkeypatch):
+    # 开了开关但环境里没装 opentelemetry(本沙箱即如此)→ 仍是安全 no-op、不抛
+    monkeypatch.setenv("GALAXY_OTEL_ENABLED", "1")
+    ot._reset_for_test()
+    active = ot.init_tracing()
+    # 装了 otel 就 True、没装就 False —— 两种都不许抛
+    assert active in (True, False)
+    with ot.start_span("y") as span:
+        assert span is None or span is not None  # 只要不抛即可
+
+
+class _FakeSpan:
+    def __init__(self):
+        self.attrs = {}
+        self.exceptions = []
+        self.status = None
+
+    def set_attribute(self, k, v):
+        self.attrs[k] = v
+
+    def record_exception(self, exc):
+        self.exceptions.append(exc)
+
+    def set_status(self, status):
+        self.status = status
+
+
+class _FakeSpanCtx:
+    def __init__(self, span):
+        self._span = span
+
+    def __enter__(self):
+        return self._span
+
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.spans = []
+
+    def start_as_current_span(self, name):
+        s = _FakeSpan()
+        s.name = name
+        self.spans.append(s)
+        return _FakeSpanCtx(s)
+
+
+def test_injected_tracer_creates_span_with_attributes():
+    tracer = _FakeTracer()
+    ot._install_tracer_for_test(tracer)
+    assert ot.is_active() is True
+    with ot.start_span("galaxy.node.invoke", {"galaxy.trace_id": "tr1", "galaxy.node_id": "N"}) as span:
+        assert span is not None
+        ot.set_attribute(span, "extra", 42)
+    assert len(tracer.spans) == 1
+    s = tracer.spans[0]
+    assert s.name == "galaxy.node.invoke"
+    assert s.attrs["galaxy.trace_id"] == "tr1"
+    assert s.attrs["galaxy.node_id"] == "N"
+    assert s.attrs["extra"] == 42
+
+
+def test_span_body_exception_propagates_and_is_recorded():
+    tracer = _FakeTracer()
+    ot._install_tracer_for_test(tracer)
+    with pytest.raises(ValueError):
+        with ot.start_span("op") as span:
+            ot.record_exception(span, ValueError("boom"))
+            raise ValueError("boom")
+    # span 仍被创建,异常被记录
+    assert tracer.spans[0].exceptions and isinstance(tracer.spans[0].exceptions[0], ValueError)

--- a/tests/test_pr5_runtime_restart_recovery.py
+++ b/tests/test_pr5_runtime_restart_recovery.py
@@ -484,3 +484,45 @@ class TestInflightTaskDefaults:
         # The old "in-flight task queues are NOT recovered" non-goal must NOT
         # appear in non-goals since we now durably recover them.
         assert "in-flight task queues are not recovered" not in non_goal_text
+
+
+class TestDurableTaskGraphResumeStep:
+    """Step 12(Feature ①):重启恢复流程接入可持久化 DAG 续跑视图。"""
+
+    def test_resume_snapshot_populated_when_durable_enabled(self, tmp_path, monkeypatch):
+        import core.task_graph_runtime as tg
+        from core.task_graph_runtime import GraphNode, GraphNodeState, TaskGraphRuntime
+
+        monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+        monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", str(tmp_path / "g.json"))
+        tg.reset_task_graph_runtime()
+
+        # 先在"上一进程"落一个两步 DAG:t1 完成、t2 依赖 t1 待续跑
+        prev = TaskGraphRuntime()
+        prev.register_node(GraphNode(task_id="t1", state=GraphNodeState.QUEUED))
+        prev.register_node(GraphNode(task_id="t2", state=GraphNodeState.QUEUED, depends_on=["t1"]))
+        prev.transition("t1", GraphNodeState.COMPLETED)
+        # 新单例 = 重启后从盘上重建
+        tg.reset_task_graph_runtime()
+
+        coord = RuntimeRestartRecoveryCoordinator(
+            mesh_session_store=_make_mesh_session_store(str(tmp_path)),
+            body_mesh_store=_make_body_mesh_store(str(tmp_path)),
+            body_mesh_registry=FakeRegistry(),
+        )
+        report = coord.run_recovery()
+        assert report.task_graph_resume is not None
+        assert report.task_graph_resume["completed"] == ["t1"]
+        assert report.task_graph_resume["resumable"] == ["t2"]
+        assert report.to_dict()["task_graph_resume"]["resumable"] == ["t2"]
+        tg.reset_task_graph_runtime()
+
+    def test_resume_snapshot_none_when_durable_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GALAXY_DURABLE_EXEC", raising=False)
+        coord = RuntimeRestartRecoveryCoordinator(
+            mesh_session_store=_make_mesh_session_store(str(tmp_path)),
+            body_mesh_store=_make_body_mesh_store(str(tmp_path)),
+            body_mesh_registry=FakeRegistry(),
+        )
+        report = coord.run_recovery()
+        assert report.task_graph_resume is None  # 默认关 → 不接入,零影响

--- a/tests/test_task_graph_durable_resume.py
+++ b/tests/test_task_graph_durable_resume.py
@@ -1,0 +1,157 @@
+"""tests/test_task_graph_durable_resume.py
+=============================================
+Feature ① — task graph 的【步级检查点 + 断点续跑】。
+默认关(GALAXY_DURABLE_EXEC 未设)→ 不落盘、零行为变化。开启后:每步 transition 原子
+落盘;新实例(模拟进程重启)从盘上重建;已完成步被跳过、依赖满足的待执行步可续跑。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import core.task_graph_runtime as tg
+import pytest
+from core.task_graph_runtime import GraphNode, GraphNodeState, TaskGraphRuntime
+
+
+@pytest.fixture(autouse=True)
+def _iso(monkeypatch):
+    monkeypatch.delenv("GALAXY_DURABLE_EXEC", raising=False)
+    monkeypatch.delenv("GALAXY_TASK_GRAPH_STATE_PATH", raising=False)
+    tg.reset_task_graph_runtime()
+    yield
+    tg.reset_task_graph_runtime()
+
+
+def _node(task_id, state=GraphNodeState.QUEUED, depends_on=None):
+    return GraphNode(task_id=task_id, state=state, depends_on=list(depends_on or []))
+
+
+def test_disabled_by_default_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", str(tmp_path / "g.json"))
+    # 未设 GALAXY_DURABLE_EXEC → durable 关
+    rt = TaskGraphRuntime()
+    assert rt._durable is False
+    rt.register_node(_node("t1"))
+    rt.transition("t1", GraphNodeState.COMPLETED)
+    assert not (tmp_path / "g.json").exists()  # 零落盘
+
+
+def test_checkpoint_and_resume_across_restart(tmp_path, monkeypatch):
+    p = str(tmp_path / "g.json")
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", p)
+
+    rt = TaskGraphRuntime()
+    # 两步 DAG:t2 依赖 t1。t1 完成、t2 还在排队。
+    rt.register_node(_node("t1"))
+    rt.register_node(_node("t2", depends_on=["t1"]))
+    rt.transition("t1", GraphNodeState.COMPLETED)
+    assert (tmp_path / "g.json").exists()
+
+    # 模拟进程重启:全新实例从盘上重建
+    rt2 = TaskGraphRuntime()
+    assert rt2.get_node_by_task_id("t1").state == GraphNodeState.COMPLETED
+    assert rt2.get_node_by_task_id("t2").state == GraphNodeState.QUEUED
+    # t1 已完成 → 跳过;t2 依赖已满足 → 可续跑
+    assert rt2.completed_task_ids() == ["t1"]
+    assert [n.task_id for n in rt2.resumable_nodes()] == ["t2"]
+
+
+def test_blocked_when_dependency_incomplete(tmp_path, monkeypatch):
+    p = str(tmp_path / "g.json")
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", p)
+    rt = TaskGraphRuntime()
+    rt.register_node(_node("a"))
+    rt.register_node(_node("b", depends_on=["a"]))
+    # a 还没完成 → b 被依赖阻塞,不在可续跑集合里
+    rt2 = TaskGraphRuntime()
+    assert [n.task_id for n in rt2.resumable_nodes()] == ["a"]  # 只有无依赖的 a 可跑
+    snap = rt2.resume_snapshot()
+    assert "b" in snap["blocked"] and "a" in snap["resumable"]
+
+
+def test_completed_node_not_resumable(tmp_path, monkeypatch):
+    p = str(tmp_path / "g.json")
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", p)
+    rt = TaskGraphRuntime()
+    rt.register_node(_node("done"))
+    rt.transition("done", GraphNodeState.COMPLETED)
+    rt2 = TaskGraphRuntime()
+    assert rt2.resumable_nodes() == []  # 终态不重派(不重复副作用)
+    assert rt2.resume_snapshot()["completed"] == ["done"]
+
+
+def test_executed_result_state_not_resumable(tmp_path, monkeypatch):
+    # RESULT 态 = 已执行、拿到结果、等定案 → 不应重派(否则重复副作用)
+    p = str(tmp_path / "g.json")
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", p)
+    rt = TaskGraphRuntime()
+    rt.register_node(_node("r"))
+    rt.transition("r", GraphNodeState.RESULT)
+    rt2 = TaskGraphRuntime()
+    assert rt2.resumable_nodes() == []
+    assert "r" in rt2.resume_snapshot()["executed_pending_finalization"]
+
+
+def test_atomic_write_no_tmp_leftover(tmp_path, monkeypatch):
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", str(tmp_path / "g.json"))
+    rt = TaskGraphRuntime()
+    rt.register_node(_node("t1"))
+    rt.transition("t1", GraphNodeState.DISPATCH)
+    rt.transition("t1", GraphNodeState.COMPLETED)
+    assert [f for f in tmp_path.iterdir() if f.suffix == ".tmp"] == []
+
+
+def test_running_node_is_resumable_relies_on_idempotency(tmp_path, monkeypatch):
+    # RUNNING(崩时在途)算可续跑,重派靠 ② 派发幂等守卫防二次副作用
+    p = str(tmp_path / "g.json")
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", p)
+    rt = TaskGraphRuntime()
+    rt.register_node(_node("run"))
+    rt.transition("run", GraphNodeState.DISPATCH)
+    rt.transition("run", GraphNodeState.RUNNING)
+    rt2 = TaskGraphRuntime()
+    assert [n.task_id for n in rt2.resumable_nodes()] == ["run"]
+
+
+def test_resume_pending_dispatch_calls_back_and_marks_dispatch(tmp_path, monkeypatch):
+    p = str(tmp_path / "g.json")
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", p)
+    rt = TaskGraphRuntime()
+    rt.register_node(_node("t1"))
+    rt.register_node(_node("t2", depends_on=["t1"]))
+    rt.transition("t1", GraphNodeState.COMPLETED)
+
+    rt2 = TaskGraphRuntime()  # 重启
+    dispatched = []
+
+    async def _dispatch(node):
+        dispatched.append(node.task_id)
+
+    out = asyncio.run(rt2.resume_pending_dispatch(_dispatch))
+    assert dispatched == ["t2"]  # 只重派可续跑的 t2(t1 已完成跳过)
+    assert out["resumed"] == ["t2"] and out["failed"] == []
+    assert rt2.get_node_by_task_id("t2").state == GraphNodeState.DISPATCH  # 置回 DISPATCH
+
+
+def test_resume_pending_dispatch_isolates_failures(tmp_path, monkeypatch):
+    monkeypatch.setenv("GALAXY_DURABLE_EXEC", "1")
+    monkeypatch.setenv("GALAXY_TASK_GRAPH_STATE_PATH", str(tmp_path / "g.json"))
+    rt = TaskGraphRuntime()
+    rt.register_node(_node("ok"))
+    rt.register_node(_node("bad"))
+
+    def _dispatch(node):
+        if node.task_id == "bad":
+            raise RuntimeError("dispatch boom")
+
+    out = asyncio.run(rt.resume_pending_dispatch(_dispatch))
+    assert "ok" in out["resumed"]
+    assert any(f[0] == "bad" for f in out["failed"])  # 单个失败被隔离

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -49,11 +49,19 @@ class _OkResult:
 
 
 @pytest.fixture(autouse=True)
-def _reset(monkeypatch):
+def _reset(monkeypatch, tmp_path):
     wr.reset_worker_runtime()
     monkeypatch.delenv("GALAXY_MASTER_BRAIN_ENABLED", raising=False)
+    monkeypatch.delenv("GALAXY_DISPATCH_IDEMPOTENCY", raising=False)
+    # 派发幂等守卫默认开且可持久化 → 隔离到 tmp,避免把 task_id 记进真实 data/ 文件、
+    # 污染同一进程/重跑(否则第二次跑同一 task_id 会被去重、invoke_node 不再被调)。
+    import core.durable_dispatch_idempotency as ddi
+
+    ddi.reset_durable_dispatch_id_store()
+    ddi.get_durable_dispatch_id_store(str(tmp_path / "dispatch_idem.json"))
     yield
     wr.reset_worker_runtime()
+    ddi.reset_durable_dispatch_id_store()
 
 
 class TestExecuteDispatch:
@@ -95,6 +103,58 @@ class TestExecuteDispatch:
         w = wr.WorkerRuntime(worker_id="w1", nats_bus=_FakeBus())
         res = asyncio.run(w.execute_dispatch({"task_id": "t3", "node_id": "N", "action": "a"}))
         assert res.status == "failed" and "worker 执行异常" in res.error
+
+
+class TestDispatchIdempotency:
+    """派发侧幂等:同一派发被 NATS 重投时不二次执行副作用(默认开)。"""
+
+    def _count_invokes(self, monkeypatch):
+        calls = {"n": 0}
+
+        async def _invoke(*a, **k):
+            calls["n"] += 1
+            return _OkResult()
+
+        monkeypatch.setattr("core.node_invocation.invoke_node", _invoke)
+        return calls
+
+    def test_redelivery_does_not_double_execute(self, monkeypatch):
+        calls = self._count_invokes(monkeypatch)
+        w = wr.WorkerRuntime(worker_id="w1", nats_bus=_FakeBus())
+        d = {"task_id": "dup1", "node_id": "N", "action": "click", "params": {}}
+        r1 = asyncio.run(w.execute_dispatch(d))
+        r2 = asyncio.run(w.execute_dispatch(d))  # 模拟重投
+        assert calls["n"] == 1  # 副作用只执行一次
+        assert r1.status == "completed"
+        assert r2.status == "completed" and r2.result.get("deduplicated") is True
+
+    def test_executor_exception_rolls_back_key_so_retry_runs(self, monkeypatch):
+        state = {"boom": True, "n": 0}
+
+        async def _invoke(*a, **k):
+            state["n"] += 1
+            if state["boom"]:
+                state["boom"] = False
+                raise RuntimeError("transient")
+            return _OkResult()
+
+        monkeypatch.setattr("core.node_invocation.invoke_node", _invoke)
+        w = wr.WorkerRuntime(worker_id="w1", nats_bus=_FakeBus())
+        d = {"task_id": "retry1", "node_id": "N", "action": "click", "params": {}}
+        r1 = asyncio.run(w.execute_dispatch(d))  # 抛异常 → 回滚键
+        r2 = asyncio.run(w.execute_dispatch(d))  # 重投 → 应真正重试执行
+        assert r1.status == "failed"
+        assert r2.status == "completed"
+        assert state["n"] == 2  # 回滚后确实重跑了
+
+    def test_disabled_flag_always_executes(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_DISPATCH_IDEMPOTENCY", "0")
+        calls = self._count_invokes(monkeypatch)
+        w = wr.WorkerRuntime(worker_id="w1", nats_bus=_FakeBus())
+        d = {"task_id": "off1", "node_id": "N", "action": "click", "params": {}}
+        asyncio.run(w.execute_dispatch(d))
+        asyncio.run(w.execute_dispatch(d))
+        assert calls["n"] == 2  # 关掉守卫 → 每次都执行(旧行为)
 
 
 class TestStartSubscribeReply:

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -1256,6 +1256,26 @@ class GalaxyUnified:
         if os.environ.get("GALAXY_VOICE", "1").strip().lower() in ("0", "false", "no", "off"):
             self._voice_input_disabled_reason = "GALAXY_VOICE=0(已手动关闭)"
             return False
+        # 麦克风采集依赖 sounddevice/PortAudio。它不就位时 AudioCaptureService.start()
+        # 会【静默跳过】、mic 永不打开,而此前本函数照样 return True → 摘要谎报"语音交互
+        # 已开启"(所有者反馈"对它说话没反应、不知为何")。这里显式探测并如实报因。
+        try:
+            from core.multimodal.audio_ingest import _SOUNDDEVICE_AVAILABLE as _sd_ok
+        except Exception:
+            _sd_ok = False
+        if not _sd_ok:
+            self._voice_input_disabled_reason = (
+                "麦克风采集不可用:sounddevice/PortAudio 未就绪 —— 对它说话不会有反应。"
+                "Linux 装 libportaudio2 portaudio19-dev;Windows 试 "
+                "pip install --force-reinstall sounddevice"
+            )
+            logger.warning(
+                "\n%s\n⚠️  语音输入未启用:麦克风采集依赖 sounddevice/PortAudio 未就绪。\n    %s\n%s",
+                "=" * 66,
+                self._voice_input_disabled_reason,
+                "=" * 66,
+            )
+            return False
         try:
             from core.voice_loop import VoiceLoop
 


### PR DESCRIPTION
Two thematic groups of work on this branch (see commits).

## Group A — desktop / launcher / voice / config fixes
1. **Windows MSVC detection** — no more false-positive that lets `cargo build` run for minutes then die at `link.exe not found`.
2. **Podman-first** container menus (headless stays docker-first); calmer Phase-6 frontend prep; unified + condensed pre-flight box.
3. **Smooth streaming** — flipped `GALAXY_TEXT_VOICE_LOCKSTEP` default OFF (per-token panel + TTS in parallel); **mic resurrection** — input-device fallback + honest sounddevice reporting + dep-banner fix.
4. **Config save honesty** — persist-first so "已配置" and "保存失败" can never contradict.

## Group B — reliability set (①②③), all env-gated default-off, wired into the real path

**② Durable dispatch idempotency** (`core/durable_dispatch_idempotency.py`)
NATS worker dispatch is at-least-once; a crash before ack redelivers and re-executes the side effect (double android tap). Added a file-backed guard **before** the effect in `worker_runtime.execute_dispatch`: mark pessimistically, short-circuit redeliveries with a "deduplicated" result, roll back only if the executor *raises*. `GALAXY_DISPATCH_IDEMPOTENCY=0` disables. (10 tests)

**③ OpenTelemetry tracing** (`core/otel_tracing.py`)
No-op-safe, lazy wrapper (OTel is NOT a hard dep). Spans wrap the universal `invoke_node` entry (covers in-process ReAct / REST / command-router / worker) + the worker execute, with the bespoke `trace_id` carried as `galaxy.trace_id`. Init once in `startup.bootstrap_subsystems`. `GALAXY_OTEL_ENABLED=1` to turn on. (5 tests, incl. a caught contextmanager bug)

**① Durable DAG checkpoint + resume** (`core/task_graph_runtime.py`)
The canonical DAG model was in-memory; a restart *abandoned* non-terminal tasks. Added atomic step-level checkpointing (persist after every register/transition), rehydrate on construction, and a resume API: `completed_task_ids` (skip set), `resumable_nodes` (pending + deps satisfied; RUNNING relies on ②), `resume_snapshot`, and an async `resume_pending_dispatch(dispatch_fn)` re-dispatch seam. Wired into `RuntimeRestartRecoveryCoordinator.run_recovery` as **Step 12** (report gains `task_graph_resume`). `GALAXY_DURABLE_EXEC=1` + `GALAXY_TASK_GRAPH_STATE_PATH`. (11 tests)

Design note: intentionally NOT adopting Azure Durable Task / Entra ID — the *patterns* (checkpoint/resume, idempotency, OTel) fit our local-first cross-device model; persistence stays `runtime/` JSON, identity stays Ed25519 mesh.

### Verification
`py_compile` + `flake8 --max-line-length=120` clean on every changed non-test file. Consolidated regression across all feature + touched suites: **308 passed** (feature/node/graph/recovery) and **119 passed** (config/voice/launcher), 0 failures attributable to this diff. The one failing `load_dotenv` grep-test pre-exists on origin/main. Distributed end-to-end (real NATS + devices) can't run in CI; everything is default-off, unit+integration tested, and wired into the real execution path.

The red required checks are the repo's pre-existing systemic gates (governance/complexity/ssot/capability/lint/test), unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)