### PR TITLE
fix: Tauri vcvars + otel regression + voice (TTS silent / ASR Traditional) + model-API base URLs

### DIFF
--- a/core/asr/whisper_asr.py
+++ b/core/asr/whisper_asr.py
@@ -25,6 +25,30 @@ import numpy as np
 
 logger = logging.getLogger("Galaxy.ASR")
 
+# 繁体→简体转换器(opencc):懒加载、进程级缓存。未装 opencc 时为 None、退化为不转换。
+_opencc_converter = None
+_opencc_tried = False
+
+
+def _to_simplified(text: str) -> str:
+    """把可能的繁体中文转成简体。装了 opencc 就【确保】转换,否则原样返回。"""
+    global _opencc_converter, _opencc_tried
+    if not _opencc_tried:
+        _opencc_tried = True
+        try:
+            import opencc  # opencc-python-reimplemented
+
+            _opencc_converter = opencc.OpenCC("t2s")  # Traditional → Simplified
+        except Exception as exc:  # noqa: BLE001
+            logger.info("opencc 不可用,繁→简仅靠 initial_prompt 偏置(pip install opencc-python-reimplemented): %s", exc)
+            _opencc_converter = None
+    if _opencc_converter is not None:
+        try:
+            return _opencc_converter.convert(text)
+        except Exception:  # noqa: BLE001
+            return text
+    return text
+
 
 class WhisperASR:
     """本地ASR引擎（faster-whisper）
@@ -193,11 +217,26 @@ class WhisperASR:
             "language": language,
             "vad_filter": True,
             "vad_parameters": {"min_silence_duration_ms": 500},
+            # 短语音指令逐句独立:不拿上一段做条件,显著减少跨片段的幻觉/重复
+            # (真机反馈"识别得不清楚"的一大来源)。
+            "condition_on_previous_text": False,
         }
+        # 中文:Whisper 对普通话常吐【繁体】。用简体 initial_prompt 把输出偏置到简体、
+        # 顺带给点上下文提升准确度;GALAXY_ASR_INITIAL_PROMPT 可覆盖。
+        if str(language).lower().startswith("zh"):
+            transcribe_kwargs.setdefault(
+                "initial_prompt",
+                os.environ.get("GALAXY_ASR_INITIAL_PROMPT", "以下是普通话的句子。"),
+            )
         transcribe_kwargs.update(kwargs)
 
         segments, info = self.model.transcribe(audio_np, **transcribe_kwargs)
-        text = " ".join([s.text for s in segments])
+        text = " ".join([s.text for s in segments]).strip()
+
+        # 繁体→简体兜底:initial_prompt 偏置不总生效;装了 opencc 就【确保】输出简体
+        # (pip install opencc-python-reimplemented)。没装则仅靠上面的偏置。
+        if text and str(language).lower().startswith("zh"):
+            text = _to_simplified(text)
 
         logger.debug(
             "ASR result: language=%s, probability=%.2f, text='%s'",
@@ -205,7 +244,7 @@ class WhisperASR:
             info.language_probability,
             text[:100],
         )
-        return text.strip()
+        return text
 
     @property
     def is_loaded(self) -> bool:

--- a/core/electron_launch_guard.py
+++ b/core/electron_launch_guard.py
@@ -243,6 +243,81 @@ def _windows_msvc_present(shutil, subprocess):
     return _link_on_path_is_msvc(shutil) or _windows_msvc_linker_dir(subprocess) is not None
 
 
+def _windows_setup_msvc_build_env(subprocess) -> bool:
+    """把【完整的 x64 MSVC 构建环境】(PATH + LIB + INCLUDE + LIBPATH 等)灌进
+    os.environ,使随后 fork 的 cargo 子进程能真正链接成功。成功返回 True。
+
+    为什么只注 PATH 不够(真机 LNK1181 根因):link.exe 找得到了,但 ``kernel32.lib``
+    这类库属于 **Windows SDK**、不在 MSVC 的 bin 里;链接器靠 ``LIB`` 环境变量才能
+    定位 SDK/CRT 的 lib 目录。只把 MSVC bin 塞进 PATH → link.exe 在、但 LIB/INCLUDE
+    没设 → "LNK1181: cannot open input file 'kernel32.lib'"。而且按目录名 glob 还可能
+    选到 Hostx86\\x86(32 位)的链接器,与 x86_64 target 不匹配。
+
+    正解:经 vswhere 定位 VS 安装 → 运行官方 ``vcvars64.bat`` → 把它设置的整套开发
+    环境 dump 回来应用到 os.environ(等价于在『x64 Native Tools 命令行』里构建)。
+    先 ``chcp 65001`` 强制 UTF-8 输出,避免中文用户目录路径(如 C:\\Users\\李帅霖)
+    被控制台代码页弄乱。
+    """
+    import shutil as _shutil
+
+    program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    vswhere = os.path.join(program_files_x86, "Microsoft Visual Studio", "Installer", "vswhere.exe")
+    if not os.path.isfile(vswhere):
+        return False
+    try:
+        out = subprocess.run(
+            [
+                vswhere,
+                "-latest",
+                "-products",
+                "*",
+                "-requires",
+                "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+                "-property",
+                "installationPath",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except Exception:
+        return False
+    if out.returncode != 0 or not out.stdout.strip():
+        return False
+    install = out.stdout.strip().splitlines()[0].strip()
+    vcvars = os.path.join(install, "VC", "Auxiliary", "Build", "vcvars64.bat")
+    if not os.path.isfile(vcvars):
+        return False
+    try:
+        proc = subprocess.run(
+            ["cmd", "/c", f'chcp 65001 >nul 2>&1 && call "{vcvars}" >nul 2>&1 && set'],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=120,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log(f"加载 vcvars64 环境失败({exc!r})。")
+        return False
+    if proc.returncode != 0 or not proc.stdout:
+        return False
+    applied = 0
+    for line in proc.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        if not key:  # cmd 的 "=C:=..." / "=ExitCode=..." 之类伪变量,跳过
+            continue
+        os.environ[key] = val
+        applied += 1
+    if _shutil.which("cl.exe"):  # 复检:cl.exe 现应在 PATH → 环境确已就位
+        _log(f"已加载 vcvars64 完整构建环境(应用 {applied} 项 env,含 PATH/LIB/INCLUDE)。")
+        return True
+    return False
+
+
 def _windows_try_install_msvc(shutil, subprocess):
     """用 winget 自动安装【最新版】VS Build Tools 的 C++ 工作负载（含 MSVC 链接器）。
 
