### PR TITLE
fix(voice): VAD 自适应噪声门限——救回低增益麦克风的语音输入

### DIFF
--- a/core/multimodal/audio_capture_service.py
+++ b/core/multimodal/audio_capture_service.py
@@ -345,8 +345,8 @@ class AudioCaptureService:
         elif self._speech_chunks == 0:
             logger.warning(
                 "🎙️ 语音输入无效:%.0fs 内收到音频(%d 块)但【VAD 从未判定为说话】——"
-                "多半是麦克风增益太低/选错了输入设备/太安静。请对着麦克风正常音量说话,"
-                "或在系统里调高该麦克风的输入音量。",
+                "麦克风增益极低/选错了输入设备/太安静。VAD 已自适应噪声底,若仍不触发,"
+                "请在系统里调高该麦克风输入音量,或设 GALAXY_VAD_MIN_FLOOR=0.001(更灵敏)后重跑。",
                 delay,
                 self._chunks_seen,
             )

--- a/core/multimodal/vad.py
+++ b/core/multimodal/vad.py
@@ -1,10 +1,23 @@
 """Lightweight Voice Activity Detection (VAD) based on RMS energy.
 
 No heavy ASR or neural networks — intentionally minimal.
+
+Adaptive noise floor
+--------------------
+A *fixed* absolute RMS threshold silently fails on low-gain microphones: real
+machines reported "收到音频但 VAD 从未判定为说话" (audio arrives, but VAD never
+sees speech) because quiet-but-real speech stayed below the hard 0.01 gate. To
+fix this the detector also tracks the ambient noise floor (a low percentile of
+recent frame energies) and fires when energy rises clearly above it — so it
+adapts to whatever input gain the user's mic happens to have, instead of
+demanding they crank up Windows input volume first. The fixed threshold is kept
+as a fast "definitely speech" path; the adaptive path only *adds* sensitivity.
+Everything is env-tunable (see :meth:`VADConfig.from_env`) and on by default.
 """
 
 from __future__ import annotations
 
+import os
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -13,14 +26,55 @@ from typing import Deque, Optional
 import numpy as np
 
 
+def _env_float(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name)
+        return float(raw) if raw not in (None, "") else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw in (None, ""):
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
 @dataclass
 class VADConfig:
     """Configuration for the VAD."""
 
-    energy_threshold: float = 0.01  # RMS threshold for activity
+    energy_threshold: float = 0.01  # RMS threshold for activity (fast path)
     frame_duration_ms: int = 20  # Duration of each VAD frame (ms)
     window_duration_ms: int = 300  # Rolling window for ratio metrics (ms)
     min_speech_frames: int = 3  # Consecutive active frames to confirm speech
+
+    # 自适应噪声门限(修复"麦克风增益低→固定阈值 0.01 永不触发"):除固定阈值外,
+    # 再按"能量显著高于近段噪声底"判活。对任意麦克风增益自适应,无需用户先调高
+    # 系统输入音量。仅【增加】灵敏度,不改变对响亮语音/纯静音的既有判定。
+    adaptive: bool = True
+    adaptive_speech_mult: float = 3.0  # 能量 > 噪声底 × 该倍数 → 判活(约 +9.5 dB)
+    adaptive_min_floor: float = 0.0020  # 绝对下限(≈ -54 dBFS),防数字静音/极低底噪误触发
+    noise_window_frames: int = 100  # 噪声底估计的滚动窗口(帧)
+    noise_percentile: float = 20.0  # 取窗口内该分位数作噪声底(避开语音峰值)
+
+    @classmethod
+    def from_env(cls) -> "VADConfig":
+        """Build a config with ``GALAXY_VAD_*`` env overrides applied.
+
+        Used for the live pipeline (which constructs the detector with no
+        explicit config) so operators can tune sensitivity on the real machine
+        without code changes. Tests that pass an explicit :class:`VADConfig`
+        bypass this and keep fully deterministic values.
+        """
+        return cls(
+            energy_threshold=_env_float("GALAXY_VAD_ENERGY_THRESHOLD", cls.energy_threshold),
+            min_speech_frames=int(_env_float("GALAXY_VAD_MIN_SPEECH_FRAMES", cls.min_speech_frames)),
+            adaptive=_env_bool("GALAXY_VAD_ADAPTIVE", cls.adaptive),
+            adaptive_speech_mult=_env_float("GALAXY_VAD_SPEECH_MULT", cls.adaptive_speech_mult),
+            adaptive_min_floor=_env_float("GALAXY_VAD_MIN_FLOOR", cls.adaptive_min_floor),
+        )
 
 
 @dataclass
@@ -45,7 +99,9 @@ class VoiceActivityDetector:
         config: Optional[VADConfig] = None,
         sample_rate: int = 16000,
     ) -> None:
