### PR TITLE
fix(setup): Docker/Podman 选择——单一已装时被静默跳过的真根因

### DIFF
--- a/core/container_runtime.py
+++ b/core/container_runtime.py
@@ -288,6 +288,94 @@ def interactive_install_guide() -> str:
     return ""  # 当前仍不可用(安装进行中/待装),偏好已持久化
 
 
+def setup_wizard_select_runtime() -> str:
+    """首启配置向导专用:【总是】展示 Docker/Podman 完整选择菜单,不因为已装了其中
+    一个就静默跳过。
+
+    真 bug 修复:``resolve_runtime()`` 的"只装了一个 → 直接用、不打扰"是【自动化
+    静默启动路径】(``unified_launcher.ensure_docker_infra``,每次 ``python main.py``
+    都会走)的正确设计——不该在日常启动时突然弹一个交互菜单。但配置向导
+    (``setup_wizard.py``,只在 ``python main.py --setup`` 时跑一次)的意图恰恰
+    相反:用户主动来"配置"就是想【看到并做选择】,而不是被代码替他决定。之前
+    ``_configure_databases()`` 直接调用 ``resolve_runtime(interactive=True)``,
+    继承了它"单一已装就跳过菜单"的短路——绝大多数机器只装了 Docker(比 Podman
+    普及得多),于是"Docker/Podman 选择"在向导里实际上【几乎从来不出现】,这正是
+    "压根就没有"这个报告的真根因,而不是菜单代码本身有 bug。
+
+    环境变量 ``GALAXY_CONTAINER_RUNTIME`` 仍是最高优先级(操作者显式指定,任何
+    场景都该尊重,包括这里)。其余情况一律展示菜单;已安装的选项标注"已安装"
+    可直接生效,未安装的选项选中后走安装引导(同 ``interactive_install_guide``
+    的自动装/手动装分支)。非交互终端(无 TTY)不弹菜单,委托给
+    ``resolve_runtime(interactive=False)`` 的静默逻辑,避免在自动化场景卡住。
+    """
+    env = _env_choice()
+    if env in _RUNTIMES and shutil.which(env):
+        save_choice(env)
+        return env
+
+    if not (sys.stdin and sys.stdin.isatty()):
+        return resolve_runtime(interactive=False)
+
+    from core import cli_render as r
+    from core.ascii_art import Colors
+
+    def _c(t, color):
+        return f"{color}{t}{Colors.ENDC}" if r._use_color() else t
+
+    installed = set(available_runtimes())
+    menu = _prefer_recommended(list(_RUNTIMES))
+    print()
+    print("  " + _c("选择容器运行时", Colors.BOLD + Colors.CYAN) + _c("  (后台拉取并运行节点基础设施)", Colors.DIM))
+    r.rule()
+    for i, rt in enumerate(menu, 1):
+        is_first = i == 1
+        marker = _c("▸", Colors.GREEN) if is_first else " "
+        num = _c(f"[{i}]", Colors.BOLD if is_first else Colors.DIM)
+        name = r.pad_display(rt.capitalize(), 10)
+        status = _c("  ✓ 已安装", Colors.GREEN) if rt in installed else _c("  未安装（选中后自动/引导安装）", Colors.DIM)
+        tail = (_c("  ← 推荐" if rt == _RECOMMENDED else "  ← 默认", Colors.GREEN) if is_first else "") + status
+        print(f"  {marker} {num} {name}{tail}")
+        print(f"         {_c(_LABELS.get(rt, ''), Colors.DIM)}")
+    r.rule()
+    print("  " + _c("回车=用默认 · 数字=手选 · s=跳过(桌面照常运行)", Colors.DIM))
+    try:
+        choice = input(f"  请选择运行时 [1-{len(menu)} / 回车 / s]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        choice = ""
+    if choice == "s":
+        return ""
+    pick = menu[0]
+    if choice.isdigit() and 1 <= int(choice) <= len(menu):
+        pick = menu[int(choice) - 1]
+    elif choice in _RUNTIMES:
+        pick = choice
+
+    if pick in installed:
+        save_choice(pick)
+        print("  " + _c(f"已选择: {pick.capitalize()}（已安装，立即生效）", Colors.GREEN))
+        return pick
+
+    # 选中的运行时尚未安装:记住偏好,尽力后台自动装(同 interactive_install_guide
+    # 的安装分支);装好后下次启动即自动采用,本次仍返回 ""(当前不可用)。
+    save_choice(pick)
+    print("  " + _c(f"已记住偏好: {pick.capitalize()}（尚未安装）", Colors.GREEN))
+    if can_auto_install():
+        if background_install(pick):
+            print(
+                "  "
+                + _c(
+                    f"  正在【后台自动安装】{pick.capitalize()}…(日志 logs/container_runtime_install.log;"
+                    f"Windows 会弹一次 UAC 确认)。装好后重跑即自动启用。",
+                    Colors.CYAN,
+                )
+            )
+        else:
+            print("  " + _c(f"  安装(手动): {_INSTALL_HINTS.get(pick, '')}", Colors.DIM))
+    else:
+        print("  " + _c(f"  未检测到可用的自动安装工具,请手动安装: {_INSTALL_HINTS.get(pick, '')}", Colors.DIM))
+    return ""
+
+
 def resolve_runtime(interactive: bool = True) -> str:
     """解析并持久化最终容器运行时。返回运行时名("" = 当前无可用运行时)。
 

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -392,14 +392,20 @@ class SetupWizard:
         """配置数据库"""
         # 容器运行时选择(Docker / Podman)——此前这里对每个数据库都写死打印
         # "docker run ..."，完全没有 Podman 选项、也没给用户任何选择机会。
-        # 复用 core.container_runtime 里已实现、已测试的选择器(交互菜单/推荐项/
-        # 安装指引全部一套逻辑),而不是在这里重新造一遍不一致的文案。选一次，
-        # 后面所有数据库共用同一个运行时(与 unified_launcher.ensure_docker_infra
-        # 的语义一致：系统级只选一个容器运行时，不是逐个数据库分别选)。
+        # 真 bug 修复(第二轮):第一次改用 resolve_runtime(interactive=True) 时，
+        # 仍然继承了它"只装了一个就静默直接用、不弹菜单"的短路——而绝大多数机器
+        # 只装了 Docker(比 Podman 普及得多），于是"选择"在向导里实际上几乎从来
+        # 不出现，复现了"压根就没有"的报告。resolve_runtime 那条短路本身是对的
+        # (它同时服务日常静默启动路径 unified_launcher.ensure_docker_infra，不该
+        # 每次启动都打扰用户），问题是配置向导不该复用它——向导的意图就是让用户
+        # 主动看到并做选择。改用 setup_wizard_select_runtime()：专门给"一次性
+        # 交互配置"场景用，无论已装几个都总是展示完整菜单。选一次，后面所有
+        # 数据库共用同一个运行时(与 ensure_docker_infra 的语义一致：系统级只选
+        # 一个容器运行时，不是逐个数据库分别选)。
         runtime = ""
         try:
             from core import container_runtime as cr
-            runtime = cr.resolve_runtime(interactive=True)
+            runtime = cr.setup_wizard_select_runtime()
         except Exception:
             runtime = ""
         rt_bin = runtime or "docker"

--- a/tests/test_setup_wizard_container_runtime.py
+++ b/tests/test_setup_wizard_container_runtime.py
@@ -1,6 +1,6 @@
 """tests/test_setup_wizard_container_runtime.py
 ==================================================
-克隆界面（首启配置向导）回归防护:两个真 bug 的锁定测试。
+克隆界面（首启配置向导）回归防护:三个真 bug 的锁定测试。
 
 Bug 1 —— setup_wizard._configure_databases() 此前对每个数据库都写死打印
 "docker run ..."，完全没有 Podman 选项。现应复用 core.container_runtime 的
@@ -10,7 +10,17 @@ Bug 2 —— main.py::_run_setup_wizard() 此前调用 setup_wizard.py 不带任
 落到其 main() 的默认分支 quick_setup()（纯非交互，探测不到 env API Key 就直接
 退出），导致 start.bat 首启（无 .env 时自动 `python main.py --setup`）实际上
 【整个交互向导都没跑】——包括数据库/容器运行时选择在内的 run_interactive_setup()
-全部被跳过。这正是"克隆界面里没有 Docker/Podman 选择"的根因。
+全部被跳过。
+
+Bug 3（第二轮真机反馈:"Docker 的和 podman 选择压根就没有啊"）—— Bug 1/2 修完
+后，_configure_databases() 改调 core.container_runtime.resolve_runtime()，但
+该函数的设计是给【日常静默启动】用的（unified_launcher.ensure_docker_infra，
+每次 python main.py 都会走）："只装了一个就直接用，不弹菜单"——这在日常启动
+路径上是对的（不该打扰用户），但绝大多数机器只装了 Docker（比 Podman 普及
+得多），于是首启向导里"选择"实际上几乎从来不出现，正是本轮反馈的根因。
+新增 core.container_runtime.setup_wizard_select_runtime()：专给一次性交互
+配置场景用，无论已装几个都【总是】展示完整菜单；_configure_databases() 改调
+这个新函数，而不是复用日常启动路径的 resolve_runtime()。
 """
 
 from __future__ import annotations
@@ -26,15 +36,18 @@ import setup_wizard as sw
 
 @pytest.fixture(autouse=True)
 def _isolate(monkeypatch, tmp_path):
-    # 隔离持久化文件与环境,避免污染真实 .galaxy_runtime / 真实 stdin。
+    # 隔离持久化文件与环境，避免污染真实 .galaxy_runtime / 真实 stdin。
     monkeypatch.setattr(cr, "_CHOICE_FILE", tmp_path / ".galaxy_runtime")
     monkeypatch.delenv("GALAXY_CONTAINER_RUNTIME", raising=False)
+    # 禁用真实的自动安装尝试（会在 CI/沙盒里真的跑 apt-get/winget 等系统级命令）。
+    monkeypatch.setattr(cr, "can_auto_install", lambda: False)
+    monkeypatch.setattr(cr, "background_install", lambda rt: False)
 
 
 def _run_configure_databases(monkeypatch, capsys, stdin_text: str, which_map: dict):
     monkeypatch.setattr(cr.shutil, "which", lambda name: which_map.get(name))
     fake_stdin = io.StringIO(stdin_text)
-    fake_stdin.isatty = lambda: True  # 让 interactive_select 走真正的菜单分支
+    fake_stdin.isatty = lambda: True
     monkeypatch.setattr(sys, "stdin", fake_stdin)
 
     wiz = sw.SetupWizard()
@@ -43,42 +56,129 @@ def _run_configure_databases(monkeypatch, capsys, stdin_text: str, which_map: di
     return capsys.readouterr().out
 
 
-def test_configure_databases_offers_podman_choice_when_both_installed(monkeypatch, capsys):
-    """两者都装时,_configure_databases 必须展示 Docker/Podman 选择菜单(回归 bug 1)。"""
-    out = _run_configure_databases(
-        monkeypatch, capsys,
-        stdin_text="1\n" + "\n" * 20,  # '1' = Podman(推荐,排最前）
-        which_map={"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"},
-    )
-    assert "选择容器运行时" in out
-    assert "Podman" in out and "Docker" in out
+class TestConfigureDatabasesUsesSetupWizardSelector:
+    """_configure_databases 必须走 setup_wizard_select_runtime（不是 resolve_runtime）。"""
+
+    def test_offers_podman_choice_when_both_installed(self, monkeypatch, capsys):
+        out = _run_configure_databases(
+            monkeypatch, capsys,
+            stdin_text="1\n" + "\n" * 20,  # '1' = Podman（推荐，排最前）
+            which_map={"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"},
+        )
+        assert "选择容器运行时" in out
+        assert "Podman" in out and "Docker" in out
+
+    def test_substitutes_chosen_runtime_into_commands(self, monkeypatch, capsys):
+        out = _run_configure_databases(
+            monkeypatch, capsys,
+            stdin_text="1\n" + "\n" * 20,
+            which_map={"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"},
+        )
+        assert "podman run" in out
+        assert "docker run" not in out
+        assert "Podman 部署:" in out
+
+    def test_menu_still_shown_when_only_docker_installed(self, monkeypatch, capsys):
+        """回归锁定(bug 3 的核心断言):只装 Docker 时，菜单必须依然出现，
+        不能像 resolve_runtime 那样静默跳过——这正是"压根没有选择"的真根因。
+        """
+        out = _run_configure_databases(
+            monkeypatch, capsys,
+            stdin_text="2\n" + "\n" * 20,  # 显式选 [2]=Docker（已安装，立即生效）
+            which_map={"docker": "/usr/bin/docker"},
+        )
+        assert "选择容器运行时" in out, "只装了一个运行时时菜单被跳过——回归了 bug 3"
+        assert "Podman" in out and "Docker" in out, "菜单必须同时列出两个选项，不能只显示已装的那个"
+        assert "docker run" in out
+        assert "Docker 部署:" in out
+
+    def test_can_pick_uninstalled_runtime_when_only_docker_installed(self, monkeypatch, capsys):
+        """只装 Docker 时依然可以【选 Podman】——即便它还没装。"""
+        out = _run_configure_databases(
+            monkeypatch, capsys,
+            stdin_text="1\n" + "\n" * 20,  # '1' = Podman（未安装）
+            which_map={"docker": "/usr/bin/docker"},
+        )
+        assert "已记住偏好: Podman" in out
+        assert cr.load_choice() == "podman"
 
 
-def test_configure_databases_substitutes_chosen_runtime_into_commands(monkeypatch, capsys):
-    """选 Podman 后,打印的部署命令必须是 podman run,而不是硬编码的 docker run。"""
-    out = _run_configure_databases(
-        monkeypatch, capsys,
-        stdin_text="1\n" + "\n" * 20,
-        which_map={"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"},
-    )
-    assert "podman run" in out
-    assert "docker run" not in out
-    assert "Podman 部署:" in out
+class TestSetupWizardSelectRuntime:
+    """core.container_runtime.setup_wizard_select_runtime 的直接单测。"""
 
+    def test_env_var_wins_without_prompting(self, monkeypatch, capsys):
+        monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/podman" if name == "podman" else None)
+        monkeypatch.setenv("GALAXY_CONTAINER_RUNTIME", "podman")
+        result = cr.setup_wizard_select_runtime()
+        assert result == "podman"
+        assert "选择容器运行时" not in capsys.readouterr().out
 
-def test_configure_databases_falls_back_to_docker_when_only_docker_installed(monkeypatch, capsys):
-    """只装了 Docker 时不应打扰用户选择,直接沿用 docker(与 resolve_runtime 语义一致)。"""
-    out = _run_configure_databases(
-        monkeypatch, capsys,
-        stdin_text="\n" * 20,
-        which_map={"docker": "/usr/bin/docker"},
-    )
-    assert "docker run" in out
-    assert "Docker 部署:" in out
+    def test_non_interactive_falls_back_silently(self, monkeypatch):
+        monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+        fake_stdin = io.StringIO("")
+        fake_stdin.isatty = lambda: False
+        monkeypatch.setattr(sys, "stdin", fake_stdin)
+        assert cr.setup_wizard_select_runtime() == "docker"
+
+    def test_single_installed_still_shows_full_menu(self, monkeypatch, capsys):
+        """核心回归断言:与 resolve_runtime 不同，单一已装不应跳过菜单。"""
+        monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+        fake_stdin = io.StringIO("2\n")  # 显式选 Docker
+        fake_stdin.isatty = lambda: True
+        monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+        result = cr.setup_wizard_select_runtime()
+        out = capsys.readouterr().out
+        assert "选择容器运行时" in out
+        assert "Docker" in out and "Podman" in out
+        assert result == "docker"
+
+    def test_picking_installed_runtime_returns_immediately_usable(self, monkeypatch):
+        monkeypatch.setattr(
+            cr.shutil, "which",
+            lambda name: {"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"}.get(name),
+        )
+        fake_stdin = io.StringIO("2\n")  # Docker
+        fake_stdin.isatty = lambda: True
+        monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+        assert cr.setup_wizard_select_runtime() == "docker"
+        assert cr.load_choice() == "docker"
+
+    def test_picking_uninstalled_runtime_saves_preference_and_returns_empty(self, monkeypatch):
+        """选中一个还没装的运行时:偏好必须持久化(下次自动采用),但本次不可用(返回"")。"""
+        monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+        fake_stdin = io.StringIO("1\n")  # Podman，未安装
+        fake_stdin.isatty = lambda: True
+        monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+        result = cr.setup_wizard_select_runtime()
+        assert result == ""
+        assert cr.load_choice() == "podman"
+
+    def test_skip_returns_empty_without_saving(self, monkeypatch):
+        monkeypatch.setattr(cr.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+        fake_stdin = io.StringIO("s\n")
+        fake_stdin.isatty = lambda: True
+        monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+        assert cr.setup_wizard_select_runtime() == ""
+        assert cr.load_choice() == ""
+
+    def test_enter_picks_recommended_default(self, monkeypatch):
+        monkeypatch.setattr(
+            cr.shutil, "which",
+            lambda name: {"docker": "/usr/bin/docker", "podman": "/usr/bin/podman"}.get(name),
+        )
+        fake_stdin = io.StringIO("\n")  # 回车 = 默认（推荐 Podman）
+        fake_stdin.isatty = lambda: True
+        monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+        assert cr.setup_wizard_select_runtime() == "podman"
 
 
 def test_run_setup_wizard_invokes_interactive_flag(monkeypatch, tmp_path):
-    """main.py::_run_setup_wizard 必须传 --interactive,否则落到无交互的 quick_setup()
+    """main.py::_run_setup_wizard 必须传 --interactive，否则落到无交互的 quick_setup()
     （bug 2 的根因）——用一个假的 setup_wizard.py 路径 + mock subprocess.call 锁定调用参数。
     """
     import main as main_mod
@@ -101,5 +201,5 @@ def test_run_setup_wizard_invokes_interactive_flag(monkeypatch, tmp_path):
 
     assert "cmd" in captured, "subprocess.call 应被调用"
     assert "--interactive" in captured["cmd"], (
-        f"_run_setup_wizard 必须传 --interactive,实际调用: {captured['cmd']}"
+        f"_run_setup_wizard 必须传 --interactive，实际调用: {captured['cmd']}"
     )


### PR DESCRIPTION
## 背景

真机反馈(#1511 合并后复测):"Docker 的和 podman 选择压根就没有啊"。

## 排查

#1511 修的两层 bug(向导没真正跑交互模式 + 数据库配置没有运行时选项)确实解决了,但改用的 `core.container_runtime.resolve_runtime(interactive=True)` 继承了它服务**日常静默启动路径**(`unified_launcher.ensure_docker_infra`,每次 `python main.py` 都会走)的设计:"只装了一个就直接用、不打扰用户"。这个短路在日常启动路径上是对的(不该每次启动都弹交互菜单),但**绝大多数机器只装了 Docker**(远比 Podman 普及)——于是首启向导里"选择"实际上几乎从来不出现,正是本轮反馈的真根因。

实测确认(本沙盒环境):

```
detected: {'docker': '/usr/bin/docker', 'podman': None}
=> resolve_runtime(interactive=True) 在只装一个时直接静默返回 'docker',零提示
```

## 修复

新增 `core.container_runtime.setup_wizard_select_runtime()`:专给**一次性交互配置**场景用,无论已装 0/1/2 个都**总是**展示完整菜单(已装的标"✓ 已安装"可立即生效,未装的选中后走自动/引导安装,同 `interactive_install_guide` 的分支);仅当 `GALAXY_CONTAINER_RUNTIME` 显式设置时才跳过(操作者 override,任何场景都该尊重)。`resolve_runtime()` 本身完全不改——日常静默启动路径的行为不受影响。`_configure_databases()` 改调新函数。

## 验证(真实沙盒,非纯 mock)

- 用 `shutil.which` 真实探测(本沙盒只装了 docker)跑通整条 `_configure_databases()` 路径,确认菜单在只装一个的情况下依然完整展示 Docker+Podman 两个选项;选 Podman 后真实触发了后台自动安装(沙盒验证期间确实装上了 podman,仅影响沙盒环境)。
- 两者都装后重跑,确认菜单依然展示、选中已装项立即生效。
- 新增/更新 12 项针对 `setup_wizard_select_runtime` 与 `_configure_databases` 的回归测试(mock 掉自动安装以避免测试环境的真实副作用),连同既有 container_runtime 测试共 **19 项全绿**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_