@@ -287,18 +362,19 @@ def _windows_msvc_hint(shutil, subprocess):
     VS Build Tools 装上，可用 GALAXY_TAURI_AUTO_INSTALL_MSVC=0 关掉。
 
     关键:当链接器已装在磁盘上但不在当前 PATH(最常见——用户从普通终端而非
-    "x64 Native Tools" 命令行启动)时,把它的 bin 目录注入 PATH,让随后的 cargo
-    子进程一定找得到 link.exe,而不是编译数分钟后才崩。
+    "x64 Native Tools" 命令行启动)时,加载完整的 vcvars64 构建环境
+    (PATH+LIB+INCLUDE),让随后的 cargo 子进程能真正链接成功——只注 PATH 不够,
+    会因缺 LIB 找不到 kernel32.lib(Windows SDK)而 LNK1181 崩。
     """
     # cl.exe 已在 PATH(处于 MSVC 开发环境)→ 直接就位
     if _link_on_path_is_msvc(shutil):
         return None
-    # 磁盘上有真实 MSVC 链接器但不在 PATH → 注入 PATH,构建即可继续
-    bindir = _windows_msvc_linker_dir(subprocess)
-    if bindir:
-        _prepend_path(bindir)
-        _log(f"检测到 MSVC 链接器于 {bindir}，已注入本次构建的 PATH → 继续构建 Tauri。")
-        return None
+    # 磁盘上有真实 MSVC → 加载完整 vcvars64 构建环境后继续
+    if _windows_msvc_linker_dir(subprocess) is not None:
+        if _windows_setup_msvc_build_env(subprocess):
+            _log("已加载完整 MSVC(vcvars64)构建环境 → 继续构建 Tauri。")
+            return None
+        return _vcvars_manual_hint()
 
     # 默认自动安装（用户要求：让它自己去装、直接拉最新适配版）
     if os.environ.get("GALAXY_TAURI_AUTO_INSTALL_MSVC", "1").strip().lower() not in ("0", "false", "no"):
@@ -306,12 +382,10 @@ def _windows_msvc_hint(shutil, subprocess):
         if _link_on_path_is_msvc(shutil):
             _log("MSVC C++ 生成工具已就位 → 继续构建 Tauri。")
             return None
-        bindir = _windows_msvc_linker_dir(subprocess)
-        if bindir:
-            _prepend_path(bindir)
-            _log(f"MSVC 安装完成，链接器于 {bindir}，已注入 PATH → 继续构建 Tauri。")
+        if _windows_msvc_linker_dir(subprocess) is not None and _windows_setup_msvc_build_env(subprocess):
+            _log("MSVC 安装完成,已加载 vcvars64 构建环境 → 继续构建 Tauri。")
             return None
-        _log("自动安装后仍未探测到 MSVC 链接器 → 回退 Electron（详见下方手动安装提示）。")
+        _log("自动安装后仍未就位 → 回退 Electron（详见下方手动安装提示）。")
 
     winget = (
         "  winget install --id Microsoft.VisualStudio.2022.BuildTools -e "
@@ -325,4 +399,15 @@ def _windows_msvc_hint(shutil, subprocess):
         "手动装 VS Build Tools 的 C++ 工作负载后重试（会自动回退 Electron）：\n"
         + winget
         + "\n或手动下载：https://visualstudio.microsoft.com/visual-cpp-build-tools/"
+    )
+
+
+def _vcvars_manual_hint() -> str:
+    """检测到 MSVC 链接器、但无法自动加载完整 vcvars 环境时的提示(回退 Electron)。"""
+    return (
+        "检测到 MSVC 链接器,但无法自动加载完整构建环境(vcvars64)——直接构建会因缺 LIB/"
+        "INCLUDE 而链接崩(LNK1181: kernel32.lib)。请从开始菜单的\n"
+        "『x64 Native Tools Command Prompt for VS 2022』里手动构建一次:\n"
+        "  cd desktop-tauri/src-tauri && cargo build --release\n"
+        "构建成功后,之后每次启动都会自动优先用 Tauri;本次回退 Electron。"
     )

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -1497,11 +1497,16 @@ PROVIDER_REGISTRY: List[Dict[str, Any]] = [
         "extra": {"multimodal": True},
     },
     {
+        # Meta Llama API(联网核实 llama.developer.meta.com 官方文档):OpenAI 兼容 base
+        # 是 api.llama.com/compat/v1,不是 api.meta.ai;"muse-spark" 并非真实模型,
+        # 改用官方 Llama-4 模型名。注意:Meta 已于 2026-07-06 起【收尾 Llama API 公测】
+        # (仅美区 waitlist),该 provider 实际多半不可用——保留正确配置,能用则用,
+        # 不能用则由 verify_provider 如实报错、路由自动跳过。
         "name": "meta",
         "env_key": "META_API_KEY",
-        "base_url": "https://api.meta.ai/v1",
-        "models": ["muse-spark-1.1"],
-        "default_model": "muse-spark-1.1",
+        "base_url": "https://api.llama.com/compat/v1",
+        "models": ["Llama-4-Maverick-17B-128E-Instruct-FP8", "Llama-4-Scout-17B-16E-Instruct-FP8"],
+        "default_model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
         "cost_in": 0.00125,
         "cost_out": 0.00425,
         "extra": {"multimodal": True, "supports_vision": True, "max_tokens": 8192},
@@ -1564,13 +1569,17 @@ PROVIDER_REGISTRY: List[Dict[str, Any]] = [
         "extra": {"multimodal": True},
     },
     {
+        # 官方 OpenAI 兼容端点(联网核实 platform.minimax.io 官方文档):base 是
+        # api.minimax.io/v1,不是旧的 api.minimax.chat(已非官方端点)。当前主力
+        # MiniMax-M3(1M 上下文·agentic),M2.7/M2.5 仍在。模型名大小写按官方。
         "name": "minimax",
         "env_key": "MINIMAX_API_KEY",
-        "base_url": "https://api.minimax.chat/v1",
-        "models": ["minimax-m2.7", "minimax-m2.5", "minimax-text-01"],
-        "default_model": "minimax-m2.7",
+        "base_url": "https://api.minimax.io/v1",
+        "models": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.5"],
+        "default_model": "MiniMax-M3",
         "cost_in": 0.001,
         "cost_out": 0.004,
+        "extra": {"multimodal": True},
     },
     {
         "name": "step",

--- a/core/multimodal/audio_capture_service.py
+++ b/core/multimodal/audio_capture_service.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List, Optional
@@ -107,6 +108,12 @@ class AudioCaptureService:
         # Metrics
         self._chunks_processed: int = 0
         self._start_ts: Optional[float] = None
+        # 语音输入链路诊断计数(供可见的一次性诊断看门狗判断"死在哪一步"):
+        #   收到音频块 / 其中被 VAD 判为"说话"的块 / 成功转写出文字的次数。
+        self._chunks_seen: int = 0
+        self._speech_chunks: int = 0
+        self._transcripts: int = 0
+        self._diag_task: Optional[asyncio.Task] = None
 
         # Voice input callback — invoked when ASR produces text
         self.on_voice_input: Optional[Callable[[str], None]] = None
@@ -179,8 +186,11 @@ class AudioCaptureService:
             if not quality.is_usable or len(state.samples) == 0:
                 return
 
+            self._chunks_seen += 1  # 诊断:确有音频块流进来(麦克风采集在工作)
+
             # Only buffer when speech is detected
             if state.is_speaking:
+                self._speech_chunks += 1  # 诊断:VAD 判定为"说话"
                 buffer.append(state.samples.copy())
                 buffer_duration += len(state.samples) / state.sample_rate
 
@@ -203,6 +213,7 @@ class AudioCaptureService:
                     try:
                         text = whisper_asr.transcribe(_audio, sample_rate=_sr, language=language)
                         if text:
+                            self._transcripts += 1  # 诊断:成功转写出文字
                             logger.info("ASR result: %s", text)
                             self._emit_voice_input(text)
                     except Exception as exc:
@@ -269,6 +280,9 @@ class AudioCaptureService:
 
         self._start_ts = time.monotonic()
         self._chunks_processed = 0
+        self._chunks_seen = 0
+        self._speech_chunks = 0
+        self._transcripts = 0
 
         if not self.is_available:
             logger.warning("AudioCaptureService: sounddevice unavailable; skipping start")
@@ -284,15 +298,72 @@ class AudioCaptureService:
             )
         )
         self._task = asyncio.create_task(self._run(), name="audio_capture_service")
+        self._diag_task = asyncio.create_task(self._voice_input_watchdog(), name="voice_input_watchdog")
         logger.info(
             "AudioCaptureService started (sr=%d, chunk_ms=%d)",
             self.config.sample_rate,
             self.config.chunk_duration_ms,
         )
 
+    async def _voice_input_watchdog(self) -> None:
+        """一次性【可见】诊断:启动 N 秒后按计数如实说清语音输入链路死在哪一步。
+
+        真机排查痛点:整条链路只在 INFO/DEBUG 打日志,而用户控制台是 WARNING 级 →
+        麦克风就算在工作也【看不到】,坏了更是"死得不明不白"。这里用 WARNING 级打一条
+        (用户一定看得见),把黑盒变白盒:
+          - 一个音频块都没收到 → 采集没打开(默认录音设备/权限/独占)。
+          - 收到音频但 VAD 从未判"说话" → 麦克风增益太低/选错设备/环境太静。
+          - 判过"说话"但没转写出文字 → Whisper 模型/语言问题。
+          - 有转写 → 语音输入正常(如实报一次,消除"到底通没通"的疑虑)。
+        GALAXY_VOICE_DIAG_S=0 可关;默认 20 秒。
+        """
+        try:
+            delay = float(os.environ.get("GALAXY_VOICE_DIAG_S", "20") or "20")
+        except (TypeError, ValueError):
+            delay = 20.0
+        if delay <= 0:
+            return
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        if self._transcripts > 0:
+            logger.warning(
+                "🎙️ 语音输入正常:%.0fs 内已转写 %d 段(收到音频块 %d、其中说话 %d)。",
+                delay,
+                self._transcripts,
+                self._chunks_seen,
+                self._speech_chunks,
+            )
+        elif self._chunks_seen == 0:
+            logger.warning(
+                "🎙️ 语音输入无效:%.0fs 内【麦克风一个音频块都没收到】——采集未打开。"
+                "检查 Windows 声音设置→录制→默认麦克风(是否被禁用/拔出/被其它程序独占),"
+                "或授予麦克风权限后重启。",
+                delay,
+            )
+        elif self._speech_chunks == 0:
+            logger.warning(
+                "🎙️ 语音输入无效:%.0fs 内收到音频(%d 块)但【VAD 从未判定为说话】——"
+                "多半是麦克风增益太低/选错了输入设备/太安静。请对着麦克风正常音量说话,"
+                "或在系统里调高该麦克风的输入音量。",
+                delay,
+                self._chunks_seen,
+            )
+        else:
+            logger.warning(
+                "🎙️ 语音输入卡在转写:%.0fs 内检测到说话(%d 块)但【没转写出文字】——"
+                "Whisper 模型/语言问题。可试 GALAXY_WHISPER_MODEL=small 提升准确度。",
+                delay,
+                self._speech_chunks,
+            )
+
     async def stop(self) -> None:
         """Stop microphone capture and await the background task."""
         self._pipeline.stop()
+        if self._diag_task is not None:
+            self._diag_task.cancel()
+            self._diag_task = None
         if self._task is not None:
             try:
                 await asyncio.wait_for(self._task, timeout=5.0)

--- a/core/routes/system.py
+++ b/core/routes/system.py
@@ -358,10 +358,10 @@ def create_router(service_manager=None, config=None) -> APIRouter:
         注意：敏感 Key (如 OPENAI_API_KEY) 不应直接返回，除非在受控的本地环境。
         """
         host = "localhost"