-        self.config = config or VADConfig()
+        # config=None 是实时管线路径 → 应用 GALAXY_VAD_* 环境变量;显式传入的
+        # config(多为测试)保持原样,确定性不变。
+        self.config = config if config is not None else VADConfig.from_env()
         self.sample_rate = sample_rate
 
         self._window_frames = max(
@@ -55,12 +111,26 @@ class VoiceActivityDetector:
         self._recent: Deque[bool] = deque(maxlen=self._window_frames)
         self._consecutive_speech = 0
         self._last_speech_ts: Optional[float] = None
+        # 近段帧能量,用于估计噪声底(自适应门限)。
+        self._energy_history: Deque[float] = deque(maxlen=max(1, self.config.noise_window_frames))
+
+    def _is_active(self, energy: float) -> bool:
+        """判活:固定阈值(快路径)∪ 显著高于噪声底(自适应,救低增益麦克风)。"""
+        if energy > self.config.energy_threshold:
+            return True
+        if not self.config.adaptive or len(self._energy_history) < 5:
+            return False
+        noise_floor = float(np.percentile(self._energy_history, self.config.noise_percentile))
+        adaptive_threshold = max(self.config.adaptive_min_floor, noise_floor * self.config.adaptive_speech_mult)
+        return energy > adaptive_threshold
 
     def process_frame(self, audio_chunk: np.ndarray) -> VADState:
         """Process one chunk of PCM audio and return a VADState."""
         samples = audio_chunk.astype(np.float32).flatten()
         energy = float(np.sqrt(np.mean(samples**2))) if samples.size else 0.0
-        is_active = energy > self.config.energy_threshold
+        # 噪声底基于历史帧估计;先判活再把当前帧计入,避免当前语音帧抬高本次门限。
+        is_active = self._is_active(energy)
+        self._energy_history.append(energy)
 
         if is_active:
             self._consecutive_speech += 1
@@ -93,5 +163,6 @@ class VoiceActivityDetector:
     def reset(self) -> None:
         """Reset rolling state."""
         self._recent.clear()
+        self._energy_history.clear()
         self._consecutive_speech = 0
         self._last_speech_ts = None

--- a/tests/test_vad_adaptive_gain.py
+++ b/tests/test_vad_adaptive_gain.py
@@ -1,0 +1,80 @@
+"""tests/test_vad_adaptive_gain.py
+====================================
+自适应噪声门限 VAD:真机反馈"收到音频但 VAD 从未判定为说话"——低增益麦克风的
+真实语音 RMS 低于固定阈值 0.01,永远进不了"说话"分支。本测试证明:
+ - 低增益语音(< 0.01 固定阈值,但显著高于噪声底)现在能触发说话;
+ - 稳定的低电平底噪【不会】误触发;
+ - 纯静音仍判非说话(不因自适应而误判);
+ - GALAXY_VAD_* 环境变量能调节灵敏度。
+不依赖真实麦克风(直接喂 numpy PCM)。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from core.multimodal.vad import VADConfig, VoiceActivityDetector
+
+
+def _chunk(amp: float, n: int = 1600) -> np.ndarray:
+    """恒定幅度块:RMS == amp(便于精确控制"能量")。"""
+    return np.ones(n, dtype=np.float32) * amp
+
+
+def test_low_gain_speech_below_fixed_threshold_now_triggers():
+    # 低增益麦克风:底噪 RMS≈0.0008,语音 RMS≈0.006(< 0.01 固定阈值 → 旧 VAD 漏判)。
+    vad = VoiceActivityDetector(config=VADConfig(min_speech_frames=1))
+    for _ in range(10):
+        vad.process_frame(_chunk(0.0008))  # 建立噪声底
+    state = vad.process_frame(_chunk(0.006))
+    assert state.is_speaking  # 自适应门限救回低增益语音
+
+
+def test_steady_low_noise_does_not_trigger():
+    # 稳定低电平底噪不应被判为说话(能量未显著高于噪声底)。
+    vad = VoiceActivityDetector(config=VADConfig(min_speech_frames=1))
+    triggered = False
+    for _ in range(40):
+        st = vad.process_frame(_chunk(0.0015))
+        triggered = triggered or st.is_speaking
+    assert not triggered
+
+
+def test_pure_silence_still_not_speaking():
+    vad = VoiceActivityDetector(config=VADConfig(min_speech_frames=1))
+    for _ in range(30):
+        st = vad.process_frame(np.zeros(1600, dtype=np.float32))
+        assert not st.is_speaking
+
+
+def test_loud_speech_still_triggers_via_fast_path():
+    # 响亮语音仍走固定阈值快路径(与既有行为一致)。
+    vad = VoiceActivityDetector(config=VADConfig(min_speech_frames=1))
+    state = vad.process_frame(_chunk(0.3))
+    assert state.is_speaking
+
+
+def test_adaptive_can_be_disabled_via_config():
+    # 关掉自适应 → 退回纯固定阈值:低增益语音重新漏判(证明是自适应在起作用)。
+    vad = VoiceActivityDetector(config=VADConfig(min_speech_frames=1, adaptive=False))
+    for _ in range(10):
+        vad.process_frame(_chunk(0.0008))
+    state = vad.process_frame(_chunk(0.006))
+    assert not state.is_speaking
+
+
+def test_env_override_min_floor(monkeypatch):
+    # 抬高绝对下限到 0.05 → 低增益语音(0.006)被挡住,证明 env 生效(config=None 路径)。
+    monkeypatch.setenv("GALAXY_VAD_MIN_FLOOR", "0.05")
+    monkeypatch.setenv("GALAXY_VAD_MIN_SPEECH_FRAMES", "1")
+    vad = VoiceActivityDetector()  # config=None → from_env
+    for _ in range(10):
+        vad.process_frame(_chunk(0.0008))
+    state = vad.process_frame(_chunk(0.006))
+    assert not state.is_speaking
+
+
+def test_env_adaptive_off(monkeypatch):
+    monkeypatch.setenv("GALAXY_VAD_ADAPTIVE", "false")
+    cfg = VADConfig.from_env()
+    assert cfg.adaptive is False


### PR DESCRIPTION
## 背景

上一版合入了「语音输入一次性可见诊断看门狗」(PR #1506)。真机运行后,看门狗在 WARNING 级如实打出了确诊信息:

```
🎙️ 语音输入无效:20s 内收到音频(199 块)但【VAD 从未判定为说话】
```

黑盒被打成白盒:麦克风采集**正常**(199 个音频块流入),死在 **VAD** —— 从未把任何一块判为「说话」,所以缓冲区永远为空、Whisper 从不被触发,表现为「对它说话没反应」。

## 根因

`VoiceActivityDetector` 用**固定绝对阈值** `energy_threshold=0.01`(RMS)判活。低增益麦克风上真实语音的 RMS 常低于 0.01,于是 `is_active` 恒为假 → `is_speaking` 恒为假。固定阈值无法适应不同的输入增益 —— 这是一类非常常见的真机问题(用户 Windows 麦克风输入音量偏低)。

## 方案:自适应噪声门限

在固定阈值(保留为「确定是语音」的快路径,既有行为与全部既有测试不变)之外,新增自适应判活:

- 用近段帧能量的**低分位数**(默认 20 分位、窗口 100 帧)估计环境**噪声底**;
- 当能量**显著高于噪声底**(默认 ×3,约 +9.5 dB)时判活;
- 设绝对下限 `adaptive_min_floor ≈ 0.0020`(≈ -54 dBFS)防数字静音/极低底噪误触发;
- **先按历史帧判活、再把当前帧计入**,避免当前语音帧抬高本次门限。

对任意麦克风增益自适应,用户无需先调高系统输入音量。判活仅**增加**灵敏度,不改变对响亮语音/纯静音的既有判定。

## 一体化与可调

- 实时管线以 `VoiceActivityDetector(config=None)` 构造 → 走 `VADConfig.from_env()`,修复**自动全链路生效**;显式传 config 的测试保持确定性不变。
- 全部 `GALAXY_VAD_*` 环境变量可调:`GALAXY_VAD_ADAPTIVE` / `GALAXY_VAD_ENERGY_THRESHOLD` / `GALAXY_VAD_SPEECH_MULT` / `GALAXY_VAD_MIN_FLOOR` / `GALAXY_VAD_MIN_SPEECH_FRAMES`,默认开启。
- 看门狗的「收到音频但没说话」提示同步更新:指向 `GALAXY_VAD_MIN_FLOOR=0.001`(更灵敏)供极端低增益兜底。

## 改动文件

- `core/multimodal/vad.py` —— 自适应噪声门限 + `VADConfig` 新字段与 `from_env()`。
- `core/multimodal/audio_capture_service.py` —— 看门狗「无说话」提示更新为指向调节旋钮。
- `tests/test_vad_adaptive_gain.py`(新增)—— 低增益语音触发 / 稳定底噪不误触发 / 纯静音仍非说话 / 关自适应退回漏判 / env 覆盖。

## 测试

- 新增 7 项自适应 VAD 测试全绿。
- 既有 `test_audio_ingest`(含全部 VAD/features 断言)+ `test_pr7_multimodal_io/wiring` + `test_pr16_canonical_perception_state` + `test_video_ingest` + `test_ingress_bus` + 语音看门狗/ASR 非阻塞,共 **188+ 项全绿**,无回归。
- flake8 + black(line-length=120)干净。

## 用户下一步

真机重跑后,语音看门狗应改报「🎙️ 语音输入正常」。若仍报「无说话」(极端低增益),按提示设 `GALAXY_VAD_MIN_FLOOR=0.001` 或调高 Windows 麦克风输入音量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_