### PR TITLE
fix(setup): 克隆界面补上 Docker/Podman 选择——真根因是首启向导没在跑

### DIFF
--- a/main.py
+++ b/main.py
@@ -838,10 +838,19 @@ def phase2_ensure_deps(env_status: dict) -> bool:
 
 
 def _run_setup_wizard() -> int:
-    """Run the interactive setup wizard."""
+    """Run the interactive setup wizard.
+
+    真 bug 修复:此前不带任何参数调用 setup_wizard.py,而它的 main() 在没有
+    --interactive/--quick/--test 时默认落到 quick_setup()(纯非交互、只从环境变量
+    探测 API Key,探测不到就打印一行提示直接退出)——也就是说 start.bat 首启(无 .env
+    时自动跑 `python main.py --setup`)实际上【什么交互向导都没跑】,包括数据库/
+    容器运行时(Docker/Podman)配置在内的整个 run_interactive_setup() 流程全被跳过。
+    这正是"克隆界面里没有 Docker/Podman 选择"的根因——不是选项没做,是这条路径
+    压根没跑到有选项的那个函数。显式传 --interactive 走真正的交互向导。
+    """
     wizard_path = PROJECT_ROOT / "setup_wizard.py"
     if wizard_path.exists():
-        sys.exit(subprocess.call([sys.executable, str(wizard_path)]))
+        sys.exit(subprocess.call([sys.executable, str(wizard_path), "--interactive"]))
     else:
         logger.info("Configuration wizard not found: %s", wizard_path)  # L2 fixed
         sys.exit(1)

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -390,12 +390,32 @@ class SetupWizard:
             
     def _configure_databases(self):
         """配置数据库"""
+        # 容器运行时选择(Docker / Podman)——此前这里对每个数据库都写死打印
+        # "docker run ..."，完全没有 Podman 选项、也没给用户任何选择机会。
+        # 复用 core.container_runtime 里已实现、已测试的选择器(交互菜单/推荐项/
+        # 安装指引全部一套逻辑),而不是在这里重新造一遍不一致的文案。选一次，
+        # 后面所有数据库共用同一个运行时(与 unified_launcher.ensure_docker_infra
+        # 的语义一致：系统级只选一个容器运行时，不是逐个数据库分别选)。
+        runtime = ""
+        try:
+            from core import container_runtime as cr
+            runtime = cr.resolve_runtime(interactive=True)
+        except Exception:
+            runtime = ""
+        rt_bin = runtime or "docker"
+        rt_label = cr.display_name(runtime) if runtime else "Docker"
+
         for db in DATABASE_CONFIGS:
             print(f"\n{Colors.BOLD}{db['name']}{Colors.ENDC} - {db['description']}")
             print(f"  环境变量: {db['env_var']}")
             print(f"  默认值: {db['default']}")
-            print(f"  Docker 部署: {db['docker_cmd']}")
-            
+            # Podman 的 CLI 与 Docker 基本兼容（`podman run` 同名参数），故直接替换
+            # 命令前缀即可，不需要为每个数据库单独维护一份 Podman 命令。
+            cmd = db['docker_cmd']
+            if rt_bin != "docker":
+                cmd = cmd.replace("docker run", f"{rt_bin} run", 1)
+            print(f"  {rt_label} 部署: {cmd}")
+
             current = self.config.get(db['env_var'])
             if current:
                 print(f"  当前值: {current}")

