### PR TITLE
fix(panel+voice): API-key 占位符误判为已配置 + VAD 自我投毒 + Kokoro 被动预取

### DIFF
--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -18,6 +18,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import httpx
 
+from core.credential_vault import PLACEHOLDER_PREFIXES
+
 logger = logging.getLogger("Galaxy.LLMRouter")
 
 
@@ -1710,7 +1712,7 @@ class MultiLLMRouter:
                 # 修复:.env/UnifiedConfig._load_env() 按真实长名(小写)存储，
                 # 短名从未命中过——补上按长名查询。
                 val = _cfg.get(f"api_keys.{real_env_key}", "")
-            if val and not str(val).startswith("your-"):
+            if val and not str(val).lower().startswith(PLACEHOLDER_PREFIXES):
                 return str(val)
         except Exception as exc:
             logger.warning("Exception suppressed: %s", exc)
@@ -1724,11 +1726,17 @@ class MultiLLMRouter:
         except Exception as exc:
             logger.warning("Exception suppressed: %s", exc)
         # 3. 环境变量（兜底）—— 修复:优先用真实长名查(.env/系统环境变量都是
-        # 这个约定)，短名查询保留作最后兜底(不改变既有行为)。
+        # 这个约定)，短名查询保留作最后兜底(不改变既有行为)。同样要过滤占位符
+        # (.env.example 里未编辑的模板值,如 "your_deepseek_api_key_here"),否则
+        # 这条兜底路径会把模板文字当真密钥返回,provider 照样被注册、真实调用
+        # 必然认证失败。
         val = os.environ.get(real_env_key, "")
-        if val:
+        if val and not val.lower().startswith(PLACEHOLDER_PREFIXES):
             return val
-        return os.environ.get(key_name.upper() if "_" in key_name else key_name, "")
+        val = os.environ.get(key_name.upper() if "_" in key_name else key_name, "")
+        if val and not val.lower().startswith(PLACEHOLDER_PREFIXES):
+            return val
+        return ""
 
     @staticmethod
     def _normalize_base_url(raw: str) -> str:
@@ -1777,7 +1785,7 @@ class MultiLLMRouter:
                     key = os.environ.get(envk, "")
                     if key:
                         break
-            if not key or key.startswith("your-"):
+            if not key or key.lower().startswith(PLACEHOLDER_PREFIXES):
                 continue
             base = spec["base_url"]
             base_key = spec.get("base_key")
@@ -1825,7 +1833,7 @@ class MultiLLMRouter:
                     ollama_url = ollama_default_url
             except Exception as exc:
                 logger.warning("Exception suppressed: %s", exc)
-        if ollama_url and not ollama_url.startswith("your-"):
+        if ollama_url and not ollama_url.lower().startswith(PLACEHOLDER_PREFIXES):
             # 检测 Ollama 实际可用的模型（包括 VLM）
             detected_models = ["gemma4:12b", "gemma4:e4b"]
             try:

--- a/core/multimodal/vad.py
+++ b/core/multimodal/vad.py
@@ -46,7 +46,11 @@ class VADConfig:
     """Configuration for the VAD."""
 
     energy_threshold: float = 0.01  # RMS threshold for activity (fast path)
-    frame_duration_ms: int = 20  # Duration of each VAD frame (ms)
+    # 真机复现的第二个 bug:此值此前假设 20ms/帧,但实际管线(audio_ingest.py /
+    # audio_capture_service.py)按 ~100ms/块投喂——于是 window_duration_ms 换算出的
+    # 帧数窗口实际上比文档意图长 5 倍(300ms 名义窗口其实是 1.5s)。改成与真实
+    # 投喂节奏一致的 100ms,窗口大小才如注释所述。
+    frame_duration_ms: int = 100  # Duration of each VAD frame (ms) — matches real ~100ms chunks
     window_duration_ms: int = 300  # Rolling window for ratio metrics (ms)
     min_speech_frames: int = 3  # Consecutive active frames to confirm speech
 
@@ -58,6 +62,12 @@ class VADConfig:
     adaptive_min_floor: float = 0.0020  # 绝对下限(≈ -54 dBFS),防数字静音/极低底噪误触发
     noise_window_frames: int = 100  # 噪声底估计的滚动窗口(帧)
     noise_percentile: float = 20.0  # 取窗口内该分位数作噪声底(避开语音峰值)
+    # 真机复现的第一个 bug(自我投毒):此前【每一帧】——包括正在说话的帧——都会被
+    # 计入 _energy_history,于是持续说话 ~10s 后噪声底估计值收敛到语音电平本身,
+    # 自适应门限("显著高于噪声底")变得不可企及,VAD 从此永久不再判活(直到一段
+    # 静音把窗口冲刷掉)。现在只把"确认静音"的帧计入噪声底——语音期间及其后
+    # adaptive_hangover_frames 帧一律跳过,噪声底只反映真实的环境背景。
+    adaptive_hangover_frames: int = 5  # 语音结束后再跳过几帧才恢复计入噪声底估计
 
     @classmethod
     def from_env(cls) -> "VADConfig":