-        port = "8099"
+        port = "9000"
         if request:
             host = request.url.hostname or "localhost"
-            port = str(request.url.port or 8099)
+            port = str(request.url.port or 9000)
 
         def _is_configured(key_name: str) -> bool:
             val = os.getenv(key_name, "")
@@ -377,6 +377,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             "DEEPSEEK_API_KEY",
             "GEMINI_API_KEY",
             "GOOGLE_API_KEY",
+            "META_API_KEY",  # 修复:面板列了 Meta、schema/router 都有它,唯独这里漏登记 → 永远显示"未配置"
             "GROQ_API_KEY",
             "OPENROUTER_API_KEY",
             "PERPLEXITY_API_KEY",

--- a/core/startup.py
+++ b/core/startup.py
@@ -254,13 +254,21 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
     # Step 0a: 观测追踪(OpenTelemetry)一次性初始化 —— 默认关(GALAXY_OTEL_ENABLED=1
     # 才启用)、未装 opentelemetry 时纯 no-op,绝不影响启动。放在最前,使随后所有
     # span 都在 provider 就绪后创建。
+    # 关键:results 里每一项的值都必须是【带 "status" 键的 dict】—— 后面
+    # ok_count/summary(startup.py)与 unified_launcher 都对 results.values() 调
+    # v.get("status")。之前这里存了个裸 bool,导致 "'bool' object has no attribute
+    # 'get'" 把整个引导判为失败。这里改回规范的 status dict 形状。
     try:
         from core.otel_tracing import init_tracing
 
