### PR TITLE
fix(startup): 真正把 OpenTelemetry SDK 装上——否则"默认开"只是纸面开关

### DIFF
--- a/main.py
+++ b/main.py
@@ -594,6 +594,14 @@ def phase2_ensure_deps(env_status: dict) -> bool:
         # 也没有 → 真机全新克隆缺包,speech_output 每次合成静默失败,表现为
         # "回复文字出来了、一句话都不说"。包本身很小(纯 HTTP 客户端)。
         "edge_tts": "edge-tts",
+        # 分布式追踪(OpenTelemetry SDK):core/otel_tracing.py 默认跟随跨设备开关
+        # 而开(跨设备默认开),但只有这里真的把包装上,"默认开"才不只是纸面上的
+        # 开关——否则每次全新 clone 后 import 失败,仍会静默降级为 no-op、启动摘要
+        # 里打"otel_tracing: skipped"警告。纯 Python、无重型原生依赖,装得快,跟
+        # jsonschema/tqdm 一个量级,放进阻塞式核心依赖清单不会拖慢首启。
+        # (OTLP 导出器额外依赖 grpcio,较重且默认不导出——按需手动装,见下方引导,
+        # 不放进这里,呼应"语音依赖不阻塞首启"的同一条原则。)
+        "opentelemetry.sdk": "opentelemetry-sdk",
     }
     # 高性能事件循环(平台各取所需):Windows 默认 Proactor 循环开销大(真机:
     # 面板首开并发把循环拖出 10s 级冻结),winloop ≈5×;Linux/macOS 用 uvloop。
@@ -833,6 +841,18 @@ def phase2_ensure_deps(env_status: dict) -> bool:
     except Exception:
         print_item("PyAudio 未安装(可选)", "warn",
                    "手动: apt install portaudio19-dev && pip install pyaudio")
+
+    # OTLP 导出器(可选;真正导出追踪数据到 Jaeger/Tempo 等后端时才需要,依赖较重
+    # 的 grpcio,默认 GALAXY_OTEL_EXPORTER 未设时用不上——不在首启阻塞安装,
+    # 同一条"首启健壮"原则,按需手动装)
+    try:
+        __import__("opentelemetry.exporter.otlp.proto.grpc.trace_exporter")
+    except Exception:
+        print_item(
+            "OTLP 追踪导出器未安装(可选,导出到 Jaeger/Tempo 等才需要)",
+            "warn",
+            "手动: pip install opentelemetry-exporter-otlp-proto-grpc",
+        )
 
     return all_ok
 


### PR DESCRIPTION
## 背景

真机反馈:合并 #1508(OTel 默认跟随跨设备开关而开)之后,`otel_tracing: skipped` 警告仍在。

## 根因

#1508 只在 `requirements.txt` 里声明了 opentelemetry 依赖,但用户的实际用法是**每次全新 `git clone` 后直接 `python main.py`**,从不手动跑 `pip install -r requirements.txt`——机器上从来没真的装过这个包。`otel_enabled()` 的默认值确实拨对了(跟随跨设备开关,默认 True),但 `init_tracing()` 一 import 就失败,安全降级为 no-op——开关拨对了,可包根本不在,状态自然还是 `skipped`。

## 方案

本仓库刚好在同一批(#1509,`430335b`)确立了一条原则:**首启不阻塞安装重型/网络依赖的可选组件**(语音栈 sounddevice/faster-whisper 改成引导手动装,而不是每次启动都现装)。照着同一条原则,把 OTel 相关依赖拆成两块:

- **`opentelemetry-sdk`**(纯 Python、无重型原生依赖,体积跟已经在自动装清单里的 `jsonschema`/`tqdm`一个量级)——加进 `main.py` Phase 2 的阻塞式核心依赖清单,首启自动装上,不会拖慢首启,直接让"默认开"变成真的开。
- **`opentelemetry-exporter-otlp-proto-grpc`**(依赖较重的 `grpcio`,且只有显式设 `GALAXY_OTEL_EXPORTER=otlp` 才用得上,不影响"默认开、不报警"这个基线状态)——保持可选,改为清晰打印引导(`pip install opentelemetry-exporter-otlp-proto-grpc`),不自动装,呼应语音依赖同一条"首启健壮"原则。

## 改动

`main.py`:
- `phase2_ensure_deps()` 的阻塞式 `core_modules` 依赖清单新增 `opentelemetry.sdk` → `opentelemetry-sdk`。
- pyaudio 引导块之后新增 OTLP 导出器的引导打印(不自动装)。

## 验证

- 语法检查通过;`git diff` 确认新增代码块本身已是 black 格式(`main.py` 本身不在 CI 的 `black --check core/ tests/` 覆盖范围内,是仓库既有状态,与本次改动无关)。
- 手动验证探测逻辑:装了 `opentelemetry.sdk` → 不会重复安装;未装 OTLP 导出器 → 打印引导而非阻塞安装。
- `tests/test_otel_tracing.py` 既有 7 项测试全绿(逻辑未变,只是让依赖真正落地)。
- `phase2_ensure_deps` 本身在仓库里没有专门的单元测试覆盖(与 #1509 的改动一致,未新增)。

## 用户下一步

拉最新代码后重新 `python main.py`(全新 clone 或已有环境均可),Phase 2 会自动装上 `opentelemetry-sdk`,启动日志里应不再出现 `otel_tracing: skipped` 这行警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_