@@ -74,6 +84,9 @@ class VADConfig:
             adaptive=_env_bool("GALAXY_VAD_ADAPTIVE", cls.adaptive),
             adaptive_speech_mult=_env_float("GALAXY_VAD_SPEECH_MULT", cls.adaptive_speech_mult),
             adaptive_min_floor=_env_float("GALAXY_VAD_MIN_FLOOR", cls.adaptive_min_floor),
+            adaptive_hangover_frames=int(
+                _env_float("GALAXY_VAD_HANGOVER_FRAMES", cls.adaptive_hangover_frames)
+            ),
         )
 
 
@@ -111,8 +124,11 @@ class VoiceActivityDetector:
         self._recent: Deque[bool] = deque(maxlen=self._window_frames)
         self._consecutive_speech = 0
         self._last_speech_ts: Optional[float] = None
-        # 近段帧能量,用于估计噪声底(自适应门限)。
+        # 近段帧能量,用于估计噪声底(自适应门限)——只累积"确认静音"的帧,
+        # 见 process_frame 与 VADConfig.adaptive_hangover_frames 的说明。
         self._energy_history: Deque[float] = deque(maxlen=max(1, self.config.noise_window_frames))
+        # 语音结束后仍需跳过的帧数(hangover),跳过期间也不计入噪声底。
+        self._hangover_remaining = 0
 
     def _is_active(self, energy: float) -> bool:
         """判活:固定阈值(快路径)∪ 显著高于噪声底(自适应,救低增益麦克风)。"""
@@ -128,9 +144,21 @@ class VoiceActivityDetector:
         """Process one chunk of PCM audio and return a VADState."""
         samples = audio_chunk.astype(np.float32).flatten()
         energy = float(np.sqrt(np.mean(samples**2))) if samples.size else 0.0
-        # 噪声底基于历史帧估计;先判活再把当前帧计入,避免当前语音帧抬高本次门限。
+        # 噪声底基于历史帧估计;先判活再决定是否把当前帧计入,避免当前语音帧
+        # 抬高本次门限。
         is_active = self._is_active(energy)
-        self._energy_history.append(energy)
+
+        # 自我投毒修复:只把"确认静音"的帧计入噪声底估计——语音期间(is_active)
+        # 以及语音结束后 adaptive_hangover_frames 帧内一律跳过,不进 _energy_history。
+        # 否则持续说话会把整个滚动窗口填满语音自身的能量,20 分位数估计出的"噪声底"
+        # 收敛到语音电平,自适应门限(噪声底 × 3)变得不可企及——真机复现:VAD 在
+        # 持续说话数秒后永久停止判活,直到出现一段真实静音把窗口冲刷掉为止。
+        if is_active:
+            self._hangover_remaining = self.config.adaptive_hangover_frames
+        elif self._hangover_remaining > 0:
+            self._hangover_remaining -= 1
+        else:
+            self._energy_history.append(energy)
 
         if is_active:
             self._consecutive_speech += 1
@@ -166,3 +194,4 @@ class VoiceActivityDetector:
         self._energy_history.clear()
         self._consecutive_speech = 0
         self._last_speech_ts = None
+        self._hangover_remaining = 0

--- a/core/routes/system.py
+++ b/core/routes/system.py
@@ -364,8 +364,10 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             port = str(request.url.port or 9000)
 
         def _is_configured(key_name: str) -> bool:
+            from core.credential_vault import PLACEHOLDER_PREFIXES
+
             val = os.getenv(key_name, "")
-            return bool(val and not val.startswith("your-") and not val.startswith("sk-YOUR"))
+            return bool(val and not val.lower().startswith(PLACEHOLDER_PREFIXES) and not val.startswith("sk-YOUR"))
 
         # 模型 tab / 设置 tab 需要"每个 env key 是否已配置"来渲染状态,以及少量
         # 非敏感值(地址/模型名)用于回填。密钥值一律不下发(只给布尔),地址与

--- a/core/tts/kokoro_engine.py
+++ b/core/tts/kokoro_engine.py
@@ -85,7 +85,19 @@ def kick_background_fetch() -> None:
                 shutil.copyfile(got, d / fname)
             logger.info("Kokoro 模型就绪(%s)——下次语音引擎选择/重启后启用", _model_dir())
         except Exception as exc:  # noqa: BLE001