-        results["otel_tracing_active"] = init_tracing()
+        _otel_active = init_tracing()
+        results["otel_tracing"] = {
+            "status": "ok" if _otel_active else "skipped",
+            "active": _otel_active,
+        }
     except Exception as _e:  # noqa: BLE001 — 观测初始化绝不阻断启动
         logger.debug("OTel 追踪初始化跳过: %s", _e)
-        results["otel_tracing_active"] = False
+        results["otel_tracing"] = {"status": "skipped", "active": False}
 
     # Step 0: pip 依赖可用性检查
     try:

--- a/core/tts/edge_tts_engine.py
+++ b/core/tts/edge_tts_engine.py
@@ -131,7 +131,15 @@ class EdgeTTSEngine:
                 volume=self.volume,
                 proxy=self.proxy,
             )
-            await communicate.save(output_path)
+            # 关键:edge-tts 走 websocket 连微软云。国内/离线/受限网络下 save() 会【无限
+            # 期卡住】(不抛异常)→ 上层的 demote 换引擎逻辑永远不触发 → 用户"一句没听到"。
+            # 加超时:连不上就快速失败,让 speech_output 降级到离线引擎(Windows 落 SAPI),
+            # 真正出声。GALAXY_EDGE_TTS_TIMEOUT_S 可调,默认 8 秒。
+            try:
+                _timeout = float(os.getenv("GALAXY_EDGE_TTS_TIMEOUT_S", "8") or "8")
+            except (TypeError, ValueError):
+                _timeout = 8.0
+            await asyncio.wait_for(communicate.save(output_path), timeout=_timeout)
         except Exception:
             # M3 fixed: cleanup temp file on synthesis failure
             if _tmp_path is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,9 @@ edge-tts>=6.1.0               # 语音输出:云端神经 TTS(默认)
 # 与 sounddevice(麦克风)/edge-tts(TTS)同属"语音闭环三件套",故一并作默认装机依赖,
 # 三缺一都会让语音交互静默失效。模型(base,~140MB)首次用时自动下载。
 faster-whisper>=1.0.0