--- a/tests/test_setup_wizard_container_runtime.py
+++ b/tests/test_setup_wizard_container_runtime.py
@@ -1,0 +1,105 @@
+"""tests/test_setup_wizard_container_runtime.py
+==================================================
+克隆界面（首启配置向导）回归防护:两个真 bug 的锁定测试。
+
+Bug 1 —— setup_wizard._configure_databases() 此前对每个数据库都写死打印
+"docker run ..."，完全没有 Podman 选项。现应复用 core.container_runtime 的
+选择器（不重新造文案），并把选中的运行时代入命令前缀。
+
+Bug 2 —— main.py::_run_setup_wizard() 此前调用 setup_wizard.py 不带任何参数，
+落到其 main() 的默认分支 quick_setup()（纯非交互，探测不到 env API Key 就直接
+退出），导致 start.bat 首启（无 .env 时自动 `python main.py --setup`）实际上
+【整个交互向导都没跑】——包括数据库/容器运行时选择在内的 run_interactive_setup()
+全部被跳过。这正是"克隆界面里没有 Docker/Podman 选择"的根因。
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from core import container_runtime as cr
+import setup_wizard as sw
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    # 隔离持久化文件与环境,避免污染真实 .galaxy_runtime / 真实 stdin。
+    monkeypatch.setattr(cr, "_CHOICE_FILE", tmp_path / ".galaxy_runtime")
+    monkeypatch.delenv("GALAXY_CONTAINER_RUNTIME", raising=False)
+
+
+def _run_configure_databases(monkeypatch, capsys, stdin_text: str, which_map: dict):
+    monkeypatch.setattr(cr.shutil, "which", lambda name: which_map.get(name))
+    fake_stdin = io.StringIO(stdin_text)
+    fake_stdin.isatty = lambda: True  # 让 interactive_select 走真正的菜单分支
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    wiz = sw.SetupWizard()
+    wiz.config = {}
+    wiz._configure_databases()
+    return capsys.readouterr().out
+
+
+def test_configure_databases_offers_podman_choice_when_both_installed(monkeypatch, capsys):
+    """两者都装时,_configure_databases 必须展示 Docker/Podman 选择菜单(回归 bug 1)。"""
+    out = _run_configure_databases(
+        monkeypatch, capsys,
+        stdin_text="1\n" + "\n" * 20,  # '1' = Podman(推荐,排最前）
+        which_map={"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"},
+    )
+    assert "选择容器运行时" in out
+    assert "Podman" in out and "Docker" in out
+
+
+def test_configure_databases_substitutes_chosen_runtime_into_commands(monkeypatch, capsys):
+    """选 Podman 后,打印的部署命令必须是 podman run,而不是硬编码的 docker run。"""
+    out = _run_configure_databases(
+        monkeypatch, capsys,
+        stdin_text="1\n" + "\n" * 20,
+        which_map={"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"},
+    )
+    assert "podman run" in out
+    assert "docker run" not in out
+    assert "Podman 部署:" in out
+
+
+def test_configure_databases_falls_back_to_docker_when_only_docker_installed(monkeypatch, capsys):
+    """只装了 Docker 时不应打扰用户选择,直接沿用 docker(与 resolve_runtime 语义一致)。"""
+    out = _run_configure_databases(
+        monkeypatch, capsys,
+        stdin_text="\n" * 20,
+        which_map={"docker": "/usr/bin/docker"},
+    )
+    assert "docker run" in out
+    assert "Docker 部署:" in out
+
+
+def test_run_setup_wizard_invokes_interactive_flag(monkeypatch, tmp_path):
+    """main.py::_run_setup_wizard 必须传 --interactive,否则落到无交互的 quick_setup()
+    （bug 2 的根因）——用一个假的 setup_wizard.py 路径 + mock subprocess.call 锁定调用参数。
+    """
+    import main as main_mod
+
+    captured = {}
+
+    def _fake_call(cmd, *a, **k):
+        captured["cmd"] = cmd
+        return 0
+
+    fake_wizard = tmp_path / "setup_wizard.py"
+    fake_wizard.write_text("# stub\n", encoding="utf-8")
+
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(main_mod.subprocess, "call", _fake_call)
+    monkeypatch.setattr(main_mod.sys, "exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit):
+        main_mod._run_setup_wizard()
+
+    assert "cmd" in captured, "subprocess.call 应被调用"
+    assert "--interactive" in captured["cmd"], (
+        f"_run_setup_wizard 必须传 --interactive,实际调用: {captured['cmd']}"
+    )


### PR DESCRIPTION
## 背景 / 问题

所有者报告:克隆后首启的"克隆界面"里没有 Docker/Podman 选择。

排查发现 `core/container_runtime.py` 里其实早已有一套完整的交互选择器(菜单、Podman 推荐项、安装指引),从未被删除——`git log -S"podman"` 确认它今天(`6cbe299`)刚被增强,不存在"被移除"的历史。但它只接在 `unified_launcher.py` 的常规启动流程里。真正的"克隆界面"是 **`start.bat` 首启(无 `.env` 时)自动执行的 `python main.py --setup`**,这条路径命中两个真 bug。

## 根因 & 修复

1. **`main.py::_run_setup_wizard()` 调用 `setup_wizard.py` 不带任何参数** —— 而 `setup_wizard.py` 的 `main()` 在没有 `--interactive`/`--quick`/`--test` 时默认落到 `quick_setup()`:纯非交互,只从环境变量探测 API Key,探测不到就打印一行提示直接退出。**也就是说包含数据库/容器运行时配置在内的整个交互向导 `run_interactive_setup()` 从来没被跑过。**
   → 补 `--interactive` 参数。

2. 即便向导真的跑起来,`_configure_databases()` 此前对每个数据库都写死打印 `"docker run ..."`,**完全没有 Podman 选项**。
   → **复用** `core.container_runtime` 里已实现、已测试的选择器(不重新造文案):选一次容器运行时,代入所有数据库部署命令的前缀(Podman CLI 与 Docker 参数兼容)。

## 验证

- 新增 4 个回归测试锁定这两个 bug(`tests/test_setup_wizard_container_runtime.py`),全过。
- 既有 `tests/test_container_runtime_selection.py` 7 个测试全过,无回归。
- 手动隔离沙盒(临时 choice 文件、mock stdin)跑通 `_configure_databases()`:两者都装时展示菜单选 Podman → 打印命令正确替换为 `podman run`;只装 Docker 时不打扰、照常用 `docker run`。
- 确认未污染真实仓库(`.galaxy_runtime` 本就 gitignore,测试全程用临时路径隔离)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_