-            logger.info("Kokoro 模型拉取失败(下次启动再试): %s", exc)
+            # 真机排查发现:此前只 INFO 级(默认 WARNING 控制台看不到),用户只会
+            # 看到"语音降级为系统音"的笼统提示,不知道离线引擎为什么没准备好。
+            # 提到 WARNING,并给出可操作的具体路径/文件名/镜像,呼应
+            # speech_output._note_engine_choice() 的"手动预置模型"指引。
+            logger.warning(
+                "Kokoro 模型拉取失败(下次启动再试): %s ——网络受限时可手动下载 %s 与 %s"
+                " 放到 %s(HF 镜像可设 HF_ENDPOINT=https://hf-mirror.com,来源仓库 %s)",
+                exc,
+                _model_file(),
+                _VOICES_FILE,
+                _model_dir(),
+                _HF_REPO,
+            )
 
     threading.Thread(target=_fetch, name="kokoro-fetch", daemon=True).start()
 

--- a/core/unified/config_manager.py
+++ b/core/unified/config_manager.py
@@ -168,10 +168,21 @@ class UnifiedConfigManager:
             raise ConfigError(f"Failed to save config: {exc}") from exc
 
     def reload(self) -> None:
-        """从磁盘重新加载配置。"""
+        """从磁盘重新加载配置。
+
+        真 bug 修复(面板 API-key 排查):此前漏了 `_load_from_config_store()`
+        这一步 —— 它是 runtime/secrets.env(面板保存密钥的落盘位置)真正被读回
+        Dashboard 层的地方。少了它,一次实时 reload() 不会把刚保存的密钥反映到
+        `UnifiedConfig._config`,此前全靠 core/routes/config.py 里紧跟着的
+        `os.environ.update()` 巧合掩盖(任何只走 Dashboard 层、不兜底
+        os.environ 的调用方都会读不到)。顺序须与 UnifiedConfig.__init__ 一致
+        (config.json → runtime store → .env/环境变量,后者优先级更高)。
+        """
         try:
             if hasattr(self._backend, "_load_config"):
                 self._backend._load_config()
+            if hasattr(self._backend, "_load_from_config_store"):
+                self._backend._load_from_config_store()
             if hasattr(self._backend, "_load_env"):
                 self._backend._load_env()
             logger.info("Config reloaded", extra={"event": "reload"})

--- a/main.py
+++ b/main.py
@@ -414,14 +414,39 @@ def phase0_env_check() -> dict:
     status["env_exists"] = env_exists
 
     # API Key check
+    # 真 bug(面板 API-key 排查发现):此前只读 .env 文本计数——但密钥经面板保存后
+    # 会被收敛进 runtime/secrets.env(不再明文留在 .env,见 core/config_store.py),
+    # 于是这条横幅在密钥已正确保存的情况下依然永远报"未配置",强化"存了但没用"
+    # 的错觉。这里额外并入 secrets.env 里的真实密钥键,并用共享的占位符前缀表
+    # 过滤 .env 里尚未替换的模板值(如 your_openai_api_key_here),避免双向误判。
     api_count = 0
+    seen_keys: set[str] = set()
     try:
+        from core.credential_vault import PLACEHOLDER_PREFIXES
+
         env_text = ENV_FILE.read_text() if env_exists else ""
         for line in env_text.splitlines():
             if "=" in line and not line.startswith("#"):
                 key, _, val = line.partition("=")
-                if val.strip() and any(k in key.upper() for k in ["API_KEY", "KEY"]):
-                    api_count += 1
+                val = val.strip()
+                key = key.strip()
+                if (
+                    val
+                    and not val.lower().startswith(PLACEHOLDER_PREFIXES)
+                    and any(k in key.upper() for k in ["API_KEY", "KEY"])
+                ):
+                    seen_keys.add(key.upper())
+        try:
+            from core.config_store import get_config_store
+
+            for key, val in get_config_store().read_secrets().items():
+                if val and not val.lower().startswith(PLACEHOLDER_PREFIXES) and any(
+                    k in key.upper() for k in ["API_KEY", "KEY"]
+                ):
+                    seen_keys.add(key.upper())
+        except Exception:
+            pass
+        api_count = len(seen_keys)
     except Exception:
         pass
     if api_count > 0:

--- a/tests/test_config_schema_ui_parity.py
+++ b/tests/test_config_schema_ui_parity.py
@@ -94,10 +94,25 @@ class TestPostConfigEndToEnd:
     """直接打 POST /api/config,复现并验证修复。"""
 
     def _client(self, tmp_path, monkeypatch):
+        import core.config_store as config_store_module
         import core.routes.config as config_module
 
         # 隔离真实 .env,避免测试写脏仓库根目录的 .env。
         monkeypatch.setattr(config_module, "ENV_FILE", tmp_path / ".env.test")
+        # 隔离真实 runtime/secrets.env:此前这里漏了这一步 —— POST /api/config
+        # 里凡是分类为 secret 的 key(DEEPSEEK_API_KEY/OPENROUTER_API_KEY/...)会经
+        # ConfigService().set_secret() 落到进程级单例 ConfigStore(core/config_store.py
+        # 的 get_config_store()),而该单例默认路径就是仓库真实的
+        # runtime/secrets.env——测试假密钥(sk-ds-test 等)会真的写进本地这份文件,
+        # 污染真实的密钥库状态。改为进程级单例注入一个指向 tmp_path 的 ConfigStore。
+        monkeypatch.setattr(
+            config_store_module,
+            "_singleton",
+            config_store_module.ConfigStore(
+                config_path=tmp_path / "config.json.test",
+                secrets_path=tmp_path / "secrets.env.test",
+            ),
+        )
 
         app = FastAPI()
         app.include_router(config_module.router)