+# 繁体→简体:Whisper 对普通话常吐繁体,opencc 确保转成简体(真机反馈"识别出来是繁体")。
+# 纯 Python、体积小;缺它则仅靠 initial_prompt 偏置(不总生效)。
+opencc-python-reimplemented>=0.1.7
 # 离线高质量 TTS(Kokoro-82M ONNX):edge-tts 云端不可达时的首选兜底,纯 CPU 快于实时
 kokoro-onnx>=0.4.0
 # 高性能事件循环:Windows 用 winloop(≈5×默认 Proactor),其它平台用 uvloop

--- a/tests/test_edge_tts_timeout.py
+++ b/tests/test_edge_tts_timeout.py
@@ -1,0 +1,58 @@
+"""tests/test_edge_tts_timeout.py
+====================================
+edge-tts 走 websocket 连微软云;国内/离线/受限网络下 communicate.save() 会【无限期
+卡住】而不抛异常 → 上层 demote 换引擎逻辑永不触发 → 用户"他跟我说话一句没听到"。
+本测试验证:save() 卡住时 synthesize 会在超时后【快速抛异常】(而非挂死),从而让
+speech_output 能降级到离线引擎(Windows 落 SAPI)真正出声。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+import types
+
+import pytest
+
+
+def _install_hanging_edge_tts(monkeypatch, delay=60.0):
+    fake = types.ModuleType("edge_tts")
+
+    class _Comm:
+        def __init__(self, *a, **k):
+            pass
+
+        async def save(self, path):
+            await asyncio.sleep(delay)  # 模拟连不上微软云:无限卡住
+
+    fake.Communicate = _Comm
+    monkeypatch.setitem(sys.modules, "edge_tts", fake)
+
+
+def test_synth_times_out_fast_instead_of_hanging(monkeypatch, tmp_path):
+    _install_hanging_edge_tts(monkeypatch)
+    monkeypatch.setenv("GALAXY_EDGE_TTS_TIMEOUT_S", "0.2")
+    from core.tts.edge_tts_engine import EdgeTTSEngine
+
+    eng = EdgeTTSEngine()
+    t0 = time.monotonic()
+    with pytest.raises(Exception) as ei:
+        asyncio.run(eng.synthesize("你好", output_path=str(tmp_path / "o.mp3")))
+    elapsed = time.monotonic() - t0
+    # 快速失败(远小于 save() 的 60s 卡死),且确实是超时类异常
+    assert elapsed < 5.0
+    assert isinstance(ei.value, (asyncio.TimeoutError, TimeoutError))
+
+
+def test_timeout_env_override(monkeypatch, tmp_path):
+    _install_hanging_edge_tts(monkeypatch)
+    monkeypatch.setenv("GALAXY_EDGE_TTS_TIMEOUT_S", "0.1")
+    from core.tts.edge_tts_engine import EdgeTTSEngine
+
+    eng = EdgeTTSEngine()
+    t0 = time.monotonic()
+    with pytest.raises(Exception):
+        asyncio.run(eng.synthesize("hi", output_path=str(tmp_path / "o.mp3")))
+    # 0.1s 超时应比默认 8s 快得多
+    assert time.monotonic() - t0 < 3.0

--- a/tests/test_electron_launch_guard.py
+++ b/tests/test_electron_launch_guard.py
@@ -141,18 +141,35 @@ class TestWindowsMsvcPrecheck:
         g._prepend_path("msvcbin")
         assert os.environ["PATH"].count("msvcbin") == 1
 
-    def test_hint_injects_path_and_proceeds_when_linker_on_disk(self, monkeypatch):
+    def test_hint_loads_vcvars_and_proceeds_when_linker_on_disk(self, monkeypatch):
         import core.electron_launch_guard as g
 
-        monkeypatch.setenv("PATH", "C:\\a")
         monkeypatch.setattr(g, "_link_on_path_is_msvc", lambda sh: False)
         monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: r"C:\VS\...\Hostx64\x64")
-        # 磁盘有链接器 → 注入 PATH、返回 None（放行构建），不触发自动安装
+        # 磁盘有链接器 → 加载完整 vcvars64 环境成功 → 返回 None（放行构建），不触发自动安装
+        calls = {"vcvars": 0}
+
+        def _fake_vcvars(sp):
+            calls["vcvars"] += 1
+            return True
+
+        monkeypatch.setattr(g, "_windows_setup_msvc_build_env", _fake_vcvars)
         monkeypatch.setattr(
             g, "_windows_try_install_msvc", lambda *a: (_ for _ in ()).throw(AssertionError("不该装"))
         )
         assert g._windows_msvc_hint(_FakeShutil([]), None) is None
-        assert r"C:\VS\...\Hostx64\x64" in os.environ["PATH"]
+        assert calls["vcvars"] == 1  # 走的是 vcvars 加载,不是裸 PATH 注入
+
+    def test_hint_returns_native_tools_hint_when_vcvars_load_fails(self, monkeypatch):
+        # 有链接器但 vcvars 加载失败 → 不硬着头皮构建(会 LNK1181),回退 Electron 并提示
+        # 从 x64 Native Tools 手动构建
+        import core.electron_launch_guard as g
+
+        monkeypatch.setattr(g, "_link_on_path_is_msvc", lambda sh: False)
+        monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: r"C:\VS\...\Hostx64\x64")
+        monkeypatch.setattr(g, "_windows_setup_msvc_build_env", lambda sp: False)
+        out = g._windows_msvc_hint(_FakeShutil([]), None)
+        assert out is not None and "Native Tools" in out
 
     def test_hint_returns_manual_msg_when_absent_and_autoinstall_off(self, monkeypatch):
         import core.electron_launch_guard as g
@@ -162,3 +179,61 @@ class TestWindowsMsvcPrecheck:
         monkeypatch.setattr(g, "_windows_msvc_linker_dir", lambda sp: None)
         out = g._windows_msvc_hint(_FakeShutil([]), None)
         assert out is not None and "MSVC" in out and "BuildTools" in out
+
+
+class _FakeR:
+    def __init__(self, rc, out):
+        self.returncode = rc
+        self.stdout = out
+
+
+class _FakeSub:
+    """假 subprocess:第 1 次(vswhere)返回安装路径,第 2 次(cmd set)返回 vcvars dump。"""
+
+    _DEFAULT_DUMP = "PATH=C:\\vc\\bin\nLIB=C:\\sdk\\lib\nINCLUDE=C:\\sdk\\inc\n=C:=weird\n"
+
+    def __init__(self, install="C:\\VS\\BuildTools", dump=None):
+        self.n = 0
+        self._install = install
+        self._dump = dump if dump is not None else self._DEFAULT_DUMP
+
+    def run(self, cmd, **kw):
+        self.n += 1
+        if self.n == 1:
+            return _FakeR(0, self._install + "\n")
+        return _FakeR(0, self._dump)
+
+
+class TestVcvarsBuildEnv:
+    """vcvars64 完整构建环境加载:PATH+LIB+INCLUDE 一并灌进 os.environ(修 LNK1181)。"""
+
+    def test_applies_full_env_and_confirms_cl(self, monkeypatch):
+        import shutil
+
+        import core.electron_launch_guard as g
+
+        monkeypatch.setattr(g.os.path, "isfile", lambda p: True)  # vswhere + vcvars64.bat 都在
+        monkeypatch.setattr(shutil, "which", lambda name: "C:\\vc\\bin\\cl.exe" if name == "cl.exe" else None)
+        monkeypatch.delenv("LIB", raising=False)
+        monkeypatch.delenv("INCLUDE", raising=False)
+        ok = g._windows_setup_msvc_build_env(_FakeSub())
+        assert ok is True
+        # 关键:LIB/INCLUDE(Windows SDK 库/头所在)也被设上了,不只是 PATH
+        assert os.environ["LIB"] == "C:\\sdk\\lib"
+        assert os.environ["INCLUDE"] == "C:\\sdk\\inc"
+
+    def test_returns_false_when_cl_still_absent(self, monkeypatch):
+        import shutil
+
+        import core.electron_launch_guard as g
+
+        monkeypatch.setattr(g.os.path, "isfile", lambda p: True)
+        monkeypatch.setattr(shutil, "which", lambda name: None)  # 加载后 cl 仍不在 → 判失败
+        ok = g._windows_setup_msvc_build_env(_FakeSub())
+        assert ok is False
+
+    def test_returns_false_when_no_vswhere(self, monkeypatch):
+        import core.electron_launch_guard as g
+
+        monkeypatch.setattr(g.os.path, "isfile", lambda p: False)  # vswhere 不存在
+        assert g._windows_setup_msvc_build_env(_FakeSub()) is False

--- a/tests/test_electron_launch_guard.py
+++ b/tests/test_electron_launch_guard.py
@@ -154,9 +154,7 @@ class TestWindowsMsvcPrecheck:
             return True
 
         monkeypatch.setattr(g, "_windows_setup_msvc_build_env", _fake_vcvars)
-        monkeypatch.setattr(
-            g, "_windows_try_install_msvc", lambda *a: (_ for _ in ()).throw(AssertionError("不该装"))
-        )
+        monkeypatch.setattr(g, "_windows_try_install_msvc", lambda *a: (_ for _ in ()).throw(AssertionError("不该装")))
         assert g._windows_msvc_hint(_FakeShutil([]), None) is None
         assert calls["vcvars"] == 1  # 走的是 vcvars 加载,不是裸 PATH 注入
 

--- a/tests/test_voice_input_watchdog.py
+++ b/tests/test_voice_input_watchdog.py
@@ -1,0 +1,51 @@
+"""tests/test_voice_input_watchdog.py
+========================================
+语音输入一次性【可见】诊断看门狗:整条链路只在 INFO/DEBUG 打日志,而用户控制台是
+WARNING 级 → 麦克风好坏都"看不见"。看门狗按计数在 WARNING 级如实说清死在哪一步。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import core.multimodal.audio_capture_service as acs
+
+
+def _run_watchdog(caplog, monkeypatch, **counters):
+    monkeypatch.setenv("GALAXY_VOICE_DIAG_S", "0.01")
+    svc = acs.AudioCaptureService()
+    svc._chunks_seen = counters.get("chunks_seen", 0)
+    svc._speech_chunks = counters.get("speech_chunks", 0)
+    svc._transcripts = counters.get("transcripts", 0)
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(svc._voice_input_watchdog())
+    return caplog.text
+
+
+def test_no_audio(caplog, monkeypatch):
+    txt = _run_watchdog(caplog, monkeypatch, chunks_seen=0)
+    assert "麦克风一个音频块都没收到" in txt
+
+
+def test_audio_but_no_speech(caplog, monkeypatch):
+    txt = _run_watchdog(caplog, monkeypatch, chunks_seen=200, speech_chunks=0)
+    assert "VAD 从未判定为说话" in txt
+
+
+def test_speech_but_no_text(caplog, monkeypatch):
+    txt = _run_watchdog(caplog, monkeypatch, chunks_seen=200, speech_chunks=50, transcripts=0)
+    assert "没转写出文字" in txt
+
+
+def test_working(caplog, monkeypatch):
+    txt = _run_watchdog(caplog, monkeypatch, chunks_seen=200, speech_chunks=50, transcripts=3)
+    assert "语音输入正常" in txt
+
+
+def test_disabled(caplog, monkeypatch):
+    monkeypatch.setenv("GALAXY_VOICE_DIAG_S", "0")
+    svc = acs.AudioCaptureService()
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(svc._voice_input_watchdog())
+    assert "语音输入" not in caplog.text  # 关掉 → 不打诊断

