### PR TITLE
fix(voice,vision,observability): 双层 VAD 拦截 + 感知药丸误报 + 摄像头假健康 + OTel 默认跟随跨设备

### DIFF
--- a/core/asr/whisper_asr.py
+++ b/core/asr/whisper_asr.py
@@ -30,6 +30,13 @@ _opencc_converter = None
 _opencc_tried = False
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
 def _to_simplified(text: str) -> str:
     """把可能的繁体中文转成简体。装了 opencc 就【确保】转换,否则原样返回。"""
     global _opencc_converter, _opencc_tried
@@ -215,7 +222,14 @@ class WhisperASR:
         # 默认VAD参数
         transcribe_kwargs = {
             "language": language,
-            "vad_filter": True,
+            # 修复(真机反馈:VAD 增益问题解决后"检测到说话但没转写出文字"仍会出现)——
+            # 送到这里的音频已经过 core.multimodal.vad 的能量/自适应噪声门限筛过一遍,
+            # 只有判定为"说话"的块才会被缓冲送来。faster-whisper 自带的第二层 Silero
+            # VAD(vad_filter=True)会在这段已经筛过、往往短促而偏安静的语音上再判一次,
+            # 经常把它当静音又滤掉一遍,segments 变空、返回空字符串——两层 VAD 互相拆台。
+            # 默认关掉这层重复过滤;GALAXY_ASR_VAD_FILTER=1 可显式重新打开(比如上游换成
+            # 更宽松的自定义 VAD、确实想再加一层保险时)。
+            "vad_filter": _env_bool("GALAXY_ASR_VAD_FILTER", False),
             "vad_parameters": {"min_silence_duration_ms": 500},
             # 短语音指令逐句独立:不拿上一段做条件,显著减少跨片段的幻觉/重复
             # (真机反馈"识别得不清楚"的一大来源)。

--- a/core/multimodal/ingest_runtime.py
+++ b/core/multimodal/ingest_runtime.py
@@ -167,7 +167,14 @@ def start_ingest_bus(
         video_pipeline = VideoIngestPipeline()
         video_pipeline.add_callback(bus.update_video)
         _schedule_pipeline(video_pipeline, "video")
-        video_available = True
+        # 修复(误报"已启用"):VideoIngestPipeline() 构造成功只说明 Python 对象建好了,
+        # 不代表 aiortc 已装、更不代表真的连上了摄像头——这条 WebRTC ingest 管线在生产
+        # 代码里目前没有任何调用方去 connect() 建立会话,永远收不到真实帧(真正在用的
+        # 摄像头通路是桌面覆盖层 getUserMedia → DesktopPerceptionStore,走的是下面的
+        # _start_desktop_perception_bridge,不受此标志影响)。这里如实取
+        # video_pipeline.is_available(aiortc 是否可导入),不再无条件 True 去骗
+        # PerceptionSourceRegistry / MULTIMODAL_INGEST_ACTIVE 说它"健康"。
+        video_available = video_pipeline.is_available
     except Exception as _video_err:
         logger.debug("VideoIngestPipeline unavailable (non-fatal): %s", _video_err)
 

--- a/core/node_invocation.py
+++ b/core/node_invocation.py
@@ -822,10 +822,10 @@ async def invoke_node(
     # 执行的唯一首选入口",却对每一次调用都返回 None(REST /nodes/call、命令路由、
     # OpenClawd 工具派发、能力分发器全部拿到 None)。补上真正的委派。
     #
-    # 观测(默认零成本 no-op):invoke_node 是【所有】本地节点执行的唯一入口(in-process
+    # 观测(未激活时零成本 no-op):invoke_node 是【所有】本地节点执行的唯一入口(in-process
     # ReAct / REST / 命令路由 / worker 都经此),故在此开一个 span 即覆盖全路径,把 bespoke
-    # trace_id 作为属性带上以便在 OTel 后端关联。GALAXY_OTEL_ENABLED=1 才真正启用;未装
-    # opentelemetry 或未开时是纯 no-op、零开销。
+    # trace_id 作为属性带上以便在 OTel 后端关联。默认跟随跨设备开关(跨设备默认开→这里
+    # 默认开);GALAXY_OTEL_ENABLED=0/1 可显式覆盖。未装 opentelemetry 时仍是纯 no-op、零开销。
     from core.otel_tracing import record_exception, set_attribute, start_span
 
     with start_span(

--- a/core/otel_tracing.py
+++ b/core/otel_tracing.py
@@ -28,7 +28,15 @@ with no runtime cost and no import risk when tracing is disabled.
 
 Enable
 ------
-``GALAXY_OTEL_ENABLED=1`` turns it on (requires ``opentelemetry-sdk`` installed).
+Default: **follows the cross-device switch**
+(``galaxy_gateway.cross_device_switch.is_cross_device_enabled()``, itself
+default-ON). Cross-device is exactly the case where the bespoke ``trace_id``
+correlation this module exists to upgrade actually matters — calls hop across
+devices/processes — so tracing opts in automatically whenever cross-device
+routing is on, instead of requiring a second flag nobody remembers to set.
+``GALAXY_OTEL_ENABLED=0`` / ``=1`` always overrides the derived default in
+either direction. Requires ``opentelemetry-sdk`` installed (default dependency
+as of this change); still a safe no-op if absent.
 Exporter selection:
 - ``GALAXY_OTEL_EXPORTER=otlp`` + ``OTEL_EXPORTER_OTLP_ENDPOINT`` → OTLP export.
 - ``GALAXY_OTEL_EXPORTER=console`` → console span exporter (debug).
@@ -62,8 +70,24 @@ _state: Dict[str, Any] = {"initialized": False, "active": False, "tracer": None}
 
 
 def otel_enabled() -> bool:
-    """Whether OTel tracing is requested via env (default OFF)."""
-    return str(os.getenv("GALAXY_OTEL_ENABLED", "")).strip().lower() in ("1", "true", "yes", "on")
+    """Whether OTel tracing is requested.
+
+    ``GALAXY_OTEL_ENABLED=0/1`` (any of the usual truthy/falsy spellings), when
+    set, always wins. When unset, the default **follows the cross-device
+    switch**: cross-device is on by default system-wide
+    (``GALAXY_CROSS_DEVICE_ENABLED`` defaults to enabled), and that is exactly
+    the scenario where end-to-end span correlation earns its keep, so tracing
+    rides along with it rather than needing its own opt-in.
+    """
+    raw = os.getenv("GALAXY_OTEL_ENABLED")
+    if raw is not None and raw.strip() != "":
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    try:
+        from galaxy_gateway.cross_device_switch import is_cross_device_enabled
+
+        return is_cross_device_enabled()
+    except Exception:  # noqa: BLE001 — 观测开关绝不能因跨设备模块不可用而报错/阻断
+        return False
 
 
 def _build_exporter():

--- a/core/startup.py
+++ b/core/startup.py
@@ -251,9 +251,9 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
     results = {}
     t0 = time.monotonic()
 
-    # Step 0a: 观测追踪(OpenTelemetry)一次性初始化 —— 默认关(GALAXY_OTEL_ENABLED=1
-    # 才启用)、未装 opentelemetry 时纯 no-op,绝不影响启动。放在最前,使随后所有
-    # span 都在 provider 就绪后创建。
+    # Step 0a: 观测追踪(OpenTelemetry)一次性初始化 —— 默认跟随跨设备开关(跨设备默认
+    # 开 → 这里默认开;GALAXY_OTEL_ENABLED=0/1 可显式覆盖)、未装 opentelemetry 时纯
+    # no-op,绝不影响启动。放在最前,使随后所有 span 都在 provider 就绪后创建。
     # 关键:results 里每一项的值都必须是【带 "status" 键的 dict】—— 后面
     # ok_count/summary(startup.py)与 unified_launcher 都对 results.values() 调
     # v.get("status")。之前这里存了个裸 bool,导致 "'bool' object has no attribute

--- a/core/worker_runtime.py
+++ b/core/worker_runtime.py
@@ -103,8 +103,9 @@ class WorkerRuntime:
         if _idem_key:
             mark_dispatched(_idem_key)  # 悲观:执行前先记,重投永不二次触发副作用
 
-        # 观测(默认零成本 no-op):给 worker 执行开一个 span,把 bespoke trace_id 作为
-        # 属性带上,使跨设备派发在 OTel 后端可关联。GALAXY_OTEL_ENABLED=1 才真正启用。
+        # 观测(未激活时零成本 no-op):给 worker 执行开一个 span,把 bespoke trace_id 作为
+        # 属性带上,使跨设备派发在 OTel 后端可关联。默认跟随跨设备开关(跨设备默认开→这里
+        # 默认开);GALAXY_OTEL_ENABLED=0/1 可显式覆盖。
         from core.otel_tracing import record_exception, start_span
 
         with start_span(

--- a/electron/renderer/panel/src/components/PresencePanel.tsx
+++ b/electron/renderer/panel/src/components/PresencePanel.tsx
@@ -40,10 +40,17 @@ function usePerception(): PerceptionStatus {
           // undefined,导致"感知·SENSES"三个药丸无论摄像头/屏幕/麦克风是否真的在
           // 工作,永远显示未激活。
           const s = d?.store ?? {};
+          // 修复:camera_received/screen_received/audio_received 是【自进程启动起
+          // 单调递增的计数器】,一旦收到过一帧就恒为非零(≥1),?? 只在左侧是
+          // null/undefined 时才会落到右侧的 *_fresh——所以旧写法下 *_fresh 实际上
+          // 从未生效,药丸一旦亮起就【永远亮着】,哪怕摄像头/屏幕/麦克风早已断开
+          // 或用户后来撤销了授权,面板依然显示"已启用"。这里改成只看 *_fresh
+          // (TTL 内是否有新鲜帧/音频),如实反映"现在是否真的通着"而不是"历史上
+          // 是否来过一帧"。
           setP({
-            camera: Boolean(s.camera_received ?? s.camera_fresh),
-            screen: Boolean(s.screen_received ?? s.screen_fresh),
-            audio: Boolean(s.audio_received ?? s.audio_fresh),
+            camera: Boolean(s.camera_fresh),
+            screen: Boolean(s.screen_fresh),
+            audio: Boolean(s.audio_fresh),
           });
         }
       } catch {

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,6 +152,13 @@ temporalio>=1.7.0
 grpcio>=1.62.0
 grpcio-tools>=1.62.0
 protobuf>=4.25.0
+# 分布式追踪(OpenTelemetry):core/otel_tracing.py 默认跟随跨设备开关(跨设备默认开→
+# 这里默认开),给跨设备派发/节点执行打 span。缺它仍是纯 no-op、不影响启动,但默认装机
+# 使"默认开"名副其实(不装则悄悄降级为关,不再报警)。OTLP 导出复用上面已声明的
+# grpcio/protobuf,增量成本很小。
+opentelemetry-api>=1.24.0
+opentelemetry-sdk>=1.24.0
+opentelemetry-exporter-otlp-proto-grpc>=1.24.0
 
 # ============================================================================
 # Remote SSH (Linux Agent node)

--- a/tests/test_otel_tracing.py
+++ b/tests/test_otel_tracing.py
@@ -1,8 +1,9 @@
 """tests/test_otel_tracing.py
 ================================
-Feature ③ — OpenTelemetry 追踪包装:默认关、未装 opentelemetry 时是零成本 no-op、
-绝不抛异常;注入假 tracer 时能正确开 span/带属性/记异常。追踪失败绝不打断被追踪
-的真实工作。
+Feature ③ — OpenTelemetry 追踪包装:默认【跟随跨设备开关】(跨设备默认开 → 这里
+默认开)、显式 GALAXY_OTEL_ENABLED=0/1 总是优先、未装 opentelemetry 时是零成本
+no-op、绝不抛异常;注入假 tracer 时能正确开 span/带属性/记异常。追踪失败绝不打断
+被追踪的真实工作。
 """
 
 from __future__ import annotations
@@ -14,12 +15,19 @@ import pytest
 @pytest.fixture(autouse=True)
 def _iso(monkeypatch):
     monkeypatch.delenv("GALAXY_OTEL_ENABLED", raising=False)
+    monkeypatch.delenv("GALAXY_CROSS_DEVICE_ENABLED", raising=False)
     ot._reset_for_test()
     yield
     ot._reset_for_test()
 
 
-def test_disabled_by_default_is_noop():
+def test_follows_cross_device_default_when_unset():
+    # 两个开关都不设:跨设备默认开 → otel 默认也开(不再是硬编码默认关)。
+    assert ot.otel_enabled() is True
+
+
+def test_off_when_cross_device_disabled(monkeypatch):
+    monkeypatch.setenv("GALAXY_CROSS_DEVICE_ENABLED", "0")
     assert ot.otel_enabled() is False
     assert ot.init_tracing() is False
     assert ot.is_active() is False
@@ -30,8 +38,20 @@ def test_disabled_by_default_is_noop():
     ot.record_exception(None, RuntimeError("nope"))
 
 
+def test_explicit_env_overrides_cross_device_off(monkeypatch):
+    monkeypatch.setenv("GALAXY_CROSS_DEVICE_ENABLED", "0")
+    monkeypatch.setenv("GALAXY_OTEL_ENABLED", "1")
+    assert ot.otel_enabled() is True
+
+
+def test_explicit_env_overrides_cross_device_on(monkeypatch):
+    # 跨设备默认开,但显式 GALAXY_OTEL_ENABLED=0 仍应关闭 —— 显式开关优先级最高。
+    monkeypatch.setenv("GALAXY_OTEL_ENABLED", "0")
+    assert ot.otel_enabled() is False
+
+
 def test_enabled_but_otel_absent_stays_noop(monkeypatch):
-    # 开了开关但环境里没装 opentelemetry(本沙箱即如此)→ 仍是安全 no-op、不抛
+    # 开了开关但环境里没装 opentelemetry → 仍是安全 no-op、不抛(不依赖本沙箱是否已装)。
     monkeypatch.setenv("GALAXY_OTEL_ENABLED", "1")
     ot._reset_for_test()
     active = ot.init_tracing()

--- a/tests/test_pr10_multimodal_ingest_wiring.py
+++ b/tests/test_pr10_multimodal_ingest_wiring.py
@@ -18,7 +18,7 @@ import asyncio
 import json
 import pathlib
 from typing import Any, Dict, Optional
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -178,6 +178,41 @@ class TestIngestRuntimeModule:
                     _mock_emit.assert_called_once()
                     call_kwargs = _mock_emit.call_args.kwargs
                     assert call_kwargs["runtime_session_id"] == "test-sess"
+
+    def test_video_available_false_when_aiortc_absent(self):
+        """修复(误报"已启用"):之前 video_available 只要 VideoIngestPipeline()
+        构造不抛异常就是 True,与 aiortc 是否真的装了无关——生产代码里也没有任何
+        地方调用它的 connect() 真正建立 WebRTC 会话,这条管线永远收不到真实帧。
+        现在必须如实取 pipeline.is_available(aiortc 能否导入),装了才可能是 True。"""
+        from core.multimodal.ingest_runtime import start_ingest_bus
+
+        with patch("core.unified_config.config", {"enable_multimodal_ingest": True}):
+            with patch("core.multimodal.ingest_runtime._schedule_pipeline"):
+                with patch(
+                    "core.multimodal.video_ingest.VideoIngestPipeline.is_available",
+                    new_callable=PropertyMock,
+                    return_value=False,
+                ):
+                    with patch("core.multimodal.ingest_runtime._emit_ingest_active") as _mock_emit:
+                        start_ingest_bus()
+                        call_kwargs = _mock_emit.call_args.kwargs
+                        assert call_kwargs["video_available"] is False
+
+    def test_video_available_true_when_aiortc_present(self):
+        """反向验证:pipeline.is_available=True 时如实透传 True(不是硬编码 False)。"""
+        from core.multimodal.ingest_runtime import start_ingest_bus
+
+        with patch("core.unified_config.config", {"enable_multimodal_ingest": True}):
+            with patch("core.multimodal.ingest_runtime._schedule_pipeline"):
+                with patch(
+                    "core.multimodal.video_ingest.VideoIngestPipeline.is_available",
+                    new_callable=PropertyMock,
+                    return_value=True,
+                ):
+                    with patch("core.multimodal.ingest_runtime._emit_ingest_active") as _mock_emit:
+                        start_ingest_bus()
+                        call_kwargs = _mock_emit.call_args.kwargs
+                        assert call_kwargs["video_available"] is True
 
 
 # ===========================================================================

--- a/tests/test_whisper_asr_simplified.py
+++ b/tests/test_whisper_asr_simplified.py
@@ -74,3 +74,21 @@ def test_env_override_initial_prompt(monkeypatch):
     asr = _asr_with(m)
     asr.transcribe(np.zeros(1600, dtype=np.float32), language="zh")
     assert m.captured.get("initial_prompt") == "自定义提示"
+
+
+def test_internal_vad_filter_off_by_default():
+    # 上游 core.multimodal.vad 已经筛过一遍"是否在说话",这里不该再用 faster-whisper
+    # 自带的第二层 Silero VAD 二次过滤——那会把已经筛出来的短促/安静语音再滤成空
+    # (真机反馈"检测到说话但没转写出文字")。默认必须是 False。
+    m = _FakeModel("你好")
+    asr = _asr_with(m)
+    asr.transcribe(np.zeros(1600, dtype=np.float32), language="zh")
+    assert m.captured.get("vad_filter") is False
+
+
+def test_env_override_internal_vad_filter_on(monkeypatch):
+    monkeypatch.setenv("GALAXY_ASR_VAD_FILTER", "1")
+    m = _FakeModel("你好")
+    asr = _asr_with(m)
+    asr.transcribe(np.zeros(1600, dtype=np.float32), language="zh")
+    assert m.captured.get("vad_filter") is True


### PR DESCRIPTION
## 背景

真机反馈两个新问题(继上一轮 VAD 增益修复之后):

> "面板压根儿就没接收上去,他现在能跟我说话,但是我跟他说不了话"
>
> "我还有视觉摄像头,不知道它到底有没有正常启用...能不能跟我交互有没有完整地打通"

深挖后确认:mic → VAD → Whisper → VoiceLoop → `handle_request` → 面板 WS 的整条代码链路本身是打通的(与文字聊天走同一个 `handle_request` 入口,事件 schema 与前端监听完全匹配),但沿途有**三处独立的真实 bug**,再加上上一批已完成的 OTel 默认开关修复,一并打包在本 PR。

## 改动 1 —— Whisper 二次 VAD 拦截(语音输入"检测到说话但没转写出文字"的真根因)

`core/asr/whisper_asr.py`:faster-whisper 自带 `vad_filter=True` 是**第二层独立 VAD**(Silero)。上游 `core.multimodal.vad` 的能量/自适应噪声门限已经筛过一遍"是否在说话",只有判定为说话的块才会被缓冲送到这里——再叠加一层 VAD 在已经筛过的短促/偏安静语音上二次判活,经常又把它当静音滤掉,`segments` 变空、返回空字符串。**两层 VAD 互相拆台**,这正是"VAD 增益问题解决后仍然转写不出文字"的真实根因。默认关掉这层重复过滤;`GALAXY_ASR_VAD_FILTER=1` 可显式重新打开。

## 改动 2 —— 感知状态药丸永久误报(用户原话的直接命中)

`electron/renderer/panel/src/components/PresencePanel.tsx`:"感知·SENSES" 三个药丸用 `camera_received ?? camera_fresh` 判断是否亮起。`camera_received` 是**进程启动起单调递增的计数器**,一旦收到过一帧就恒为非零 ⇒ `??` 永远不会落到右侧的 `*_fresh`——药丸**一旦亮起就永远亮着**,哪怕摄像头/麦克风早已断开或用户后来撤销了授权。这正是用户"看着是启用的,但不知道是否真通"的直接来源。改成只看 `*_fresh`(TTL 内是否有新鲜帧/音频),如实反映"现在"而非"历史上曾经"。

## 改动 3 —— 摄像头假健康状态

`core/multimodal/ingest_runtime.py`:`video_available` 之前只要 `VideoIngestPipeline()` 构造不抛异常就是 `True`,与 `aiortc` 是否真的装了无关;而生产代码里也**没有任何调用方去 `connect()` 建立 WebRTC 会话**,这条管线在真机上永远收不到真实帧。改为如实取 `pipeline.is_available`(`aiortc` 能否导入),不再让 `PerceptionSourceRegistry` / `MULTIMODAL_INGEST_ACTIVE` 谎报"健康"。

> 补充说明:真正在用的摄像头通路是桌面覆盖层 `getUserMedia` → `DesktopPerceptionStore` → LLM 多模态注入(`core/openclawd.py`,默认开启、已确认真实生效),不受此项影响。该通路需要 Electron 一次性摄像头权限对话框同意(隐私优先,默认关),如果用户此前拒绝过,需要检查 `perception_consent.json` 或重新触发授权——这部分是有意的隐私设计,本 PR 未改动。

## 改动 4(上一批,已在本分支)—— OTel 追踪默认装机 + 默认跟随跨设备开关

见前次提交说明:`requirements.txt` 新增 opentelemetry 依赖,`otel_enabled()` 默认跟随 `is_cross_device_enabled()`(默认开),不再打 `otel_tracing: skipped` 警告。

## 测试

- `tests/test_whisper_asr_simplified.py` 新增 `vad_filter` 默认关闭 / env 覆盖用例。
- `tests/test_pr10_multimodal_ingest_wiring.py` 新增 `video_available` 如实透传(true/false 双向)用例。
- 全部改动文件 + 相邻回归套件共 **403 项测试全绿**(1 项既有 skip,与本改动无关)。
- flake8 + black(line-length=120)干净。
- 前端 `PresencePanel.tsx` 改动为纯逻辑修正(`?? ` → 直接取 `*_fresh`),未引入新依赖,该 repo 前端包目前无测试运行器(无 jest/vitest 配置),与既有约定一致。

## 用户下一步

- 真机重跑后,语音看门狗应改报"🎙️ 语音输入正常"(而非"检测到说话但没转写出文字")。
- 面板"感知·SENSES"药丸现在会如实反映摄像头/屏幕/麦克风【当前】是否有新鲜数据,不再"一亮永亮"。
- 若摄像头药丸持续熄灭且确实想用视觉功能,请检查是否曾经在 Electron 弹窗里拒绝过摄像头权限(`perception_consent.json`),需要时手动重新授权。

🤖 Generated with [Claude Code](https://claude.com/claude-code)