--- a/tests/test_kokoro_prefetch.py
+++ b/tests/test_kokoro_prefetch.py
@@ -1,0 +1,113 @@
+"""tests/test_kokoro_prefetch.py
+==================================
+Kokoro 离线 TTS 模型"被动懒加载"的回归防护。
+
+真机排查发现:此前 kick_background_fetch() 只在第一次真的要朗读、edge-tts 失败
+降级时才被 speech_output._try_kokoro() 顺手踢一次——而模型 337MB、下载起步要
+3 分钟以上,那时才开始必然来不及,当次对话只能落到 SAPI 机器人音,呼应所有者的
+"语音为什么还是用不了"反馈。
+
+本测试锁定两处修复:
+1. unified_launcher.py 的启动序列必须【无条件】(不依赖 start_voice_interaction()
+   是否成功)主动踢一次后台预取,而不是只在 speech_output 里被动触发。
+2. kick_background_fetch() 拉取失败时必须用 WARNING(而非默认控制台看不到的
+   INFO)上报,且带上可操作的具体路径/文件名/镜像指引。
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pathlib
+import sys
+import types
+
+_LAUNCHER = pathlib.Path(__file__).resolve().parents[1] / "unified_launcher.py"
+
+
+def test_launcher_calls_kokoro_prefetch_unconditionally_before_voice_interaction():
+    src = _LAUNCHER.read_text(encoding="utf-8")
+    prefetch_idx = src.find("kick_background_fetch")
+    voice_idx = src.find("await self.start_voice_interaction()")
+    assert prefetch_idx != -1, "unified_launcher.py 必须主动调用 kokoro kick_background_fetch"
+    assert voice_idx != -1, "start_voice_interaction() 调用点消失,测试基准失效"
+    assert prefetch_idx < voice_idx, (
+        "Kokoro 预取必须在语音交互启动之前触发,且不能依赖其结果——"
+        "回归了'被动懒加载,3 分钟下载来不及'的 bug"
+    )
+    # 预取调用不能被包在语音输入是否可用的判断之内——TTS 出声与麦克风/ASR
+    # 是否可用无关,不该被 GALAXY_VOICE 挡住。
+    between = src[prefetch_idx:voice_idx]
+    assert "GALAXY_VOICE" not in between, "Kokoro 预取不应被 GALAXY_VOICE 麦克风开关挡住"
+
+
+def _reload_kokoro_engine(monkeypatch, tmp_path):
+    import core.tts.kokoro_engine as kokoro_engine
+
+    importlib.reload(kokoro_engine)
+    monkeypatch.setattr(kokoro_engine, "_fetch_started", False)
+    monkeypatch.setenv("GALAXY_KOKORO_DIR", str(tmp_path))
+    return kokoro_engine
+
+
+class _SyncThread:
+    """threading.Thread 的同步替身:start() 直接原地跑 target,便于断言副作用。"""
+
+    def __init__(self, target=None, name=None, daemon=None):
+        self._target = target
+
+    def start(self) -> None:
+        if self._target:
+            self._target()
+
+
+def test_autofetch_off_switch_prevents_thread(monkeypatch, tmp_path):
+    kokoro_engine = _reload_kokoro_engine(monkeypatch, tmp_path)
+    monkeypatch.setenv("GALAXY_KOKORO_AUTOFETCH", "0")
+    ran = {"count": 0}
+    monkeypatch.setattr(
+        kokoro_engine.threading, "Thread",
+        lambda *a, **k: ran.__setitem__("count", ran["count"] + 1) or _SyncThread(*a, **k),
+    )
+    kokoro_engine.kick_background_fetch()
+    assert ran["count"] == 0, "GALAXY_KOKORO_AUTOFETCH=0 时不应起任何拉取线程"
+
+
+def test_fetch_failure_logs_at_warning_with_actionable_hint(monkeypatch, tmp_path, caplog):
+    kokoro_engine = _reload_kokoro_engine(monkeypatch, tmp_path)
+    monkeypatch.setenv("GALAXY_KOKORO_AUTOFETCH", "1")
+    monkeypatch.setattr(kokoro_engine.threading, "Thread", _SyncThread)
+
+    fake_hub = types.ModuleType("huggingface_hub")
+
+    def _boom(*a, **k):
+        raise RuntimeError("network unreachable")
+
+    fake_hub.hf_hub_download = _boom
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+    with caplog.at_level(logging.WARNING, logger="Galaxy.TTS.Kokoro"):
+        kokoro_engine.kick_background_fetch()  # _SyncThread 让 _fetch() 原地跑完
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("Kokoro 模型拉取失败" in r.message for r in warnings), (
+        f"拉取失败应以 WARNING 上报,实际记录: {[(r.levelname, r.message) for r in caplog.records]}"
+    )
+    assert any(kokoro_engine._model_file() in r.message for r in warnings), "警告应包含具体模型文件名"
+    assert any("HF_ENDPOINT" in r.message for r in warnings), "警告应包含镜像指引"
+
+
+def test_kick_background_fetch_is_idempotent(monkeypatch, tmp_path):
+    kokoro_engine = _reload_kokoro_engine(monkeypatch, tmp_path)
+    monkeypatch.setenv("GALAXY_KOKORO_AUTOFETCH", "1")
+    starts = {"count": 0}
+
+    def _counting_thread(target=None, name=None, daemon=None):
+        starts["count"] += 1
+        return _SyncThread(target=lambda: None)  # 不真的跑,只统计"起了几次线程"
+
+    monkeypatch.setattr(kokoro_engine.threading, "Thread", _counting_thread)
+    kokoro_engine.kick_background_fetch()
+    kokoro_engine.kick_background_fetch()
+    kokoro_engine.kick_background_fetch()
+    assert starts["count"] == 1, "多次调用应幂等,只起一次拉取线程"

--- a/tests/test_panel_apikey_placeholder_detection.py
+++ b/tests/test_panel_apikey_placeholder_detection.py
@@ -1,0 +1,71 @@
+"""tests/test_panel_apikey_placeholder_detection.py
+=====================================================
+面板 API-key "看起来已保存/已连接,实际用不了"回归防护(真机反馈:"还是不能正常地
+保存和使用")。
+
+根因(排查确认):`.env.example` 里未编辑的占位符用的是下划线格式
+(``your_openai_api_key_here``),但 `GET /api/config` 的 `_is_configured()`
+(core/routes/system.py)与 `core/multi_llm_router.py` 判定 provider 是否"已配置"
+时,只识别连字符格式 `"your-"`,漏判了下划线格式——于是面板把未编辑的模板值当成
+真实密钥显示为"已连接",LLM 路由器也真的拿它去注册 provider(真实调用会 401)。
+`core/config_preflight.py`/`core/credential_vault.PLACEHOLDER_PREFIXES` 早就
+正确识别两种格式——这里锁定 `_is_configured()` 与路由器改用同一份表之后的行为。
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client():
+    app = FastAPI()
+    from core.api_routes import create_api_routes
+
+    router = create_api_routes()
+    app.include_router(router)
+    with TestClient(app) as c:
+        yield c
+
+
+class TestIsConfiguredRecognizesUnderscorePlaceholder:
+    def test_underscore_placeholder_reported_as_not_configured(self, client, monkeypatch):
+        # .env.example 实际发的占位符格式(下划线,不是连字符)。
+        monkeypatch.setenv("OPENAI_API_KEY", "your_openai_api_key_here")
+        r = client.get("/api/config")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["configured"]["OPENAI_API_KEY"] is False, (
+            "下划线占位符 'your_...' 被误判为已配置——面板会显示'已连接',"
+            "而真实调用会用这串模板文字去认证,必然失败"
+        )
+        assert data["status"]["openai"] is False
+
+    def test_hyphen_placeholder_still_recognized(self, client, monkeypatch):
+        # 旧格式(连字符)必须继续被正确识别,不能因为改动而回退。
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "your-anthropic-key-here")
+        r = client.get("/api/config")
+        data = r.json()
+        assert data["configured"]["ANTHROPIC_API_KEY"] is False
+
+    def test_real_looking_key_reported_as_configured(self, client, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-realkeylookingvalue1234567890")
+        r = client.get("/api/config")
+        data = r.json()
+        assert data["configured"]["OPENAI_API_KEY"] is True
+
+
+class TestMultiLLMRouterRejectsUnderscorePlaceholder:
+    def test_get_key_rejects_underscore_placeholder_from_env(self, monkeypatch):
+        from core.multi_llm_router import MultiLLMRouter
+
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "your_deepseek_api_key_here")
+        router = MultiLLMRouter()
+        val = router._get_key("deepseek")
+        assert val in (None, ""), (
+            f"路由器把未编辑的占位符 'your_deepseek_api_key_here' 当成真实密钥返回: {val!r}——"
+            "provider 会被注册并真的拿这串模板文字去发请求"
+        )