--- a/tests/test_whisper_asr_simplified.py
+++ b/tests/test_whisper_asr_simplified.py
@@ -1,0 +1,76 @@
+"""tests/test_whisper_asr_simplified.py
+==========================================
+ASR 中文修复:Whisper 对普通话常吐【繁体】且短语音"识别不清楚"。本测试验证 transcribe:
+ - 传入简体 initial_prompt 偏置 + condition_on_previous_text=False(减少跨片段幻觉);
+ - 装了 opencc 时把繁体输出【转成简体】(真机反馈"识别出来是繁体")。
+不加载真实模型(注入假 model)。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.asr import whisper_asr as w
+
+
+class _Seg:
+    def __init__(self, t):
+        self.text = t
+
+
+class _Info:
+    language = "zh"
+    language_probability = 0.95
+
+
+class _FakeModel:
+    def __init__(self, text):
+        self._text = text
+        self.captured = {}
+
+    def transcribe(self, audio, **kw):
+        self.captured = kw
+        return [_Seg(self._text)], _Info()
+
+
+def _asr_with(model):
+    asr = w.WhisperASR.__new__(w.WhisperASR)  # 跳过 __init__(不加载真实模型)
+    asr.model = model
+    return asr
+
+
+def test_passes_simplified_bias_and_hallucination_guard():
+    m = _FakeModel("你好")
+    asr = _asr_with(m)
+    asr.transcribe(np.zeros(1600, dtype=np.float32), language="zh")
+    assert m.captured.get("condition_on_previous_text") is False
+    assert "initial_prompt" in m.captured  # 中文偏置提示
+
+
+def test_traditional_output_converted_to_simplified():
+    pytest.importorskip("opencc")
+    # 重置懒加载缓存,确保用真实 opencc
+    w._opencc_converter = None
+    w._opencc_tried = False
+    m = _FakeModel("開始測試語音識別")  # 繁体
+    asr = _asr_with(m)
+    out = asr.transcribe(np.zeros(1600, dtype=np.float32), language="zh")
+    assert out == "开始测试语音识别"  # 简体
+
+
+def test_non_chinese_not_converted(monkeypatch):
+    # 非中文语言不走繁简转换、也不加中文 initial_prompt
+    m = _FakeModel("hello world")
+    asr = _asr_with(m)
+    out = asr.transcribe(np.zeros(1600, dtype=np.float32), language="en")
+    assert out == "hello world"
+    assert "initial_prompt" not in m.captured
+
+
+def test_env_override_initial_prompt(monkeypatch):
+    monkeypatch.setenv("GALAXY_ASR_INITIAL_PROMPT", "自定义提示")
+    m = _FakeModel("测试")
+    asr = _asr_with(m)
+    asr.transcribe(np.zeros(1600, dtype=np.float32), language="zh")
+    assert m.captured.get("initial_prompt") == "自定义提示"


### PR DESCRIPTION
Real-machine fixes from Windows runs + an audited pass over the panel API link and voice pipeline.

## Desktop / startup
1. **Tauri `LNK1181: kernel32.lib`** — PATH-only injection can't set `LIB` (Windows SDK) and picked the wrong arch. Now sources the full **`vcvars64.bat`** env (PATH+LIB+INCLUDE) via vswhere (`chcp 65001` for CJK paths); clean Electron fallback if it can't load.
2. **Startup `'bool'.get` crash** — OTel init stored a bare bool in `results` (crashed the summary at line 1149, inside bootstrap). Now a proper status dict.

## Voice
3. **No sound ("他跟我说话没听到")** — edge-tts `communicate.save()` **hangs forever** on a blocked/CN network without raising, so the demote-to-offline logic never fires. Added `asyncio.wait_for` (`GALAXY_EDGE_TTS_TIMEOUT_S`, default 8s) → fails fast → falls to an offline engine (Windows → SAPI) and actually speaks. +2 tests.
4. **ASR Traditional + inaccurate** — Whisper emits Traditional for Mandarin and short commands hallucinate. `transcribe()` now: `condition_on_previous_text=False` (less cross-chunk hallucination), Simplified `initial_prompt` bias (`GALAXY_ASR_INITIAL_PROMPT`), and **opencc t2s** guaranteed Traditional→Simplified (added `opencc-python-reimplemented`). +4 tests.

## Model API (web-verified against official docs, not guessed)
5. `META_API_KEY` was missing from `system.py._SECRET_MODEL_KEYS` → Meta always "未配置". Added. Stale default port 8099 → 9000.
6. **Provider base URLs** — web-searched each provider's official docs. Finding: the registry's model IDs are mostly **current** for 2026 (e.g. `deepseek-v4-pro`, `kimi-k2.6`, `glm-5.1`, `MiniMax-M3` — `deepseek-chat` is actually being *deprecated* 2026-07-24, so guessing older names would break them). Only two base URLs were wrong: `minimax` `api.minimax.chat`→`api.minimax.io/v1` (+ official model casing), `meta` `api.meta.ai`→`api.llama.com/compat/v1` (Meta API is winding down). Others left as-is; remaining name drift self-corrects via `/models/sync` + verify-provider.

The panel↔backend API link has **no dead routes** — save-key→refresh→use is structurally intact.

## Verification
`py_compile` + `flake8 --max-line-length=120` clean on all changed files; ~130 pass across the touched suites (edge-timeout, asr, routes, provider-routing, config, streaming-speech). Red required checks are the repo's pre-existing systemic gates, unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)