--- a/tests/test_phase0_env_check_secrets_banner.py
+++ b/tests/test_phase0_env_check_secrets_banner.py
@@ -1,0 +1,67 @@
+"""tests/test_phase0_env_check_secrets_banner.py
+==================================================
+真机排查发现:启动横幅"API Key 已配置/未配置"(main.py::phase0_env_check())此前
+纯读 .env 文本计数——但密钥经面板保存后会被收敛进 runtime/secrets.env(不再明文
+留在 .env,见 core/config_store.py),于是这条横幅在密钥已正确保存的情况下依然
+永远报"未配置",强化用户"存了但没用"的错觉,与真机反馈"这个面板上的 API 它就出
+问题了为什么还是不能正常地保存和使用"完全吻合。
+
+本测试锁定:phase0_env_check() 必须把 runtime/secrets.env 里的真实密钥也计入,
+且不能把 .env 里未编辑的占位符(your_..._here)误计为已配置。
+"""
+
+from __future__ import annotations
+
+
+def _run(monkeypatch, tmp_path, env_text: str, secrets: dict):
+    import core.config_store as config_store_module
+    import main as main_mod
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(env_text, encoding="utf-8")
+    monkeypatch.setattr(main_mod, "ENV_FILE", env_file)
+
+    store = config_store_module.ConfigStore(
+        config_path=tmp_path / "config.json",
+        secrets_path=tmp_path / "secrets.env",
+    )
+    for k, v in secrets.items():
+        store.write_secret(k, v)
+    monkeypatch.setattr(config_store_module, "_singleton", store)
+
+    return main_mod.phase0_env_check()
+
+
+def test_secret_saved_only_in_secrets_env_is_counted(monkeypatch, tmp_path, capsys):
+    # .env 里该 key 是未编辑的占位符(面板保存后会把它从 .env 里剔除,但这里
+    # 模拟"用户还没存过这个 key、.env 仍是自动生成的模板"这一常见起始状态)。
+    status = _run(
+        monkeypatch, tmp_path,
+        env_text="OPENAI_API_KEY=your_openai_api_key_here\n",
+        secrets={"DEEPSEEK_API_KEY": "sk-real-deepseek-key"},
+    )
+    out = capsys.readouterr().out
+    assert status["api_keys_configured"] == 1, (
+        f"只计了 .env 文本,漏了 runtime/secrets.env 里真实保存的密钥: {status}"
+    )
+    assert "API Key 已配置 (1个)" in out
+
+
+def test_placeholder_only_reports_zero_configured(monkeypatch, tmp_path, capsys):
+    status = _run(
+        monkeypatch, tmp_path,
+        env_text="OPENAI_API_KEY=your_openai_api_key_here\nGALAXY_API_TOKEN=your_galaxy_api_token_here\n",
+        secrets={},
+    )
+    out = capsys.readouterr().out
+    assert status["api_keys_configured"] == 0, "未编辑的占位符不该被计为已配置"
+    assert "API Key 未配置" in out
+
+
+def test_dedupes_key_present_in_both_env_and_secrets(monkeypatch, tmp_path, capsys):
+    status = _run(
+        monkeypatch, tmp_path,
+        env_text="ANTHROPIC_API_KEY=sk-real-anthropic-key\n",
+        secrets={"ANTHROPIC_API_KEY": "sk-real-anthropic-key"},
+    )
+    assert status["api_keys_configured"] == 1, "同一个 key 出现在两处不应被重复计数"

--- a/tests/test_unified_config_manager_reload_secrets.py
+++ b/tests/test_unified_config_manager_reload_secrets.py
@@ -1,0 +1,78 @@
+"""tests/test_unified_config_manager_reload_secrets.py
+=========================================================
+面板 API-key 排查发现:`UnifiedConfigManager.reload()`(core/unified/config_manager.py)
+只调用了 `_load_config()`(config.json)与 `_load_env()`(.env/os.environ),漏了
+`_load_from_config_store()`——这一步才是 `runtime/secrets.env`(面板保存密钥的
+真正落盘位置,见 core/config_store.py)被读回 `UnifiedConfig._config`(Dashboard 层)
+的地方。少了它,一次 reload() 不会让刚保存的密钥反映到 Dashboard 层,此前全靠
+`core/routes/config.py::update_config()` 里紧跟着的 `os.environ.update()` 巧合掩盖
+——任何只走 Dashboard 层、不兜底 os.environ 的调用方都会读不到刚保存的密钥。
+"""
+
+from __future__ import annotations
+
+
+def test_reload_calls_load_from_config_store():
+    """回归锁定:reload() 必须调用 _load_from_config_store(),不能只有 _load_config/_load_env。"""
+    from core.unified.config_manager import UnifiedConfigManager
+
+    calls: list[str] = []
+
+    class _FakeBackend:
+        def _load_config(self):
+            calls.append("_load_config")
+
+        def _load_from_config_store(self):
+            calls.append("_load_from_config_store")
+
+        def _load_env(self):
+            calls.append("_load_env")
+
+    mgr = UnifiedConfigManager.__new__(UnifiedConfigManager)
+    mgr._backend = _FakeBackend()
+
+    mgr.reload()
+
+    assert "_load_from_config_store" in calls, (
+        "reload() 漏了 _load_from_config_store() —— runtime/secrets.env 里刚保存的"
+        "密钥不会被读回 Dashboard 层"
+    )
+    # 顺序必须和 UnifiedConfig.__init__ 一致:config.json(最低)→ runtime store
+    # (secrets.env,居中)→ .env/环境变量(最高),否则优先级会被打乱。
+    assert calls == ["_load_config", "_load_from_config_store", "_load_env"]
+
+
+def test_reload_actually_refreshes_secret_from_config_store(tmp_path, monkeypatch):
+    """端到端:直接用真实 UnifiedConfig + ConfigStore,验证 reload() 后能读到新写入的密钥。"""
+    import core.config_store as config_store_module
+    from core.unified.config_manager import UnifiedConfigManager
+    from core.unified_config import UnifiedConfig
+
+    monkeypatch.setattr(
+        config_store_module,
+        "_singleton",
+        config_store_module.ConfigStore(
+            config_path=tmp_path / "config.json",
+            secrets_path=tmp_path / "secrets.env",
+        ),
+    )
+
+    backend = UnifiedConfig.__new__(UnifiedConfig)
+    backend._config = {}
+    backend.project_root = tmp_path
+    backend.config_file = tmp_path / "config.json.static"
+    backend.env_file = tmp_path / ".env.nonexistent"
+    backend._callbacks = {}
+    backend._initialized = True
+
+    mgr = UnifiedConfigManager.__new__(UnifiedConfigManager)
+    mgr._backend = backend
+
+    assert mgr.get("deepseek_api_key", "") == ""
+
+    config_store_module.get_config_store().write_secret("DEEPSEEK_API_KEY", "sk-real-saved-key")
+    mgr.reload()
+
+    assert mgr.get("deepseek_api_key", "") == "sk-real-saved-key", (
+        "reload() 之后 Dashboard 层应能读到刚保存进 runtime/secrets.env 的密钥"
+    )

--- a/tests/test_vad_adaptive_gain.py
+++ b/tests/test_vad_adaptive_gain.py
@@ -78,3 +78,39 @@ def test_env_adaptive_off(monkeypatch):
     monkeypatch.setenv("GALAXY_VAD_ADAPTIVE", "false")
     cfg = VADConfig.from_env()
     assert cfg.adaptive is False
+
+
+def test_sustained_speech_does_not_self_poison_noise_floor():
+    """回归锁定(真机复现的自我投毒 bug):持续说话不能让噪声底收敛到语音电平。
+
+    此前 _energy_history 无差别吸收【每一帧】能量(含正在说话的帧)——持续说话
+    ~10s(100 帧默认窗口)后,20 分位数估计出的"噪声底"收敛到语音本身电平,
+    自适应门限(噪声底 × 3)变得不可企及,VAD 从此永久停止判活,与真机反馈
+    "20s 内收到 199 块音频但 VAD 从未判定为说话"完全吻合。现在只把确认静音的
+    帧计入噪声底,持续说话应该【从头到尾】保持判活,不会中途"熄火"。
+    """
+    vad = VoiceActivityDetector(config=VADConfig(min_speech_frames=1))
+    for _ in range(20):  # 2s 静音,建立噪声底(RMS≈0.0008)
+        vad.process_frame(_chunk(0.0008))
+
+    results = [vad.process_frame(_chunk(0.006)).is_speaking for _ in range(180)]  # 18s 持续说话
+
+    # 旧 bug 下,大约 frame 75 起(噪声底被语音自身喂饱之后)会连续判非说话;
+    # 这里断言窗口填满之后(> noise_window_frames 帧)依然持续判活。
+    tail = results[120:]
+    assert all(tail), f"持续说话中途停止触发(自我投毒回归):tail={tail}"
+
+
+def test_hangover_frames_excluded_from_noise_floor():
+    """语音结束后的 hangover 帧也不应被计入噪声底(避免拖尾能量污染估计)。"""
+    vad = VoiceActivityDetector(config=VADConfig(min_speech_frames=1, adaptive_hangover_frames=5))
+    for _ in range(20):
+        vad.process_frame(_chunk(0.0008))
+    vad.process_frame(_chunk(0.006))  # 一帧语音,触发 hangover
+
+    # hangover 期间(接下来 5 帧)即便能量仍偏高,也不应被计入 _energy_history。
+    before = list(vad._energy_history)
+    for _ in range(5):
+        vad.process_frame(_chunk(0.004))  # 拖尾能量,理应被跳过
+    after = list(vad._energy_history)
+    assert before == after, "hangover 期间的帧不应计入噪声底历史"

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -1655,6 +1655,21 @@ class GalaxyUnified:
         except Exception as _exc:  # noqa: BLE001
             logger.debug("远程桌面兜底自动开启跳过(非致命): %s", _exc)
 
+        # ── Kokoro 离线 TTS 模型主动预取(与语音输入是否可用无关)──
+        # 真机排查发现:kokoro 的模型拉取此前【纯被动】——只有第一次真的要朗读、
+        # edge-tts 失败降级时才会被 _try_kokoro() 顺手踢一次后台线程,而模型
+        # 337MB、~3 分钟起,那时才开始下载必然来不及,当次对话只能落到 SAPI
+        # 机器人音。对比 Whisper ASR 模型(145MB)在 start_voice_interaction()
+        # 里就是主动 eager 拉取的——这里补上同等的主动性:启动时无条件踢一次
+        # 后台拉取(幂等、非阻塞,不依赖麦克风/GALAXY_VOICE,TTS 出声本就与语音
+        # 输入是否可用无关),让下载与启动的其余步骤 + 用户前几轮对话的等待时间
+        # 并行,而不是等真正要用了才临时抱佛脚。
+        try:
+            from core.tts.kokoro_engine import kick_background_fetch as _kokoro_prefetch
+            _kokoro_prefetch()
+        except Exception as _exc:  # noqa: BLE001
+            logger.debug("Kokoro 模型主动预取跳过(非致命): %s", _exc)
+
         # ── 语音交互闭环：听 → 识别 → 主回路(驱动三态 + 回复) → 朗读 ──
         # 这是"对它说话它会回应、三态随对话变化"的关键(此前 VoiceLoop 从未启动)。
         voice_ok = await self.start_voice_interaction()


### PR DESCRIPTION
## Summary

真机排查(所有者反馈:"这个面板上的 API 它就出问题了为什么还是不能正常地保存和使用" + "语音为什么还是用不了",附带真实 Windows 终端日志)定位并修复五个独立真 bug。

**面板 API-key 保存/使用**
- `core/routes/system.py::_is_configured` + `core/multi_llm_router.py`(4 处)此前只识别连字符占位符 `"your-"`,但 `.env.example` 实际用下划线格式 `your_..._here`——未编辑的模板值被误判为"已配置",面板显示"已连接"、路由器真的拿它去注册 provider,真实调用必然认证失败。改用 `core.credential_vault.PLACEHOLDER_PREFIXES` 统一识别两种格式(`_get_key()` 的 Dashboard 层与环境变量兜底层都补上了)。
- `main.py` 启动横幅纯读 `.env` 文本计数,密钥经面板保存后收敛到 `runtime/secrets.env`,横幅永远误报"未配置"。改为一并计入 secrets store 并过滤占位符。
- `UnifiedConfigManager.reload()` 漏了 `_load_from_config_store()`,实时 reload 不会把刚保存的密钥反映到 Dashboard 层,此前全靠 `core/routes/config.py` 里巧合的 `os.environ.update()` 掩盖。

**语音(VAD 输入 + Kokoro TTS 输出)**
- VAD 自适应噪声底自我投毒(真机复现:20s 内收到 199 块音频但从未判定为说话):持续说话时 `_energy_history` 无差别吸收活跃语音能量,~10s 后噪声底收敛到语音本身电平,自适应门限变得不可企及。修复为只把确认静音的帧(排除语音期间及 hangover)计入噪声底估计;同时修正 `frame_duration_ms` 默认值以匹配真实 ~100ms 采集节奏。用真实合成音频复现脚本验证:修复前语音检测在 ~10s 后永久停止,修复后 200 帧持续判活。
- Kokoro 离线 TTS 模型此前纯被动拉取(只在 edge-tts 失败降级时才踢一次 337MB/~3 分钟下载,当次对话必然来不及),改为启动时无条件主动预取(与 Whisper ASR 同等 eager 力度,和麦克风/`GALAXY_VOICE` 状态无关),失败日志从 INFO 提到 WARNING 并给出具体路径/文件名/镜像指引。

## Test plan

- [x] 新增/更新回归测试全部通过:`test_vad_adaptive_gain.py`(+2 用例复现并锁定修复)、`test_kokoro_prefetch.py`(新)、`test_panel_apikey_placeholder_detection.py`(新)、`test_phase0_env_check_secrets_banner.py`(新)、`test_unified_config_manager_reload_secrets.py`(新)
- [x] VAD 修复用真实(非 mock)合成音频复现脚本验证:18s 持续语音从"检测 2.2s 后永久熄火"变为"全程判活"
- [x] 全量跑相关子集(`multi_llm_router`/`unified_launcher`/`config`/`vad`/`kokoro` 依赖测试,约 1150+ 例)确认无回归;3 处遇到的失败经 `git stash` 交叉验证均为改动前既已存在的无关问题(缺 `nats-py`/`dotenv` 依赖、`meta`/`openrouter` 映射旧缺口、docstring/健康探针顺序断言),与本 PR 改动无关
- [x] 顺手修复一处测试隔离 bug(`test_config_schema_ui_parity.py` 此前会把假测试密钥真实写入仓库本地 `runtime/secrets.env`,污染真实密钥库状态,已隔离到 tmp_path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_