### PR TITLE
fix(sweep-8): contract-layer logic & drift fixes (follow-up to #1524)

### DIFF
--- a/contracts/cross_repo_schema_version_gate.py
+++ b/contracts/cross_repo_schema_version_gate.py
@@ -366,7 +366,6 @@ def _build_legacy_safe_result_identity(
     message: Mapping[str, Any],
 ) -> Dict[str, Any]:
     payload = message.get("payload")
-    payload_mapping = payload if isinstance(payload, Mapping) else {}
     raw_task_id = _extract_text_field(message, "task_id", "goal_id")
     if not raw_task_id and normalized_type == "goal_execution_result":
         raw_task_id = _extract_text_field(message, "correlation_id")
@@ -441,9 +440,8 @@ def evaluate_android_uplink_schema_gate(
     }
 
     if not observed_schema_version:
-        if (
-            compatibility_mode == "strict_reject"
-            and _can_degrade_missing_schema_for_legacy_result(normalized_type, message)
+        if compatibility_mode == "strict_reject" and _can_degrade_missing_schema_for_legacy_result(
+            normalized_type, message
         ):
             return _build_legacy_safe_result_degrade_decision(
                 normalized_type=normalized_type,
@@ -659,7 +657,9 @@ def verify_cross_repo_schema_gate(
     if not isinstance(participation_truth, Mapping):
         issues.append("participation_truth_consumption must be a mapping.")
     else:
-        missing_participation_truth = sorted(k for k in REQUIRED_PARTICIPATION_TRUTH_FIELDS if k not in participation_truth)
+        missing_participation_truth = sorted(
+            k for k in REQUIRED_PARTICIPATION_TRUTH_FIELDS if k not in participation_truth
+        )
         if missing_participation_truth:
             issues.append(f"participation_truth_consumption is missing required fields: {missing_participation_truth}.")
 
@@ -680,7 +680,9 @@ def verify_cross_repo_schema_gate(
                 k for k in REQUIRED_ACCEPTANCE_CLOSURE_SEMANTIC_FIELDS if k not in acceptance
             )
             if missing_acceptance_semantics:
-                issues.append(f"acceptance_closure_truth is missing required semantic fields: {missing_acceptance_semantics}.")
+                issues.append(
+                    f"acceptance_closure_truth is missing required semantic fields: {missing_acceptance_semantics}."
+                )
         else:
             issues.append("acceptance_closure_truth must be a mapping.")
 
@@ -688,7 +690,9 @@ def verify_cross_repo_schema_gate(
         if not isinstance(diagnostics_snapshot, Mapping):
             issues.append("truth_acceptance_closure_contract.diagnostics_snapshot must be a mapping.")
         else:
-            missing_diagnostics = sorted(k for k in REQUIRED_DIAGNOSTICS_SNAPSHOT_FIELDS if k not in diagnostics_snapshot)
+            missing_diagnostics = sorted(
+                k for k in REQUIRED_DIAGNOSTICS_SNAPSHOT_FIELDS if k not in diagnostics_snapshot
+            )
             if missing_diagnostics:
                 issues.append(f"diagnostics_snapshot is missing required fields: {missing_diagnostics}.")
 

--- a/contracts/cross_repo_schema_version_gate.py
+++ b/contracts/cross_repo_schema_version_gate.py
@@ -377,7 +377,9 @@ def _build_legacy_safe_result_identity(
         "status": normalized_status,
         "device_id": _extract_text_field(message, "device_id"),
         "trace_id": _extract_text_field(message, "trace_id"),
-        "payload_present": isinstance(payload_mapping, Mapping),
+        # 检查【原始】payload,而非 payload_mapping —— 后者在缺失时已回退成 {},
+        # 恒为 Mapping,导致 payload_present 永远为 True。
+        "payload_present": isinstance(payload, Mapping),
     }
 
 

--- a/contracts/cross_runtime_result_merge.py
+++ b/contracts/cross_runtime_result_merge.py
@@ -757,9 +757,7 @@ class MergedRuntimeResult(BaseModel):
             "task_id": self.task_id,
             "session_id": self.session_id,
             "merge_policy": (
-                self.merge_policy.value
-                if isinstance(self.merge_policy, ResultMergePolicy)
-                else str(self.merge_policy)
+                self.merge_policy.value if isinstance(self.merge_policy, ResultMergePolicy) else str(self.merge_policy)
             ),
             "success": self.success,
             "partial": self.partial,
@@ -967,9 +965,8 @@ def from_local_takeover_result(
         _trace_id: Optional[str] = d.get("trace_id")
         _task_id: Optional[str] = d.get("task_id")
         _session_id: Optional[str] = d.get("session_id")
-        _device_id: Optional[str] = (
-            (d.get("metadata") or {}).get("device_id")
-            or (d.get("session_context") or {}).get("device_id")
+        _device_id: Optional[str] = (d.get("metadata") or {}).get("device_id") or (d.get("session_context") or {}).get(
+            "device_id"
         )
         _runtime_id: Optional[str] = d.get("runtime_session_id")
 
@@ -987,9 +984,7 @@ def from_local_takeover_result(
             trace_id=_trace_id,
             task_id=_task_id,
             execution_path="remote_handoff",
-            governance_snapshot_ref=(
-                str(_gov.get("snapshot_id", "")) if _gov and _gov.get("snapshot_id") else None
-            ),
+            governance_snapshot_ref=(str(_gov.get("snapshot_id", "")) if _gov and _gov.get("snapshot_id") else None),
             policy_alignment_ref=(
                 str(_policy.get("alignment_id", "")) if _policy and _policy.get("alignment_id") else None
             ),
@@ -1095,9 +1090,7 @@ def from_source_dispatch_result(
             trace_id=_trace_id,
             task_id=_task_id,
             execution_path=str(_mode),
-            governance_snapshot_ref=(
-                str(_gov.get("snapshot_id", "")) if _gov and _gov.get("snapshot_id") else None
-            ),
+            governance_snapshot_ref=(str(_gov.get("snapshot_id", "")) if _gov and _gov.get("snapshot_id") else None),
             policy_alignment_ref=(
                 str(_policy.get("alignment_id", "")) if _policy and _policy.get("alignment_id") else None
             ),
@@ -1470,15 +1463,11 @@ def merge_runtime_results(
                 )
             if _primary is None:
                 # Try non-fallback succeeded units before falling back
-                non_fallback_succeeded = [
-                    u for u in succeeded_units if u.role != RuntimeResultRole.fallback
-                ]
+                non_fallback_succeeded = [u for u in succeeded_units if u.role != RuntimeResultRole.fallback]
                 _primary = non_fallback_succeeded[0] if non_fallback_succeeded else None
             if _primary is None:
                 # Use a succeeded fallback unit if available, and mark fallback_applied
-                _primary = next(
-                    (u for u in succeeded_units if u.role == RuntimeResultRole.fallback), None
-                )
+                _primary = next((u for u in succeeded_units if u.role == RuntimeResultRole.fallback), None)
                 if _primary:
                     _fallback_applied = True
             if _primary is None and fallback_units:
@@ -1522,9 +1511,7 @@ def merge_runtime_results(
         elif merge_policy == ResultMergePolicy.all_required:
             if failed_units:
                 _success = False
-                _errors.extend(
-                    f"unit_failed:{u.result_unit_id}:{u.error or u.reason}" for u in failed_units
-                )
+                _errors.extend(f"unit_failed:{u.result_unit_id}:{u.error or u.reason}" for u in failed_units)
             else:
                 _success = True
                 _primary = succeeded_units[0] if succeeded_units else None
@@ -1540,9 +1527,7 @@ def merge_runtime_results(
                 _primary_unit_id = _primary.result_unit_id
                 if failed_units:
                     _partial = True
-                    _errors.extend(
-                        f"unit_failed:{u.result_unit_id}:{u.error or u.reason}" for u in failed_units
-                    )
+                    _errors.extend(f"unit_failed:{u.result_unit_id}:{u.error or u.reason}" for u in failed_units)
             else:
                 _success = False
                 _partial = True
@@ -1568,9 +1553,7 @@ def merge_runtime_results(
                     _partial = True
             else:
                 # Attempt fallback units explicitly
-                _primary = next(
-                    (u for u in fallback_units if u.status == RuntimeResultStatus.succeeded), None
-                )
+                _primary = next((u for u in fallback_units if u.status == RuntimeResultStatus.succeeded), None)
                 if _primary:
                     _merged_output = _primary.output
                     _success = True
@@ -1601,18 +1584,15 @@ def merge_runtime_results(
         # outputs or many units this may be expensive; consider hashing if
         # performance becomes a concern.
         if len(succeeded_units) > 1 and merge_policy not in (
-            ResultMergePolicy.all_required, ResultMergePolicy.best_effort
+            ResultMergePolicy.all_required,
+            ResultMergePolicy.best_effort,
         ):
             outputs = [
-                json.dumps(u.output, sort_keys=True, default=str)
-                for u in succeeded_units
-                if u.output is not None
+                json.dumps(u.output, sort_keys=True, default=str) for u in succeeded_units if u.output is not None
             ]
             unique_outputs = set(outputs)
             if len(unique_outputs) > 1:
-                _conflicts.append(
-                    f"conflicting_outputs_from_{len(succeeded_units)}_succeeded_units"
-                )
+                _conflicts.append(f"conflicting_outputs_from_{len(succeeded_units)}_succeeded_units")
 
         return build_merged_runtime_result(
             merge_id=_id,
@@ -1687,24 +1667,26 @@ def build_result_merge_summary(
         _trace = trace_id if trace_id is not None else (result.trace_id if result else None)
         _task = task_id if task_id is not None else (result.task_id if result else None)
         _session = session_id if session_id is not None else (result.session_id if result else None)
-        _policy = merge_policy if merge_policy is not None else (
-            result.merge_policy if result else ResultMergePolicy.unknown
+        _policy = (
+            merge_policy if merge_policy is not None else (result.merge_policy if result else ResultMergePolicy.unknown)
         )
         _success = success if success is not None else (result.success if result else False)
         _partial = partial if partial is not None else (result.partial if result else False)
-        _fallback = fallback_applied if fallback_applied is not None else (
-            result.fallback_applied if result else False
-        )
+        _fallback = fallback_applied if fallback_applied is not None else (result.fallback_applied if result else False)
         _reason = merge_reason if merge_reason is not None else (result.merge_reason if result else None)
 
         if result:
             _units = result.result_units or []
             _unit_c = unit_count if unit_count is not None else len(_units)
-            _succ_c = succeeded_unit_count if succeeded_unit_count is not None else sum(
-                1 for u in _units if u.status == RuntimeResultStatus.succeeded
+            _succ_c = (
+                succeeded_unit_count
+                if succeeded_unit_count is not None
+                else sum(1 for u in _units if u.status == RuntimeResultStatus.succeeded)
             )
-            _fail_c = failed_unit_count if failed_unit_count is not None else sum(
-                1 for u in _units if u.status == RuntimeResultStatus.failed
+            _fail_c = (
+                failed_unit_count
+                if failed_unit_count is not None
+                else sum(1 for u in _units if u.status == RuntimeResultStatus.failed)
             )
             _conf_c = conflict_count if conflict_count is not None else len(result.conflicts)
             _err_c = error_count if error_count is not None else len(result.errors)

--- a/contracts/cross_runtime_result_merge.py
+++ b/contracts/cross_runtime_result_merge.py
@@ -1554,10 +1554,11 @@ def merge_runtime_results(
             for _u in units:
                 if _u.status == RuntimeResultStatus.succeeded:
                     _primary = _u
-                    break
-                if _u.role == RuntimeResultRole.fallback and _u.status == RuntimeResultStatus.succeeded:
-                    _primary = _u
-                    _fallback_applied = True
+                    # role==fallback 的判定原本放在这条 succeeded 判断【之后】的
+                    # 单独 if 里,但任何 succeeded 单元都被这里先 break 掉,那条
+                    # 永不可达、fallback_applied 永远设不上。合并到此处。
+                    if _u.role == RuntimeResultRole.fallback:
+                        _fallback_applied = True
                     break
             if _primary:
                 _merged_output = _primary.output

--- a/contracts/distributed_subject_contract_v1.py
+++ b/contracts/distributed_subject_contract_v1.py
@@ -348,9 +348,9 @@ DISTRIBUTED_SUBJECT_CONTRACT_V1_FIELDS: List[SubjectContractField] = [
         dimension=SubjectContractDimension.CONTINUITY,
         label=ContractFieldLabel.CANONICAL,
         description=(
-            "Classification of the continuity context: online_session, "
-            "resumed_session, handoff_session, replay_session, "
-            "parallel_subtask, or no_continuity."
+            "Classification of the dispatch-to-session execution continuity "
+            "context, per DispatchContinuityClass: persistent, request_scoped, "
+            "transfer_scoped, or ephemeral."
         ),
         v2_anchor="contracts/dispatch_continuity.py:DispatchContinuityClass",
         android_anchor="AndroidContinuityIntegration.kt",

--- a/contracts/mesh_session_coordinator.py
+++ b/contracts/mesh_session_coordinator.py
@@ -288,10 +288,7 @@ class MeshParticipantCoordinationState(BaseModel):
     )
     ready: Optional[bool] = Field(
         default=None,
-        description=(
-            "Whether the device has confirmed readiness for its assignment.  "
-            "None = not yet confirmed."
-        ),
+        description=("Whether the device has confirmed readiness for its assignment.  " "None = not yet confirmed."),
     )
     status: MeshParticipantStatus = Field(
         default=MeshParticipantStatus.unknown,
@@ -338,16 +335,12 @@ class MeshAssignmentState(BaseModel):
     capability_required: Optional[str] = Field(
         default=None,
         description=(
-            "Optional capability key required to execute this subtask "
-            "(e.g. 'screen', 'camera', 'microphone')."
+            "Optional capability key required to execute this subtask " "(e.g. 'screen', 'camera', 'microphone')."
         ),
     )
     handoff_id: Optional[str] = Field(
         default=None,
-        description=(
-            "Optional handoff envelope ID (PR-31) used to transmit this "
-            "assignment to the target device."
-        ),
+        description=("Optional handoff envelope ID (PR-31) used to transmit this " "assignment to the target device."),
     )
     result_unit_id: Optional[str] = Field(
         default=None,
@@ -495,10 +488,7 @@ class MeshSessionCoordinatorState(BaseModel):
     )
     session_id: Optional[str] = Field(
         default=None,
-        description=(
-            "Identifier of the :class:`~contracts.mesh_session.MeshSession` "
-            "being coordinated."
-        ),
+        description=("Identifier of the :class:`~contracts.mesh_session.MeshSession` " "being coordinated."),
     )
     mesh_id: Optional[str] = Field(
         default=None,
@@ -509,10 +499,7 @@ class MeshSessionCoordinatorState(BaseModel):
     )
     trace_id: Optional[str] = Field(
         default=None,
-        description=(
-            "Optional execution trace identifier (PR-25) linking this "
-            "coordinator to a trace chain."
-        ),
+        description=("Optional execution trace identifier (PR-25) linking this " "coordinator to a trace chain."),
     )
     task_id: Optional[str] = Field(
         default=None,
@@ -536,10 +523,7 @@ class MeshSessionCoordinatorState(BaseModel):
     )
     merge_owner_device_id: Optional[str] = Field(
         default=None,
-        description=(
-            "Device ID responsible for aggregating and merging distributed "
-            "subtask results."
-        ),
+        description=("Device ID responsible for aggregating and merging distributed " "subtask results."),
     )
     pending_device_ids: List[str] = Field(
         default_factory=list,
@@ -556,8 +540,7 @@ class MeshSessionCoordinatorState(BaseModel):
     coordination_events: List[MeshCoordinationEvent] = Field(
         default_factory=list,
         description=(
-            "Lightweight log of coordination events.  Advisory only — "
-            "consumers should not depend on completeness."
+            "Lightweight log of coordination events.  Advisory only — " "consumers should not depend on completeness."
         ),
     )
     result_merge_summary: Optional[Dict[str, Any]] = Field(
@@ -861,7 +844,12 @@ def from_mesh_session(
                 a = a if hasattr(a, "items") else {}
             subtask_id = _safe_str(a.get("subtask_id", "") if isinstance(a, dict) else getattr(a, "subtask_id", ""))
             device_id_a = _safe_str(a.get("device_id", "") if isinstance(a, dict) else getattr(a, "device_id", ""))
-            capability = _safe_str(a.get("capability_required", "") if isinstance(a, dict) else getattr(a, "capability_required", "")) or None
+            capability = (
+                _safe_str(
+                    a.get("capability_required", "") if isinstance(a, dict) else getattr(a, "capability_required", "")
+                )
+                or None
+            )
             a_state = MeshAssignmentState(
                 subtask_id=subtask_id or f"subtask_{uuid.uuid4().hex[:10]}",
                 device_id=device_id_a,
@@ -870,13 +858,22 @@ def from_mesh_session(
             )
             assignments.append(a_state)
 
-        # Determine barrier state from session barrier_posture
-        barrier_posture = _safe_str(session_data.get("barrier_posture", ""))
-        barrier_status = MeshBarrierStatus.unknown
-        if "hard" in barrier_posture or "soft" in barrier_posture:
-            barrier_status = MeshBarrierStatus.open
-        elif "none" in barrier_posture:
+        # Determine barrier state from session barrier_posture.  Producer
+        # MeshSession emits the MeshBarrierPosture enum (no_barrier / wait_primary
+        # / wait_all / wait_merge_owner / soft_barrier / unknown).  NONE of those
+        # values contain "hard" or "none", so the old substring checks were dead
+        # branches and every wait_*/no_barrier posture fell through to UNKNOWN.
+        # Map the real enum values (keeping the legacy hard/none aliases tolerant).
+        barrier_posture = _safe_str(session_data.get("barrier_posture", "")).strip().lower()
+        if barrier_posture in ("no_barrier", "none", "not_required"):
             barrier_status = MeshBarrierStatus.not_required
+        elif barrier_posture in ("", "unknown"):
+            barrier_status = MeshBarrierStatus.unknown
+        else:
+            # soft_barrier / wait_primary / wait_all / wait_merge_owner (and any
+            # legacy hard/soft alias): a barrier is configured but not yet
+            # blocking at initial coordinator build time.
+            barrier_status = MeshBarrierStatus.open
         barrier_state = MeshBarrierState(status=barrier_status)
 
         return MeshSessionCoordinatorState(
@@ -895,16 +892,11 @@ def from_mesh_session(
         )
     except Exception as exc:
         _logger.warning(
-            "from_mesh_session: failed to build coordinator from session, "
-            "returning minimal state: %s",
+            "from_mesh_session: failed to build coordinator from session, " "returning minimal state: %s",
             exc,
         )
         try:
-            session_id_fallback = (
-                mesh_session.session_id
-                if hasattr(mesh_session, "session_id")
-                else None
-            )
+            session_id_fallback = mesh_session.session_id if hasattr(mesh_session, "session_id") else None
         except Exception:
             session_id_fallback = None
         return MeshSessionCoordinatorState(session_id=session_id_fallback)
@@ -1033,9 +1025,7 @@ def update_coordinator_with_takeover_result(
 
         # Update per-participant status
         if device_id:
-            new_status = (
-                MeshParticipantStatus.completed if success else MeshParticipantStatus.failed
-            )
+            new_status = MeshParticipantStatus.completed if success else MeshParticipantStatus.failed
             new_participants = []
             for p in updated.participants:
                 if p.device_id == device_id:
@@ -1063,9 +1053,7 @@ def update_coordinator_with_takeover_result(
         new_assignments = []
         for a in updated.assignments:
             if a.device_id == device_id:
-                new_a_status = (
-                    MeshAssignmentStatus.completed if success else MeshAssignmentStatus.failed
-                )
+                new_a_status = MeshAssignmentStatus.completed if success else MeshAssignmentStatus.failed
                 a = a.model_copy(update={"status": new_a_status, "updated_at": time.time()})
             new_assignments.append(a)
         updated.assignments = new_assignments

--- a/contracts/multi_device_runtime_projection.py
+++ b/contracts/multi_device_runtime_projection.py
@@ -84,7 +84,6 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-
 # ---------------------------------------------------------------------------
 # PR-8 canonical authority markers
 # ---------------------------------------------------------------------------
@@ -144,25 +143,17 @@ class RuntimeProjectionDeviceEntry(BaseModel):
     """
 
     device_id: str = Field(description="Unique device identifier.")
-    platform: Optional[str] = Field(
-        default=None, description="Device platform (e.g. 'android', 'windows', 'macos')."
-    )
+    platform: Optional[str] = Field(default=None, description="Device platform (e.g. 'android', 'windows', 'macos').")
     form_factor: Optional[str] = Field(
         default=None, description="Device form factor (e.g. 'phone', 'tablet', 'desktop')."
     )
-    status: Optional[str] = Field(
-        default=None, description="Current device status (e.g. 'online', 'offline')."
-    )
+    status: Optional[str] = Field(default=None, description="Current device status (e.g. 'online', 'offline').")
     connection_state: Optional[str] = Field(
         default=None,
         description="Current connection state (e.g. 'connected', 'disconnected').",
     )
-    runtime_capable: bool = Field(
-        default=True, description="Whether the device is capable of hosting a runtime."
-    )
-    health_score: Optional[float] = Field(
-        default=None, ge=0.0, le=1.0, description="Health score [0, 1]."
-    )
+    runtime_capable: bool = Field(default=True, description="Whether the device is capable of hosting a runtime.")
+    health_score: Optional[float] = Field(default=None, ge=0.0, le=1.0, description="Health score [0, 1].")
     source_runtime_posture: str = Field(
         default="control_only",
         description=(
@@ -193,21 +184,11 @@ class RuntimeProjectionHostEntry(BaseModel):
     """
 
     host_id: str = Field(description="Unique identifier for this runtime host.")
-    device_id: Optional[str] = Field(
-        default=None, description="Underlying device ID."
-    )
-    status: Optional[str] = Field(
-        default=None, description="Host lifecycle status."
-    )
-    execution_mode: Optional[str] = Field(
-        default=None, description="Current execution mode."
-    )
-    accepts_handoff: bool = Field(
-        default=False, description="Whether the host accepts incoming handoffs."
-    )
-    can_delegate: bool = Field(
-        default=False, description="Whether the host can delegate to other runtimes."
-    )
+    device_id: Optional[str] = Field(default=None, description="Underlying device ID.")
+    status: Optional[str] = Field(default=None, description="Host lifecycle status.")
+    execution_mode: Optional[str] = Field(default=None, description="Current execution mode.")
+    accepts_handoff: bool = Field(default=False, description="Whether the host accepts incoming handoffs.")
+    can_delegate: bool = Field(default=False, description="Whether the host can delegate to other runtimes.")
     source_runtime_posture: str = Field(
         default="control_only",
         description=(
@@ -233,21 +214,11 @@ class RuntimeProjectionMeshSessionEntry(BaseModel):
     session_id: str = Field(description="Unique mesh session identifier.")
     mesh_id: Optional[str] = Field(default=None, description="Mesh/body identifier.")
     status: Optional[str] = Field(default=None, description="Session lifecycle status.")
-    source_device_id: Optional[str] = Field(
-        default=None, description="Device that initiated the session."
-    )
-    primary_device_id: Optional[str] = Field(
-        default=None, description="Device executing primarily."
-    )
-    participant_count: int = Field(
-        default=0, description="Number of participants in this session."
-    )
-    multi_device_required: bool = Field(
-        default=False, description="Whether multi-device is required."
-    )
-    merge_policy: Optional[str] = Field(
-        default=None, description="Result merge policy."
-    )
+    source_device_id: Optional[str] = Field(default=None, description="Device that initiated the session.")
+    primary_device_id: Optional[str] = Field(default=None, description="Device executing primarily.")
+    participant_count: int = Field(default=0, description="Number of participants in this session.")
+    multi_device_required: bool = Field(default=False, description="Whether multi-device is required.")
+    merge_policy: Optional[str] = Field(default=None, description="Result merge policy.")
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -268,15 +239,9 @@ class RuntimeProjectionDispatchEntry(BaseModel):
         default=None, description="Dispatch mode (e.g. 'local', 'remote_handoff', 'staged_mesh')."
     )
     status: Optional[str] = Field(default=None, description="Dispatch result status.")
-    source_device_id: Optional[str] = Field(
-        default=None, description="Originating device ID."
-    )
-    target_device_id: Optional[str] = Field(
-        default=None, description="Target device ID, if applicable."
-    )
-    mesh_session_id: Optional[str] = Field(
-        default=None, description="Associated mesh session ID."
-    )
+    source_device_id: Optional[str] = Field(default=None, description="Originating device ID.")
+    target_device_id: Optional[str] = Field(default=None, description="Target device ID, if applicable.")
+    mesh_session_id: Optional[str] = Field(default=None, description="Associated mesh session ID.")
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -293,12 +258,8 @@ class RuntimeProjectionHandoffEntry(BaseModel):
     """
 
     handoff_id: str = Field(description="Unique handoff envelope identifier.")
-    source_device_id: Optional[str] = Field(
-        default=None, description="Source device ID."
-    )
-    target_device_id: Optional[str] = Field(
-        default=None, description="Target device ID."
-    )
+    source_device_id: Optional[str] = Field(default=None, description="Source device ID.")
+    target_device_id: Optional[str] = Field(default=None, description="Target device ID.")
     task_id: Optional[str] = Field(default=None, description="Associated task ID.")
     session_id: Optional[str] = Field(default=None, description="Associated session ID.")
     metadata: Dict[str, Any] = Field(default_factory=dict)
@@ -317,13 +278,9 @@ class RuntimeProjectionTakeoverEntry(BaseModel):
     """
 
     result_id: str = Field(description="Unique takeover result identifier.")
-    status: Optional[str] = Field(
-        default=None, description="Takeover execution status."
-    )
+    status: Optional[str] = Field(default=None, description="Takeover execution status.")
     device_id: Optional[str] = Field(default=None, description="Target device ID.")
-    handoff_id: Optional[str] = Field(
-        default=None, description="Associated handoff envelope ID."
-    )
+    handoff_id: Optional[str] = Field(default=None, description="Associated handoff envelope ID.")
     session_id: Optional[str] = Field(default=None, description="Associated session ID.")
     task_id: Optional[str] = Field(default=None, description="Associated task ID.")
     metadata: Dict[str, Any] = Field(default_factory=dict)
@@ -341,12 +298,8 @@ class RuntimeProjectionCoordinatorEntry(BaseModel):
     :class:`~contracts.mesh_session_coordinator.MeshSessionCoordinatorSummary`.
     """
 
-    coordinator_id: Optional[str] = Field(
-        default=None, description="Coordinator instance identifier."
-    )
-    session_id: Optional[str] = Field(
-        default=None, description="Session being coordinated."
-    )
+    coordinator_id: Optional[str] = Field(default=None, description="Coordinator instance identifier.")
+    session_id: Optional[str] = Field(default=None, description="Session being coordinated.")
     mesh_id: Optional[str] = Field(default=None, description="Mesh identifier.")
     status: Optional[str] = Field(default=None, description="Coordinator status.")
     participant_count: int = Field(default=0)
@@ -373,9 +326,7 @@ class RuntimeProjectionResultEntry(BaseModel):
     status: Optional[str] = Field(default=None, description="Overall merge status.")
     result_unit_count: int = Field(default=0, description="Number of result units merged.")
     merge_policy: Optional[str] = Field(default=None, description="Merge policy applied.")
-    session_id: Optional[str] = Field(
-        default=None, description="Associated mesh session ID."
-    )
+    session_id: Optional[str] = Field(default=None, description="Associated mesh session ID.")
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -471,9 +422,7 @@ class MultiDeviceRuntimeProjection(BaseModel):
     # PR-35
     source_dispatches: List[RuntimeProjectionDispatchEntry] = Field(
         default_factory=list,
-        description=(
-            "Projection entries for active/recent source dispatch decisions (PR-35)."
-        ),
+        description=("Projection entries for active/recent source dispatch decisions (PR-35)."),
     )
     # PR-31
     handoff_summaries: List[RuntimeProjectionHandoffEntry] = Field(
@@ -483,23 +432,17 @@ class MultiDeviceRuntimeProjection(BaseModel):
     # PR-34
     takeover_summaries: List[RuntimeProjectionTakeoverEntry] = Field(
         default_factory=list,
-        description=(
-            "Projection entries for recent local takeover results (PR-34)."
-        ),
+        description=("Projection entries for recent local takeover results (PR-34)."),
     )
     # PR-37
     coordinator_summaries: List[RuntimeProjectionCoordinatorEntry] = Field(
         default_factory=list,
-        description=(
-            "Projection entries for active mesh session coordinators (PR-37)."
-        ),
+        description=("Projection entries for active mesh session coordinators (PR-37)."),
     )
     # PR-36
     merged_results: List[RuntimeProjectionResultEntry] = Field(
         default_factory=list,
-        description=(
-            "Projection entries for cross-runtime merged result summaries (PR-36)."
-        ),
+        description=("Projection entries for cross-runtime merged result summaries (PR-36)."),
     )
     # PR-27 (optional)
     governance_snapshot: Optional[Dict[str, Any]] = Field(
@@ -675,13 +618,17 @@ def project_runtime_devices(
                 platform=d.get("platform"),
                 form_factor=d.get("form_factor"),
                 status=d.get("status"),
+                # Canonical RegisteredRuntimeDevice.to_dict() nests the transport
+                # state under "connection" (RuntimeConnectionSummary.state), NOT
+                # "connection_summary".  Check the flat field first, then the
+                # canonical "connection" key, then the legacy "connection_summary"
+                # alias — mirroring from_registered_runtime_device() so the bulk
+                # builder and the single-device adapter agree.
                 connection_state=d.get("connection_state")
-                or (_safe_dict(d.get("connection_summary", {})).get("state")),
+                or _safe_dict(d.get("connection") or d.get("connection_summary") or {}).get("state"),
                 runtime_capable=bool(d.get("runtime_capable", True)),
                 health_score=d.get("health_score"),
-                source_runtime_posture=str(
-                    d.get("source_runtime_posture", "control_only") or "control_only"
-                ),
+                source_runtime_posture=str(d.get("source_runtime_posture", "control_only") or "control_only"),
                 is_runtime_host=bool(d.get("is_runtime_host", False)),
                 metadata=_safe_dict(d.get("metadata", {})),
             )
@@ -789,11 +736,18 @@ def project_runtime_hosts(
                 device_id=d.get("device_id"),
                 status=d.get("status"),
                 execution_mode=d.get("execution_mode"),
-                accepts_handoff=bool(caps.get("accepts_handoff", d.get("accepts_handoff", False))),
-                can_delegate=bool(caps.get("can_delegate", d.get("can_delegate", False))),
-                source_runtime_posture=str(
-                    d.get("source_runtime_posture", "control_only") or "control_only"
+                # Canonical LocalRuntimeHostCapabilities expresses "accepts a
+                # cross-device handoff" as `supports_remote_handoff_receive`
+                # (see contracts.local_runtime_host); the flat `accepts_handoff`
+                # key is a projection-only alias no producer emits.  Fall back to
+                # the canonical capability so canonical hosts project truthfully.
+                accepts_handoff=bool(
+                    caps.get(
+                        "accepts_handoff", caps.get("supports_remote_handoff_receive", d.get("accepts_handoff", False))
+                    )
                 ),
+                can_delegate=bool(caps.get("can_delegate", d.get("can_delegate", False))),
+                source_runtime_posture=str(d.get("source_runtime_posture", "control_only") or "control_only"),
                 metadata=_safe_dict(d.get("metadata", {})),
             )
             result.append(entry)
@@ -914,8 +868,7 @@ def project_handoffs(
                 source_device_id=source.get("device_id") or d.get("source_device_id"),
                 target_device_id=target.get("device_id") or d.get("target_device_id"),
                 task_id=d.get("task_id") or _safe_dict(d.get("task", {})).get("task_id"),
-                session_id=d.get("session_id")
-                or _safe_dict(d.get("session_context", {})).get("session_id"),
+                session_id=d.get("session_id") or _safe_dict(d.get("session_context", {})).get("session_id"),
                 metadata=_safe_dict(d.get("metadata", {})),
             )
             result.append(entry)

--- a/contracts/runtime_session_snapshot.py
+++ b/contracts/runtime_session_snapshot.py
@@ -792,6 +792,9 @@ class RuntimeSessionSnapshot(BaseModel):
             mesh_session_id=self.mesh_session_id,
             source_device_id=self.source_device_id,
             primary_device_id=self.primary_device_id,
+            # to_identity 之前漏掉了 source_runtime_posture(两个模型都有该字段),
+            # 导致身份块丢失该 posture(coordination_role 不在 snapshot 上,无法转发)。
+            source_runtime_posture=self.source_runtime_posture,
             created_at=self.created_at,
             updated_at=self.updated_at,
             metadata=dict(self.metadata),
@@ -1275,7 +1278,10 @@ def build_runtime_session_snapshot(
                     replay_required=_safe_bool(d.get("replay_required")),
                     resume_allowed=_safe_bool(d.get("resume_allowed")),
                     merge_confirmation_required=_safe_bool(d.get("merge_confirmation_required")),
-                    has_barrier=_safe_bool(d.get("has_barrier")),
+                    # 生产方 RuntimeReconciliationState 发的是嵌套 barrier_state
+                    # (RecoveryBarrierState,含 blocking 标志),没有扁平的 has_barrier
+                    # 键——此前 d.get("has_barrier") 恒为 None。取 barrier_state.blocking。
+                    has_barrier=_safe_bool(_safe_dict(d.get("barrier_state") or {}).get("blocking")),
                     reason=_safe_str(d.get("reason") or ""),
                     metadata=dict(d.get("metadata") or {}),
                 )

--- a/contracts/runtime_session_snapshot.py
+++ b/contracts/runtime_session_snapshot.py
@@ -1217,6 +1217,26 @@ def build_runtime_session_snapshot(
         if coordinator_state is not None:
             try:
                 d = _safe_dict(coordinator_state)
+                # Producer MeshSessionCoordinatorState.to_dict() nests the barrier
+                # under "barrier_state" (MeshBarrierState.status is the enum, value
+                # "waiting" means devices are blocking at the barrier); the compact
+                # MeshSessionCoordinatorSummary emits a flat "barrier_status".  The
+                # legacy read looked for "barrier"/".blocking", which no producer
+                # emits, so barrier_active was always False.  Read the canonical
+                # shapes here.
+                _barrier_dict = _safe_dict(d.get("barrier_state") or d.get("barrier") or {})
+                _barrier_status = (
+                    _safe_str(
+                        d.get("barrier_status") or _barrier_dict.get("status") or _barrier_dict.get("barrier_status")
+                    )
+                    .strip()
+                    .lower()
+                )
+                # Producer emits the event log as "coordination_events"; the compact
+                # summary carries none.  "events"/"event_count" are legacy aliases.
+                _event_count = _safe_int(
+                    len(_safe_list(d.get("coordination_events") or d.get("events") or [])) or d.get("event_count") or 0
+                )
                 coordinator_block = RuntimeSessionSnapshotCoordinatorState(
                     coordinator_id=_safe_str(d.get("coordinator_id") or d.get("state_id")) or None,
                     coordinator_status=_safe_str(d.get("status") or d.get("coordinator_status")) or None,
@@ -1228,9 +1248,10 @@ def build_runtime_session_snapshot(
                     ),
                     barrier_active=_safe_bool(
                         d.get("barrier_active")
-                        or (d.get("barrier") is not None and _safe_bool(d.get("barrier", {}).get("blocking")))
+                        or (_barrier_status == "waiting")
+                        or _safe_bool(_barrier_dict.get("blocking"))
                     ),
-                    event_count=_safe_int(len(_safe_list(d.get("events") or [])) or d.get("event_count")),
+                    event_count=_event_count,
                     metadata=dict(d.get("metadata") or {}),
                 )
             except Exception as exc:
@@ -1242,9 +1263,21 @@ def build_runtime_session_snapshot(
             try:
                 d = _safe_dict(merged_result)
                 units = _safe_list(d.get("result_units") or [])
-                auth_ids = _extract_unit_ids_by_status(units, {"authoritative", "confirmed", "merged"})
-                stale_ids = _extract_unit_ids_by_status(units, {"stale", "superseded", "rejected"})
-                pending_ids = _extract_unit_ids_by_status(units, {"pending", "partial", "in_progress"})
+                # Producer RuntimeResultUnit.status emits the RuntimeResultStatus
+                # enum (succeeded/failed/partial/blocked/skipped/timeout/unknown).
+                # The legacy sets ({authoritative,confirmed,merged} etc.) matched
+                # NONE of those values, so all three buckets were always empty.
+                # Map the real outcome enum onto the snapshot's authoritative /
+                # stale / pending buckets, keeping the legacy aliases for compat:
+                #   succeeded            -> authoritative (confirmed-good result)
+                #   failed/blocked/
+                #   skipped/timeout      -> stale (superseded / non-authoritative)
+                #   partial/unknown      -> pending (incomplete / undetermined)
+                auth_ids = _extract_unit_ids_by_status(units, {"succeeded", "authoritative", "confirmed", "merged"})
+                stale_ids = _extract_unit_ids_by_status(
+                    units, {"failed", "blocked", "skipped", "timeout", "stale", "superseded", "rejected"}
+                )
+                pending_ids = _extract_unit_ids_by_status(units, {"partial", "unknown", "pending", "in_progress"})
                 result_block = RuntimeSessionSnapshotResultState(
                     merge_id=_safe_str(d.get("merge_id") or d.get("result_id")) or None,
                     merge_status=_safe_str(d.get("status") or d.get("merge_status")) or None,

--- a/contracts/runtime_session_snapshot.py
+++ b/contracts/runtime_session_snapshot.py
@@ -701,9 +701,7 @@ class RuntimeSessionSnapshot(BaseModel):
     # Device and host state
     runtime_devices: List[Dict[str, Any]] = Field(
         default_factory=list,
-        description=(
-            "Compact entries for all registered runtime devices in this session."
-        ),
+        description=("Compact entries for all registered runtime devices in this session."),
     )
     runtime_hosts: List[Dict[str, Any]] = Field(
         default_factory=list,
@@ -1187,9 +1185,7 @@ def build_runtime_session_snapshot(
                     dispatch_status=_safe_str(d.get("status") or d.get("dispatch_status")) or None,
                     target_device_ids=[
                         _safe_str(t)
-                        for t in _safe_list(
-                            d.get("target_device_ids") or d.get("selected_target_device_ids") or []
-                        )
+                        for t in _safe_list(d.get("target_device_ids") or d.get("selected_target_device_ids") or [])
                     ],
                     plan_id=_safe_str(d.get("plan_id")) or None,
                     reason=_safe_str(d.get("reason") or d.get("outcome_reason") or ""),
@@ -1234,9 +1230,7 @@ def build_runtime_session_snapshot(
                         d.get("barrier_active")
                         or (d.get("barrier") is not None and _safe_bool(d.get("barrier", {}).get("blocking")))
                     ),
-                    event_count=_safe_int(
-                        len(_safe_list(d.get("events") or [])) or d.get("event_count")
-                    ),
+                    event_count=_safe_int(len(_safe_list(d.get("events") or [])) or d.get("event_count")),
                     metadata=dict(d.get("metadata") or {}),
                 )
             except Exception as exc:
@@ -1271,10 +1265,9 @@ def build_runtime_session_snapshot(
                 d = _safe_dict(recovery_state)
                 recovery_block = RuntimeSessionSnapshotRecoveryState(
                     reconciliation_id=_safe_str(d.get("reconciliation_id") or d.get("recovery_id")) or None,
-                    recovery_status=_safe_str(d.get("status") or d.get("overall_status") or d.get("recovery_status")) or None,
-                    incident_count=_safe_int(
-                        d.get("incident_count") or len(_safe_list(d.get("incidents") or []))
-                    ),
+                    recovery_status=_safe_str(d.get("status") or d.get("overall_status") or d.get("recovery_status"))
+                    or None,
+                    incident_count=_safe_int(d.get("incident_count") or len(_safe_list(d.get("incidents") or []))),
                     replay_required=_safe_bool(d.get("replay_required")),
                     resume_allowed=_safe_bool(d.get("resume_allowed")),
                     merge_confirmation_required=_safe_bool(d.get("merge_confirmation_required")),

--- a/contracts/source_posture_contract.py
+++ b/contracts/source_posture_contract.py
@@ -157,11 +157,11 @@ SOURCE_POSTURE_CONTRACT_PR_PACKAGE_1_CANONICALIZATION_SENTINEL: str = (
 #: NEVER be overloaded to encode participation posture.
 CANONICAL_POSTURE_ADJACENT_FIELDS: frozenset = frozenset(
     {
-        "entry_mode",            # execution-path selection (local/cross_device/hybrid)
+        "entry_mode",  # execution-path selection (local/cross_device/hybrid)
         "cross_device_enabled",  # global feature gate — on/off only
-        "formation_role",        # multi-device formation assignment
-        "coordination_role",     # multi-device coordination role (PR-6)
-        "runtime_domain_intent", # high-level domain (cross_device/local)
+        "formation_role",  # multi-device formation assignment
+        "coordination_role",  # multi-device coordination role (PR-6)
+        "runtime_domain_intent",  # high-level domain (cross_device/local)
     }
 )
 

--- a/contracts/source_posture_contract.py
+++ b/contracts/source_posture_contract.py
@@ -429,7 +429,14 @@ def build_source_posture_field(
     SourcePostureContractField
         A validated field model.  Never raises.
     """
-    resolved = resolve_source_posture_value(posture_hint)
+    # Honour the caller-supplied *default*: an absent/unrecognised posture_hint
+    # must resolve to it, not the hardcoded CONTROL_ONLY. resolve_source_posture_value
+    # takes an enum default, while our *default* is its string value.
+    try:
+        default_value = SourcePostureValue(default)
+    except (ValueError, TypeError):
+        default_value = SourcePostureValue.CONTROL_ONLY
+    resolved = resolve_source_posture_value(posture_hint, default=default_value)
     try:
         return SourcePostureContractField(source_runtime_posture=resolved.value)
     except (ValueError, TypeError):

--- a/core/academic_retrieval.py
+++ b/core/academic_retrieval.py
@@ -278,7 +278,10 @@ class AcademicRetriever:
             )
             logger.info(
                 "Paper ingested into Knowledge Core: %s (entry_id=%s)",
-                paper.get("title", "")[:60],
+                # str()-coerce: an external API can return a null title, and
+                # None[:60] here would raise into the except below — reporting a
+                # successful ingest (entry_id already returned) as a failure ("").
+                str(paper.get("title") or "")[:60],
                 entry_id,
             )
             return entry_id

--- a/core/attached_runtime_session_registry.py
+++ b/core/attached_runtime_session_registry.py
@@ -823,6 +823,15 @@ class AttachedSessionRegistry:
 
     def _push(self, entry: AttachedSessionRegistryEntry) -> None:
         """Append *entry* to the ring buffer and update lookup indices."""
+        # The ring buffer is a bounded deque(maxlen) that silently FIFO-evicts,
+        # but _entry_by_session / _entry_by_attachment_id gain a key per entry
+        # and were never pruned → they grow without bound as distinct session /
+        # attachment ids churn over a long-lived process.  Capture the entry
+        # about to be evicted so we can drop its now-dangling index keys below.
+        evicted: Optional[AttachedSessionRegistryEntry] = None
+        if self._capacity > 0 and len(self._buffer) == self._capacity:
+            evicted = self._buffer[0]
+
         self._buffer.append(entry)
         if entry.is_active():
             self._active_by_device[entry.device_id] = entry.entry_id
@@ -830,6 +839,22 @@ class AttachedSessionRegistry:
             self._entry_by_session[entry.session_id] = entry.entry_id
         if entry.runtime_attachment_session_id:
             self._entry_by_attachment_id[entry.runtime_attachment_session_id] = entry.entry_id
+
+        # Prune the evicted entry's index keys, but ONLY if they still point at
+        # it (a newer entry may have re-used the same id above — never drop that).
+        if evicted is not None:
+            self._prune_indices_for(evicted)
+
+    def _prune_indices_for(self, entry: AttachedSessionRegistryEntry) -> None:
+        """Remove index keys that still point at *entry* (an evicted record)."""
+        sid = entry.session_id
+        if sid and self._entry_by_session.get(sid) == entry.entry_id:
+            del self._entry_by_session[sid]
+        aid = entry.runtime_attachment_session_id
+        if aid and self._entry_by_attachment_id.get(aid) == entry.entry_id:
+            del self._entry_by_attachment_id[aid]
+        if self._active_by_device.get(entry.device_id) == entry.entry_id:
+            del self._active_by_device[entry.device_id]
 
     def _update_indices(self, entry: AttachedSessionRegistryEntry) -> None:
         """Refresh lookup indices after an in-place buffer replacement."""

--- a/core/cognitive/decay_controller.py
+++ b/core/cognitive/decay_controller.py
@@ -47,6 +47,10 @@ from typing import Any, Dict, Optional
 
 from core.cognitive.continuous_state import CognitiveState, get_cognitive_state
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.Cognitive.Decay")
 
 _COGNITIVE_DECAY_EVENT = "cognitive.decay"
@@ -145,7 +149,9 @@ class DecayController:
         )
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(self._async_decay_sequence(task_id=task_id, trace_id=trace_id))
+            _bt = loop.create_task(self._async_decay_sequence(task_id=task_id, trace_id=trace_id))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except RuntimeError:
             # No running event loop — apply a single synchronous decay step
             self._sync_decay_step(task_id=task_id, trace_id=trace_id)

--- a/core/config_hot_reload.py
+++ b/core/config_hot_reload.py
@@ -20,6 +20,10 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.ConfigHotReload")
 
 
@@ -376,7 +380,9 @@ class HotReloadConfigManager:
                 if asyncio.iscoroutine(result):
                     try:
                         loop = asyncio.get_running_loop()
-                        loop.create_task(result)
+                        _bt = loop.create_task(result)
+                        _BACKGROUND_TASKS.add(_bt)
+                        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                     except RuntimeError:
                         pass  # 没有事件循环时跳过异步回调
             except Exception as e:

--- a/core/connection_manager.py
+++ b/core/connection_manager.py
@@ -29,6 +29,10 @@ from typing import Any, Callable, Dict, List, Optional
 
 import httpx
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("ConnectionManager")
 
 
@@ -356,7 +360,9 @@ class ConnectionManager:
                 conn_info.state = ConnectionState.DISCONNECTED
 
                 # 触发重连
-                asyncio.create_task(self.reconnect(connection_id))
+                _bt = asyncio.create_task(self.reconnect(connection_id))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 break
 
     async def _start_heartbeat(self, connection_id: str):

--- a/core/connection_manager.py
+++ b/core/connection_manager.py
@@ -279,6 +279,13 @@ class ConnectionManager:
         config = self.configs[connection_id]
 
         conn_info.state = ConnectionState.RECONNECTING
+        # Reset the retry budget at the START of each reconnect() invocation.
+        # retry_count is only otherwise zeroed inside connect() on success, so a
+        # reconnect() that exhausts all attempts leaves retry_count == max_retries;
+        # a later reconnect() (endpoint recovered) would then find the while-guard
+        # immediately false and return False without a single attempt — the
+        # connection would be stuck in ERROR forever.
+        conn_info.retry_count = 0
 
         while conn_info.retry_count < config.max_retries:
             # 计算退避延迟

--- a/core/cross_device_sync.py
+++ b/core/cross_device_sync.py
@@ -20,6 +20,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("Galaxy.CrossDeviceSync")
 
+# Retains fire-and-forget phase-sync tasks.  asyncio.get_event_loop().create_task
+# only keeps a WEAK reference to the task, so a bare create_task(...) whose result
+# is discarded can be garbage-collected before it runs, silently dropping the
+# cross-device phase broadcast.  Hold a strong ref until the task finishes.
+_BACKGROUND_PHASE_SYNC_TASKS: set = set()
+
 try:
     from core.schemas.aip_v3 import StateEventMsg  # noqa: F401
 
@@ -150,7 +156,7 @@ def emit_cross_device_phase_sync(
     """
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(
+        task = loop.create_task(
             _async_push_phase_to_all_devices(
                 old_phase=old_phase,
                 new_phase=new_phase,
@@ -159,6 +165,10 @@ def emit_cross_device_phase_sync(
                 trace_id=trace_id,
             )
         )
+        # Keep a strong reference until the task completes so it can't be GC'd
+        # mid-flight (the loop only holds a weak ref to the task).
+        _BACKGROUND_PHASE_SYNC_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_PHASE_SYNC_TASKS.discard)
     except RuntimeError:
         logger.debug("CrossDeviceSync: no event loop, skipping push")
 

--- a/core/desktop_presence_runtime.py
+++ b/core/desktop_presence_runtime.py
@@ -105,6 +105,10 @@ from core.desktop_presence_system import (
 )
 from core.multimodal.perception_source_registry import STREAM_CAPABLE_SOURCE_TYPES
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.Runtime")
 _STREAMING_BACKBONE_CONTRACT: Optional[Dict[str, Any]] = None
 
@@ -1767,7 +1771,9 @@ class DesktopPresenceRuntime:
                 logger.debug("主动感知目标执行失败（非致命）：%s", exc)
 
         try:
-            loop.create_task(_run())
+            _bt = loop.create_task(_run())
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             logger.info("主动感知目标已派发执行：%s", goal)
         except RuntimeError:
             pass

--- a/core/galaxy_federation.py
+++ b/core/galaxy_federation.py
@@ -31,6 +31,10 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.Federation")
 
 try:
@@ -216,7 +220,9 @@ class GalaxyFederation:
             if peer.backoff_until > now:
                 logger.debug(f"Skipping heartbeat to {peer.url} (backoff until {peer.backoff_until:.1f})")
                 continue
-            asyncio.create_task(self._ping_peer(peer, payload))
+            _bt = asyncio.create_task(self._ping_peer(peer, payload))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     async def _ping_peer(self, peer: PeerInstance, payload: Dict) -> None:
         """向单个 peer 发送心跳"""

--- a/core/github_installer.py
+++ b/core/github_installer.py
@@ -69,6 +69,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.GitHubInstaller")
 
 # ── Constants ─────────────────────────────────────────────────────────────────
@@ -864,7 +868,9 @@ def _publish_install_truth(payload: Dict[str, Any]) -> None:
         except RuntimeError:
             asyncio.run(_do_broadcast())
             return
-        loop.create_task(_do_broadcast())
+        _bt = loop.create_task(_do_broadcast())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     except Exception as exc:
         logger.warning("Exception suppressed: %s", exc)
 

--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.LocalBrain")
 
 
@@ -365,7 +369,9 @@ class LocalBrainManager:
                 self.available_models,
             )
             # 后台显式加载选定模型进内存(Ollama 惰性加载,ping 通≠模型可用)。
-            asyncio.create_task(self._warm_up_ollama_model())
+            _bt = asyncio.create_task(self._warm_up_ollama_model())
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             return True
 
         # 2. Ollama not running, try to start
@@ -398,7 +404,9 @@ class LocalBrainManager:
                         self.available_models,
                     )
                     # 后台显式加载模型进内存(serve 刚起,更需要主动预载)。
-                    asyncio.create_task(self._warm_up_ollama_model())
+                    _bt = asyncio.create_task(self._warm_up_ollama_model())
+                    _BACKGROUND_TASKS.add(_bt)
+                    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                     return True
 
         # PR-I1: Auto-install Ollama —— 仅当命令确实不存在时才尝试，

--- a/core/lumiv_websocket_bridge.py
+++ b/core/lumiv_websocket_bridge.py
@@ -16,6 +16,10 @@ import logging
 import os
 from typing import Any, Dict, Optional, Set
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 try:
     from fastapi import WebSocket, WebSocketDisconnect
 except ImportError:
@@ -170,7 +174,9 @@ class GalaxyPresenceBridge:
         self._current_mode = "static"
         self._current_depth = MODE_DEPTH_MAP["static"]
         self._intent = 0.0
-        asyncio.create_task(self._broadcast_state())
+        _bt = asyncio.create_task(self._broadcast_state())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     def _on_phase_liminal(self, event: Any) -> None:
         p = self._payload_of(event)
@@ -179,13 +185,17 @@ class GalaxyPresenceBridge:
         # intent 从 payload 中提取，如果没有则默认 0.5
         self._intent = p.get("intent_strength", 0.5)
         self._speaking = p.get("speaking", self._speaking)
-        asyncio.create_task(self._broadcast_state())
+        _bt = asyncio.create_task(self._broadcast_state())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     def _on_phase_manifest(self, payload: Dict[str, Any]) -> None:
         self._current_mode = "manifest"
         self._current_depth = MODE_DEPTH_MAP["manifest"]
         self._intent = 1.0
-        asyncio.create_task(self._broadcast_state())
+        _bt = asyncio.create_task(self._broadcast_state())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     def _on_intent_update(self, event: Any) -> None:
         """意图强度持续更新 — Liminal 态下微调 depth。"""
@@ -197,7 +207,9 @@ class GalaxyPresenceBridge:
         # depth 在 0.15-0.85 之间随 intent 线性映射
         self._current_depth = 0.15 + intent * 0.70
         self._speaking = p.get("speaking", False)
-        asyncio.create_task(self._broadcast_state())
+        _bt = asyncio.create_task(self._broadcast_state())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     @staticmethod
     def _payload_of(event: Any) -> Dict[str, Any]:
@@ -242,7 +254,9 @@ class GalaxyPresenceBridge:
         except Exception:  # noqa: BLE001
             return
         try:
-            asyncio.create_task(self._debounced_feed_push())
+            _bt = asyncio.create_task(self._debounced_feed_push())
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except Exception:  # noqa: BLE001
             pass
 
@@ -319,7 +333,9 @@ class GalaxyPresenceBridge:
         self._ambient_seeing = bool(p.get("has_frame"))
         self._ambient_hearing = bool(p.get("has_audio"))
         self._ambient_ts = _t.time()
-        asyncio.create_task(self._broadcast_state())
+        _bt = asyncio.create_task(self._broadcast_state())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     def _on_ambient_decision(self, event: Any) -> None:
         """自发注意力：三选一决策（speak/silent/delegate）+ 理由。"""
@@ -329,7 +345,9 @@ class GalaxyPresenceBridge:
         self._ambient_action = str(p.get("action", ""))
         self._ambient_rationale = str(p.get("rationale") or p.get("utterance") or p.get("task") or "")
         self._ambient_ts = _t.time()
-        asyncio.create_task(self._broadcast_state())
+        _bt = asyncio.create_task(self._broadcast_state())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     # ── WebSocket 客户端管理 ──
 
@@ -494,7 +512,9 @@ def _schedule(coro) -> None:
     """在当前事件循环里调度协程；无运行循环时同步兜底跑一次。"""
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(coro)
+        _bt = loop.create_task(coro)
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     except RuntimeError:
         try:
             asyncio.run(coro)

--- a/core/mcp_loader.py
+++ b/core/mcp_loader.py
@@ -39,6 +39,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.MCP")
 
 # C阶段 2C: 工具调用守护（可选依赖，默认不启用）
@@ -288,8 +292,12 @@ class MCPLoader:
                 pass
             _payload = {"server_id": server_id, "event": event}
             if loop and loop.is_running():
-                loop.create_task(broadcast_event("mcp_update", _payload))
-                loop.create_task(broadcast_event("capability_update", {"source": "mcp_loader", **_payload}))
+                _bt = loop.create_task(broadcast_event("mcp_update", _payload))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
+                _bt = loop.create_task(broadcast_event("capability_update", {"source": "mcp_loader", **_payload}))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except Exception as exc:
             logger.warning("MCP broadcast event failed: %s", exc)
 

--- a/core/mesh/live_mesh_runtime_engine.py
+++ b/core/mesh/live_mesh_runtime_engine.py
@@ -65,6 +65,10 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 _logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -285,7 +289,9 @@ def _emit_aip_v3_mesh_events(
                     trace_id=trace_id,
                     role="participant",
                 )
-                loop.create_task(nats.publish_mesh_join(msg))
+                _bt = loop.create_task(nats.publish_mesh_join(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
         elif event_type == "mesh_leave":
             for did in device_ids:
@@ -296,7 +302,9 @@ def _emit_aip_v3_mesh_events(
                     trace_id=trace_id,
                     reason="session_finalized",
                 )
-                loop.create_task(nats.publish_mesh_leave(msg))
+                _bt = loop.create_task(nats.publish_mesh_leave(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
         elif event_type == "mesh_result":
             if participant_results:
@@ -313,7 +321,9 @@ def _emit_aip_v3_mesh_events(
                     subtask_results=subtask_results,
                     participant_count=len(participant_results),
                 )
-                loop.create_task(nats.publish_mesh_result(msg))
+                _bt = loop.create_task(nats.publish_mesh_result(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
         elif event_type == "coord_sync":
             _import_coordinator_contracts()
@@ -336,7 +346,9 @@ def _emit_aip_v3_mesh_events(
                 barrier_status=barrier_status,
                 participant_statuses=participant_statuses,
             )
-            loop.create_task(nats.publish_coord_sync(msg))
+            _bt = loop.create_task(nats.publish_coord_sync(msg))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
     except Exception as exc:
         _logger.debug("_emit_aip_v3_mesh_events: emission failed (non-fatal): %s", exc)
@@ -399,8 +411,8 @@ def _dispatch_remote_barrier_requests(
     for device_id in waiting_device_ids:
         try:
             if convergence.is_remote(device_id):
-                # Fire-and-forget as a background task
-                loop.create_task(
+                # Fire-and-forget as a background task (retained so it can't be GC'd).
+                _bt = loop.create_task(
                     convergence.request_participant_action(
                         session_id=session_id,
                         device_id=device_id,
@@ -409,6 +421,8 @@ def _dispatch_remote_barrier_requests(
                         timeout_ms=30_000,
                     )
                 )
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 dispatched += 1
                 _log_event(
                     "barrier_remote_dispatched",
@@ -459,7 +473,9 @@ def _emit_mesh_heartbeat_leave(coordinator_state: Any, device_id: str) -> None:
         )
         nats = get_nats_bus()
         if nats.is_connected():
-            asyncio.get_running_loop().create_task(nats.publish_mesh_leave(msg))
+            _bt = asyncio.get_running_loop().create_task(nats.publish_mesh_leave(msg))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             _logger.info(
                 "[MeshHeartbeat] Participant %s timed out, MESH_LEAVE emitted",
                 device_id,

--- a/core/mesh/mesh_session_lifecycle.py
+++ b/core/mesh/mesh_session_lifecycle.py
@@ -537,6 +537,16 @@ class MeshSessionLifecycleCoordinator:
         except Exception as exc:
             logger.warning("terminate_session: failed to mark_terminal for %s: %s", session_id, exc)
 
+        # Evict the terminated record from the in-memory map.  _sessions had no
+        # removal path, so a process-wide singleton that terminates many sessions
+        # (swarm_coordinator calls this on every dispatch_team) accumulated a
+        # permanent record — each holding a full session snapshot — forever.
+        # The persistence store retains the terminal marker for any audit/recovery
+        # needs; the live in-memory map only needs non-terminal sessions.
+        if record is not None:
+            with self._lock:
+                self._sessions.pop(session_id, None)
+
         return record
 
     # ------------------------------------------------------------------

--- a/core/mesh/mesh_session_lifecycle.py
+++ b/core/mesh/mesh_session_lifecycle.py
@@ -74,6 +74,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -213,6 +214,13 @@ class MeshSessionLifecycleCoordinator:
         :func:`~core.mesh.mesh_session_persistence.get_persistence_store` is used.
     """
 
+    # Cap on terminal records kept queryable in the in-memory map.  Terminal
+    # sessions must remain visible after terminate_session (callers query them
+    # via get_record / find_sessions_for_device(only_non_terminal=False)), but
+    # without a bound the process-wide singleton leaks one record per
+    # terminated session (swarm_coordinator terminates one per dispatch_team).
+    _MAX_TERMINAL_RETAINED: int = 512
+
     def __init__(
         self,
         store: Optional[Any] = None,
@@ -220,6 +228,9 @@ class MeshSessionLifecycleCoordinator:
         self._store = store  # resolved lazily to avoid import-time side effects
         self._sessions: Dict[str, MeshSessionLifecycleRecord] = {}
         self._lock = threading.Lock()
+        # Terminal records retained in _sessions (insertion-ordered so the
+        # oldest terminal record is evicted first once the cap is reached).
+        self._terminal_retained: "OrderedDict[str, None]" = OrderedDict()
 
     # ------------------------------------------------------------------
     # Persistence store accessor (lazy)
@@ -537,15 +548,20 @@ class MeshSessionLifecycleCoordinator:
         except Exception as exc:
             logger.warning("terminate_session: failed to mark_terminal for %s: %s", session_id, exc)
 
-        # Evict the terminated record from the in-memory map.  _sessions had no
-        # removal path, so a process-wide singleton that terminates many sessions
-        # (swarm_coordinator calls this on every dispatch_team) accumulated a
-        # permanent record — each holding a full session snapshot — forever.
-        # The persistence store retains the terminal marker for any audit/recovery
-        # needs; the live in-memory map only needs non-terminal sessions.
+        # Bounded terminal retention.  Terminal records must stay queryable
+        # (get_record after termination; find_sessions_for_device with
+        # only_non_terminal=False), so they are NOT evicted immediately —
+        # instead at most _MAX_TERMINAL_RETAINED terminal records are kept and
+        # the oldest is evicted beyond that.  The persistence store retains the
+        # durable terminal marker for anything evicted from memory.
         if record is not None:
             with self._lock:
-                self._sessions.pop(session_id, None)
+                if session_id in self._sessions:
+                    self._terminal_retained[session_id] = None
+                    self._terminal_retained.move_to_end(session_id)
+                    while len(self._terminal_retained) > self._MAX_TERMINAL_RETAINED:
+                        oldest_sid, _ = self._terminal_retained.popitem(last=False)
+                        self._sessions.pop(oldest_sid, None)
 
         return record
 

--- a/core/mesh/mesh_session_persistence.py
+++ b/core/mesh/mesh_session_persistence.py
@@ -86,6 +86,7 @@ import logging
 import os
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -243,11 +244,30 @@ class MeshSessionPersistenceStore:
         ``data/mesh_sessions/`` relative to the repository root.
     """
 
+    #: Max snapshots kept in the in-memory hot cache.  The durable file is the
+    #: source of truth (load() falls back to _read_record on a cache miss), so
+    #: evicting cold/terminal entries here only trims memory — nothing is lost.
+    _MAX_MEMORY_CACHE: int = 512
+
     def __init__(self, store_dir: Optional[str] = None) -> None:
         self._store_dir = store_dir or _DEFAULT_STORE_DIR
         self._lock = threading.Lock()
-        self._memory_cache: Dict[str, SnapshotRecord] = {}
+        # OrderedDict + LRU eviction: previously a plain dict that only ever
+        # gained entries (save/load/mark_terminal all inserted, and terminal
+        # sessions were never removed), so it grew without bound over a long-
+        # running process.  load() reloads from the durable file on a miss.
+        self._memory_cache: "OrderedDict[str, SnapshotRecord]" = OrderedDict()
         self._ensure_dir()
+
+    def _cache_put(self, session_id: str, record: "SnapshotRecord") -> None:
+        """Insert/refresh *record* in the bounded LRU memory cache.
+
+        Caller must hold ``self._lock``.
+        """
+        self._memory_cache[session_id] = record
+        self._memory_cache.move_to_end(session_id)
+        while len(self._memory_cache) > self._MAX_MEMORY_CACHE:
+            self._memory_cache.popitem(last=False)
 
     # ------------------------------------------------------------------
     # Public interface
@@ -287,7 +307,7 @@ class MeshSessionPersistenceStore:
                     version=version,
                 )
                 self._write_record(record)
-                self._memory_cache[session_id] = record
+                self._cache_put(session_id, record)
                 logger.debug(
                     "Persisted mesh session snapshot: session_id=%s status=%s v=%d",
                     session_id,
@@ -318,7 +338,7 @@ class MeshSessionPersistenceStore:
                     return self._memory_cache[session_id]
                 record = self._read_record(session_id)
                 if record is not None:
-                    self._memory_cache[session_id] = record
+                    self._cache_put(session_id, record)
                 return record
         except Exception as exc:
             logger.warning("load: failed to load session %s: %s", session_id, exc)
@@ -399,7 +419,7 @@ class MeshSessionPersistenceStore:
             )
             with self._lock:
                 self._write_record(updated)
-                self._memory_cache[session_id] = updated
+                self._cache_put(session_id, updated)
             return True
         except Exception as exc:
             logger.warning("mark_terminal: failed for %s: %s", session_id, exc)

--- a/core/monitoring.py
+++ b/core/monitoring.py
@@ -23,6 +23,10 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Callable, Coroutine, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.Monitoring")
 
 
@@ -358,7 +362,9 @@ class AlertManager:
         if self._on_alert:
             try:
                 if asyncio.iscoroutinefunction(self._on_alert):
-                    asyncio.create_task(self._on_alert(alert))
+                    _bt = asyncio.create_task(self._on_alert(alert))
+                    _BACKGROUND_TASKS.add(_bt)
+                    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 else:
                     self._on_alert(alert)
             except Exception as e:

--- a/core/multimodal/audio_capture_service.py
+++ b/core/multimodal/audio_capture_service.py
@@ -45,6 +45,10 @@ from .multimodal_events import (
 )
 from .signal_quality import SignalQuality
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger(__name__)
 
 # Latency threshold above which a quality-degraded event is emitted (ms)
@@ -247,7 +251,9 @@ class AudioCaptureService:
             if asyncio.iscoroutinefunction(self.on_voice_input):
                 try:
                     # 在事件循环线程里调用:直接 create_task。
-                    asyncio.get_running_loop().create_task(self.on_voice_input(text))  # noqa: RUF006
+                    _bt = asyncio.get_running_loop().create_task(self.on_voice_input(text))  # noqa: RUF006
+                    _BACKGROUND_TASKS.add(_bt)
+                    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 except RuntimeError:
                     # 在 worker 线程里调用(无运行中的事件循环):跨线程安全调度
                     # 到 start() 时捕获的主循环。

--- a/core/multimodal/webrtc_session.py
+++ b/core/multimodal/webrtc_session.py
@@ -17,6 +17,10 @@ import numpy as np
 
 from .signal_quality import SignalQuality
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -129,7 +133,9 @@ class WebRTCCameraSession:
             @self._pc.on("track")  # type: ignore[misc]
             async def on_track(track):
                 if track.kind == "video":
-                    asyncio.create_task(self._receive_video(track))
+                    _bt = asyncio.create_task(self._receive_video(track))
+                    _BACKGROUND_TASKS.add(_bt)
+                    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
             @self._pc.on("connectionstatechange")  # type: ignore[misc]
             async def on_state_change():

--- a/core/network_graph_runtime.py
+++ b/core/network_graph_runtime.py
@@ -661,9 +661,15 @@ class NetworkGraphRuntime:
                     field_truth_grades={"topology_view": TRUTH_GRADE_RECOVERABLE},
                     extra={"recovered_at": recovered_wallclock},
                 )
+                # Per-item safe enum parse: one corrupt persisted value must not
+                # abort the entire recovery (raw constructor raises ValueError).
+                try:
+                    role = NetworkNodeRole(str(item.get("role") or NetworkNodeRole.UNKNOWN.value))
+                except ValueError:
+                    role = NetworkNodeRole.UNKNOWN
                 self._nodes[node_id] = NetworkNode(
                     node_id=node_id,
-                    role=NetworkNodeRole(str(item.get("role") or NetworkNodeRole.UNKNOWN.value)),
+                    role=role,
                     host=str(item.get("host") or ""),
                     port=int(item.get("port") or 0),
                     transport_hints=dict(item.get("transport_hints") or {}),
@@ -690,11 +696,16 @@ class NetworkGraphRuntime:
                     field_truth_grades={"topology_view": TRUTH_GRADE_RECOVERABLE},
                     extra={"recovered_at": recovered_wallclock},
                 )
+                # Per-item safe enum parse (same rationale as node roles above).
+                try:
+                    kind = NetworkEdgeKind(str(item.get("kind") or NetworkEdgeKind.FABRIC_LINK.value))
+                except ValueError:
+                    kind = NetworkEdgeKind.FABRIC_LINK
                 self._edges[edge_id] = NetworkEdge(
                     edge_id=edge_id,
                     source_node_id=str(item.get("source_node_id") or ""),
                     target_node_id=str(item.get("target_node_id") or ""),
-                    kind=NetworkEdgeKind(str(item.get("kind") or NetworkEdgeKind.FABRIC_LINK.value)),
+                    kind=kind,
                     metadata=metadata,
                     created_at=recovered_monotonic,
                 )

--- a/core/node_invocation.py
+++ b/core/node_invocation.py
@@ -63,6 +63,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.NodeInvocation")
 
 # ---------------------------------------------------------------------------
@@ -680,7 +684,9 @@ class UnifiedNodeExecutor:
             )
             nats = get_nats_bus()
             if nats.is_connected():
-                asyncio.get_running_loop().create_task(nats.publish_task_assign(msg))
+                _bt = asyncio.get_running_loop().create_task(nats.publish_task_assign(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             else:
                 logger.debug("AIPV3-LOCAL TASK_ASSIGN: %s", msg.model_dump_json(exclude_none=True))
         except Exception as exc:
@@ -708,7 +714,9 @@ class UnifiedNodeExecutor:
             )
             nats = get_nats_bus()
             if nats.is_connected():
-                asyncio.get_running_loop().create_task(nats.publish_task_result(msg))
+                _bt = asyncio.get_running_loop().create_task(nats.publish_task_result(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             else:
                 logger.debug("AIPV3-LOCAL TASK_RESULT: %s", msg.model_dump_json(exclude_none=True))
         except Exception as exc:

--- a/core/node_registry.py
+++ b/core/node_registry.py
@@ -27,6 +27,10 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Type
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("NodeRegistry")
 
 
@@ -501,7 +505,9 @@ class NodeRegistry:
 
             loop = _asyncio.get_running_loop()
             if loop.is_running():
-                loop.create_task(capability_manager.update_node_status(node_id, cap_status))
+                _bt = loop.create_task(capability_manager.update_node_status(node_id, cap_status))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except Exception as e:
             logger.debug(f"能力状态更新失败 (非致命): {e}")
 

--- a/core/routes/command.py
+++ b/core/routes/command.py
@@ -51,6 +51,10 @@ from core.routes._shared import (
 )
 from core.schemas.task_envelope import envelope_from_command_request
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 try:
     from core.auth import require_auth
 except ImportError:
@@ -352,7 +356,9 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                         }
                     )
 
-            asyncio.create_task(execute_async())
+            _bt = asyncio.create_task(execute_async())
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
             return JSONResponse(
                 {

--- a/core/routes/system.py
+++ b/core/routes/system.py
@@ -522,7 +522,10 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                     did
                     for did in connection_manager.online_device_ids()
                     if did in registered_devices
-                    and registered_devices[did].get("device_type", "").startswith("android")
+                    # str()-coerce: a present-but-None device_type would make
+                    # None.startswith(...) raise and (via the surrounding except)
+                    # silently reset the whole android_online count to 0.
+                    and str(registered_devices[did].get("device_type") or "").startswith("android")
                 ]
             )
         except Exception as exc:

--- a/core/scheduling_truth_harness.py
+++ b/core/scheduling_truth_harness.py
@@ -315,7 +315,7 @@ class SchedulingTruthHarness:
 
             # Check if already registered
             try:
-                existing = tgr.get_task(task_id)
+                existing = tgr.get_node_by_task_id(task_id)
                 if existing is not None:
                     logger.debug("ensure_task_registered: task %s already registered", task_id)
                     return True
@@ -324,7 +324,9 @@ class SchedulingTruthHarness:
 
             # Register the task
             try:
-                tgr.register_task(canonical_task)
+                from core.task_graph_runtime import WorkflowContributorKind
+
+                tgr.register_canonical_task(canonical_task, contributor=WorkflowContributorKind.SCHEDULER)
                 logger.debug(
                     "ensure_task_registered: registered task %s in TaskGraphRuntime",
                     task_id,
@@ -438,12 +440,12 @@ class SchedulingTruthHarness:
             notes.append("TaskGraphRuntime unavailable — registration cannot be verified")
         else:
             try:
-                existing = tgr.get_task(task_id) if task_id else None
+                existing = tgr.get_node_by_task_id(task_id) if task_id else None
                 task_registered = existing is not None
                 if not task_registered and task_id:
                     notes.append(f"task {task_id!r} not yet registered in TaskGraphRuntime")
             except Exception as exc:
-                notes.append(f"TaskGraphRuntime.get_task() error: {exc}")
+                notes.append(f"TaskGraphRuntime.get_node_by_task_id() error: {exc}")
 
         # 2. Check routable-executor query
         routable_ids = self.query_routable_executors(canonical_task, candidate_device_ids=candidate_device_ids)

--- a/core/skill_loader.py
+++ b/core/skill_loader.py
@@ -36,6 +36,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.Skill")
 
 
@@ -202,8 +206,12 @@ class SkillLoader:
                 pass
             _payload = {"skill_id": skill_id, "event": event}
             if loop and loop.is_running():
-                loop.create_task(broadcast_event("skill_update", _payload))
-                loop.create_task(broadcast_event("capability_update", {"source": "skill_loader", **_payload}))
+                _bt = loop.create_task(broadcast_event("skill_update", _payload))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
+                _bt = loop.create_task(broadcast_event("capability_update", {"source": "skill_loader", **_payload}))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except Exception as exc:
             logger.warning("Exception suppressed: %s", exc)
 

--- a/core/skill_md_loader.py
+++ b/core/skill_md_loader.py
@@ -33,6 +33,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.SkillMD")
 
 # Strict allowlist of commands permitted in SKILL.md execution
@@ -306,7 +310,9 @@ class SkillMDLoader:
             self._inject_skill_to_registry(skill_id)
             try:
                 loop = asyncio.get_running_loop()
-                loop.create_task(self._refresh_capability_registry(skill_id, "load"))
+                _bt = loop.create_task(self._refresh_capability_registry(skill_id, "load"))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             except RuntimeError:
                 logger.debug("SKILL.md load capability refresh skipped: no running event loop")
             except Exception as exc:
@@ -489,7 +495,9 @@ class SkillMDLoader:
 
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(self._refresh_capability_registry(skill_id, "unload"))
+            _bt = loop.create_task(self._refresh_capability_registry(skill_id, "unload"))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except RuntimeError:
             logger.debug("SKILL.md unload capability refresh skipped: no running event loop")
         except Exception as exc:

--- a/core/speech_output.py
+++ b/core/speech_output.py
@@ -22,6 +22,10 @@ import os
 import time
 from typing import Any, Callable, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.SpeechOutput")
 
 # 真流式请求上下文里已经有 IncrementalSpeaker 在边生成边念时,请求收尾处
@@ -291,7 +295,9 @@ def _dispatch_speech(coro: Any) -> None:
     """把一段发声协程调度上运行中的事件循环;无循环则同步兜底执行。"""
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(coro)  # 非阻塞:后台朗读
+        _bt = loop.create_task(coro)  # 非阻塞:后台朗读
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     except RuntimeError:
         # 无运行中的事件循环:同步兜底(尽量不长阻塞)。
         try:
@@ -425,7 +431,9 @@ def _maybe_speak_native(text: str, source: str) -> bool:
         return False
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(_run_native_speech(backend, text, source))
+        _bt = loop.create_task(_run_native_speech(backend, text, source))
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         return True
     except RuntimeError:
         # 无运行中的事件循环:同步兜底执行原生发声。
@@ -565,7 +573,9 @@ def interrupt_speech() -> None:
         return
     try:
         loop = asyncio.get_running_loop()
-        loop.create_task(speaker.interrupt())
+        _bt = loop.create_task(speaker.interrupt())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     except RuntimeError:
         try:
             asyncio.run(speaker.interrupt())

--- a/core/startup.py
+++ b/core/startup.py
@@ -1119,6 +1119,38 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
         logger.warning("启动恢复跳过（降级）: %s", _exc)
 
     # ====================================================================
+    # 20b. 可持久化 DAG 续跑重派（Feature ① 闭环）
+    # Step 20 的恢复协调器只产出续跑视图（resume_snapshot）；真正的重派入口
+    # TaskGraphRuntime.resume_pending_dispatch 由这里接线。仅在
+    # GALAXY_DURABLE_EXEC 开启时执行（默认关 = 零行为变化）；重派统一走
+    # canonical 路径 CommandRouter.route_envelope，且逐节点先过 ② 派发幂等
+    # 守卫——崩溃前已派发过的节点绝不二次触发副作用。
+    # ====================================================================
+    try:
+        from core.task_graph_runtime import durable_exec_enabled
+
+        if durable_exec_enabled():
+            from core.task_graph_resume_dispatch import resume_durable_task_graph
+
+            _resume_result = await resume_durable_task_graph()
+            results["task_graph_resume_dispatch"] = {
+                "status": "ok",
+                "resumed": len(_resume_result.get("resumed", [])),
+                "failed": len(_resume_result.get("failed", [])),
+                "deduplicated": len(_resume_result.get("deduplicated", [])),
+            }
+            logger.info(
+                "可持久化 DAG 续跑重派完成: resumed=%d failed=%d deduplicated=%d",
+                len(_resume_result.get("resumed", [])),
+                len(_resume_result.get("failed", [])),
+                len(_resume_result.get("deduplicated", [])),
+            )
+    except Exception as _exc:
+        logger.debug("Fallback triggered: %s", _exc)
+        results["task_graph_resume_dispatch"] = {"status": "degraded", "error": str(_exc)}
+        logger.warning("可持久化 DAG 续跑重派跳过（降级）: %s", _exc)
+
+    # ====================================================================
     # 21. 持久化结果幂等性存储初始化（Durable Result Idempotency Store）
     # Eagerly initialise the durable result-ID dedup store so that
     # duplicate result handling is safe immediately after startup.

--- a/core/state_event_bus.py
+++ b/core/state_event_bus.py
@@ -54,6 +54,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set, Union  # noqa
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.StateEventBus")
 
 
@@ -345,7 +349,9 @@ class StateEventBus:
                     if asyncio.iscoroutinefunction(token.callback):
                         try:
                             loop = asyncio.get_running_loop()
-                            loop.create_task(token.callback(event))  # type: ignore[arg-type]
+                            _bt = loop.create_task(token.callback(event))  # type: ignore[arg-type]
+                            _BACKGROUND_TASKS.add(_bt)
+                            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                         except RuntimeError:
                             # No running loop — skip async subscriber gracefully.
                             logger.debug(

--- a/core/state_sync_bus.py
+++ b/core/state_sync_bus.py
@@ -43,6 +43,10 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.StateSyncBus")
 
 # PR-AIPV3: AIP v3 unified message emission
@@ -221,7 +225,9 @@ class StateSynchronizationBus:
             )
             nats = get_nats_bus()
             if nats.is_connected():
-                asyncio.get_running_loop().create_task(nats.publish_state_event(msg))
+                _bt = asyncio.get_running_loop().create_task(nats.publish_state_event(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except Exception as exc:
             logger.warning("Exception suppressed: %s", exc)
 

--- a/core/streaming_speech.py
+++ b/core/streaming_speech.py
@@ -22,6 +22,10 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Callable, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.StreamingSpeech")
 
 # 句末标点（中英）+ 换行 —— 在这些位置切句，便于"说一句合成下一句"。
@@ -373,7 +377,9 @@ class IncrementalSpeaker:
         if self._stop is None:
             return
         try:
-            asyncio.get_running_loop().create_task(self._stop())
+            _bt = asyncio.get_running_loop().create_task(self._stop())
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except RuntimeError:
             pass
 

--- a/core/swarm_coordinator.py
+++ b/core/swarm_coordinator.py
@@ -102,6 +102,10 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.SwarmCoordinator")
 
 
@@ -537,7 +541,9 @@ class SwarmCoordinator:
                     session_id=session_id,
                 )
                 if nats.is_connected():
-                    loop.create_task(nats.publish_task_assign(msg))
+                    _bt = loop.create_task(nats.publish_task_assign(msg))
+                    _BACKGROUND_TASKS.add(_bt)
+                    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 else:
                     logger.debug("AIPV3-SWARM TASK_ASSIGN: %s", msg.model_dump_json(exclude_none=True))
         except Exception as exc:
@@ -582,7 +588,9 @@ class SwarmCoordinator:
                     session_id=session_id,
                 )
                 if nats.is_connected():
-                    loop.create_task(nats.publish_task_result(msg))
+                    _bt = loop.create_task(nats.publish_task_result(msg))
+                    _BACKGROUND_TASKS.add(_bt)
+                    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 else:
                     logger.debug("AIPV3-SWARM TASK_RESULT: %s", msg.model_dump_json(exclude_none=True))
         except Exception as exc:

--- a/core/tailscale_manager.py
+++ b/core/tailscale_manager.py
@@ -15,6 +15,10 @@ import shutil
 import subprocess
 from typing import Any, Callable, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.Tailscale")
 
 # PR-AIPV3: Unified AIP v3 emission
@@ -264,7 +268,9 @@ class TailscaleManager:
             )
             nats = get_nats_bus()
             if nats.is_connected():
-                asyncio.get_running_loop().create_task(nats.publish_state_event(msg))
+                _bt = asyncio.get_running_loop().create_task(nats.publish_state_event(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             else:
                 logger.debug("AIPV3-TAILSCALE STATE_EVENT: %s", msg.model_dump_json(exclude_none=True))
         except Exception as exc:

--- a/core/task_graph.py
+++ b/core/task_graph.py
@@ -49,6 +49,10 @@ from collections import defaultdict, deque
 from enum import Enum
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Set
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.TaskGraph")
 
 # PR-AIPV3-DAG: AIP v3 unified message models for cross-device task dispatch
@@ -361,7 +365,9 @@ class TaskGraph:
 
             nats = get_nats_bus()
             if nats.is_connected():
-                asyncio.get_running_loop().create_task(nats.publish_task_assign(msg))
+                _bt = asyncio.get_running_loop().create_task(nats.publish_task_assign(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             else:
                 # Log the AIP v3 message for local debugging / tracing
                 logger.debug("AIPV3-DAG TASK_ASSIGN: %s", msg.model_dump_json(exclude_none=True))
@@ -401,7 +407,9 @@ class TaskGraph:
 
             nats = get_nats_bus()
             if nats.is_connected():
-                asyncio.get_running_loop().create_task(nats.publish_task_result(msg))
+                _bt = asyncio.get_running_loop().create_task(nats.publish_task_result(msg))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             else:
                 logger.debug("AIPV3-DAG TASK_RESULT: %s", msg.model_dump_json(exclude_none=True))
         except Exception as exc:

--- a/core/task_graph_resume_dispatch.py
+++ b/core/task_graph_resume_dispatch.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+core/task_graph_resume_dispatch.py
+==================================
+Feature ① 续跑闭环的执行端接线。
+
+背景
+----
+``TaskGraphRuntime.resume_pending_dispatch()`` 是重启续跑的执行入口：对每个
+"待执行态 + 依赖已满足"的节点调用注入的 ``dispatch_fn`` 重新派发。它的文档
+说"dispatch_fn 由恢复协调器/主脑注入"，而 ``runtime_restart_recovery`` 的
+Step 12 注释说"实际重派由启动序列注入 dispatch_fn 完成"——但在本模块出现
+之前，全仓库没有任何生产代码真正接线，续跑闭环停在"只出报告、不重派"。
+
+本模块提供 :func:`resume_durable_task_graph`，由 ``core.startup`` 在启动恢复
+（Step 20）之后调用。派发策略：
+
+* 仅在 ``GALAXY_DURABLE_EXEC`` 开启时被调用（调用方把关）——默认关闭时
+  零行为变化，与 task_graph_runtime 的持久化契约一致。
+* 每个节点先过 ② 派发幂等守卫（``durable_dispatch_idempotency``）：崩溃前
+  已标记过的键说明副作用已经发生，绝不二次触发，仅将节点推回 DISPATCH。
+* 载荷从 ``node.metadata["resume_args"]`` 恢复（由
+  ``envelope_to_graph_node`` 在注册时保留）。载荷不可恢复的节点【拒绝】
+  带空参数重跑——保持待执行态，由 ``resume_snapshot()`` 暴露给操作者。
+* 重派统一走 canonical 路径 ``CommandRouter.route_envelope``。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger("Galaxy.TaskGraphResumeDispatch")
+
+# 本模块是 resume_pending_dispatch 的唯一生产接线点（启动序列专用）。
+TASK_GRAPH_RESUME_DISPATCH_WIRED: str = (
+    "TASK_GRAPH_RESUME_DISPATCH_WIRED_V1: core.startup calls "
+    "resume_durable_task_graph() after Step 20 recovery when "
+    "GALAXY_DURABLE_EXEC is enabled; dispatch goes through "
+    "CommandRouter.route_envelope guarded by durable_dispatch_idempotency."
+)
+
+
+def _build_envelope_from_node(node: Any) -> Any:
+    """Rebuild a faithful ``TaskEnvelope`` from a durable ``GraphNode``.
+
+    Raises ``RuntimeError`` when the re-dispatch payload is unrecoverable —
+    re-running a tool with empty args is worse than leaving the node pending.
+    """
+    meta: Dict[str, Any] = getattr(node, "metadata", None) or {}
+    args = meta.get("resume_args")
+    if not getattr(node, "tool_name", "") or not isinstance(args, dict):
+        raise RuntimeError(
+            f"resume payload unavailable for task {node.task_id!r} "
+            f"(tool={getattr(node, 'tool_name', '')!r}) — left pending for operator review"
+        )
+
+    from core.schemas.task_envelope import TaskEnvelope
+
+    kwargs: Dict[str, Any] = {
+        "task_id": node.task_id,
+        "source": "restart_resume",
+        "tool_name": node.tool_name,
+        "args": args,
+    }
+    if getattr(node, "trace_id", ""):
+        kwargs["trace_id"] = node.trace_id
+    if getattr(node, "session_id", ""):
+        kwargs["session_id"] = node.session_id
+    if getattr(node, "device_id", ""):
+        kwargs["targets"] = [node.device_id]
+    _timeout = meta.get("resume_timeout")
+    if isinstance(_timeout, (int, float)) and _timeout > 0:
+        kwargs["timeout"] = float(_timeout)
+    _priority = meta.get("resume_priority")
+    if isinstance(_priority, int) and 1 <= _priority <= 10:
+        kwargs["priority"] = _priority
+    return TaskEnvelope(**kwargs)
+
+
+async def resume_durable_task_graph() -> Dict[str, Any]:
+    """Run ``TaskGraphRuntime.resume_pending_dispatch`` over the canonical spine.
+
+    Returns the runtime's resume result dict ``{"resumed": [...], "failed": [...]}``
+    augmented with a ``"deduplicated"`` list of task_ids whose dispatch key was
+    already marked before the crash (side effect already ran — not re-triggered).
+    """
+    from core.task_graph_runtime import get_task_graph_runtime
+
+    tgr = get_task_graph_runtime()
+    deduplicated: list = []
+
+    async def _dispatch(node: Any) -> None:
+        # ② 派发幂等守卫:崩前已标记的键 = 副作用已发生,绝不二次执行。
+        from core.durable_dispatch_idempotency import (
+            already_dispatched,
+            dispatch_idempotency_enabled,
+            dispatch_key_for,
+        )
+
+        key = dispatch_key_for({"task_id": node.task_id}) if dispatch_idempotency_enabled() else ""
+        if key and already_dispatched(key):
+            deduplicated.append(node.task_id)
+            logger.info(
+                "resume: task %s 崩溃前已派发过(幂等键命中),不二次触发副作用",
+                node.task_id,
+            )
+            return
+
+        envelope = _build_envelope_from_node(node)
+
+        from core.command_router import get_command_router
+
+        router = get_command_router()
+        await router.route_envelope(envelope)
+
+    result = await tgr.resume_pending_dispatch(_dispatch)
+    result["deduplicated"] = deduplicated
+    return result
+
+
+__all__ = [
+    "TASK_GRAPH_RESUME_DISPATCH_WIRED",
+    "resume_durable_task_graph",
+]

--- a/core/task_graph_runtime.py
+++ b/core/task_graph_runtime.py
@@ -183,6 +183,11 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 MAX_RESULT_SUMMARY_LENGTH: int = 200
+
+# Feature ①: upper bound (JSON chars) for envelope args retained on a GraphNode
+# for restart re-dispatch.  Larger payloads are not retained — the node then
+# resumes ownership-only instead of bloating every durable checkpoint write.
+_RESUME_ARGS_MAX_JSON_CHARS: int = 32768
 """Maximum length for result_summary string stored on a GraphNode."""
 
 MAX_ERROR_LENGTH: int = 400
@@ -1905,6 +1910,28 @@ def envelope_to_graph_node(
         targets = getattr(envelope, "targets", None) or []
         device_id = targets[0] if targets else ""
 
+    # Feature ①: retain the re-dispatch payload so a durable-exec restart can
+    # rebuild a faithful envelope — GraphNode otherwise drops args/timeout and
+    # resume would re-run tools with empty parameters.  Only JSON-safe args of
+    # bounded size are retained (the per-transition checkpoint json.dumps the
+    # whole node map; an unserialisable or huge payload would silently disable
+    # durability for every node).  Nodes without a retained payload are
+    # ownership-only on resume: never re-dispatched with wrong args.
+    metadata: Dict[str, Any] = {}
+    args = getattr(envelope, "args", None)
+    if isinstance(args, dict) and args:
+        try:
+            if len(json.dumps(args, ensure_ascii=False)) <= _RESUME_ARGS_MAX_JSON_CHARS:
+                metadata["resume_args"] = args
+        except (TypeError, ValueError):
+            pass
+    _timeout = getattr(envelope, "timeout", None)
+    if isinstance(_timeout, (int, float)) and _timeout > 0:
+        metadata["resume_timeout"] = float(_timeout)
+    _priority = getattr(envelope, "priority", None)
+    if isinstance(_priority, int) and 1 <= _priority <= 10:
+        metadata["resume_priority"] = _priority
+
     return GraphNode(
         task_id=task_id,
         trace_id=trace_id,
@@ -1914,6 +1941,7 @@ def envelope_to_graph_node(
         state=GraphNodeState.QUEUED,
         contributor=contributor,
         depends_on=list(depends_on or []),
+        metadata=metadata,
     )
 
 

--- a/core/udm_registration_hook.py
+++ b/core/udm_registration_hook.py
@@ -26,6 +26,10 @@ import logging
 import time
 from typing import Any, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -192,7 +196,9 @@ class UDMRegistrationHook:
             from core.state_event_bus import StateEventType, subscribe
 
             def _on_device_event(event_type, payload):
-                asyncio.create_task(self._handle_device_event(payload))
+                _bt = asyncio.create_task(self._handle_device_event(payload))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
             subscribe(StateEventType.DEVICE_UPDATED, _on_device_event)
             self._listening = True

--- a/core/unified/device_manager.py
+++ b/core/unified/device_manager.py
@@ -59,6 +59,10 @@ from typing import Any, Dict, List, Optional  # noqa: E402  哨兵权威声明�
 from .exceptions import DeviceManagerError  # noqa: E402  哨兵权威声明置顶是本仓设计习语
 from .models import UnifiedDevice, UnifiedDeviceStatus, UnifiedDeviceType  # noqa: E402  哨兵权威声明置顶是本仓设计习语
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.Unified.DeviceManager")
 
 # Default heartbeat-timeout and grace-period constants (seconds).
@@ -477,7 +481,9 @@ class UnifiedDeviceManager:
             # because register_device() is a sync method.
             try:
                 loop = asyncio.get_running_loop()
-                loop.create_task(dwc.on_device_registered(device))
+                _bt = loop.create_task(dwc.on_device_registered(device))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 logger.debug(
                     "Scheduled Worker registration for device %s",
                     device.device_id,
@@ -510,7 +516,9 @@ class UnifiedDeviceManager:
 
             try:
                 loop = asyncio.get_running_loop()
-                loop.create_task(dwc.on_device_unregistered(device_id))
+                _bt = loop.create_task(dwc.on_device_unregistered(device_id))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                 logger.debug(
                     "Scheduled Worker unregistration for device %s",
                     device_id,
@@ -542,7 +550,9 @@ class UnifiedDeviceManager:
 
             try:
                 loop = asyncio.get_running_loop()
-                loop.create_task(dwc.on_device_heartbeat(device_id))
+                _bt = loop.create_task(dwc.on_device_heartbeat(device_id))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             except RuntimeError:
                 pass
         except Exception as exc:

--- a/core/unified_system_state_narrative.py
+++ b/core/unified_system_state_narrative.py
@@ -323,7 +323,7 @@ def _build_overall_runtime_state() -> NarrativeDimension:
     is_canonical = False
 
     try:
-        from core.runtime_readiness_matrix import ReadinessMatrix, MatrixVerdict
+        from core.runtime_readiness_matrix import MatrixVerdict, ReadinessMatrix
 
         matrix = ReadinessMatrix()
         verdict = matrix.evaluate()

--- a/core/webrtc_task_lifecycle.py
+++ b/core/webrtc_task_lifecycle.py
@@ -106,6 +106,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Deque, Dict, List, Optional
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger("Galaxy.WebRTCTaskLifecycle")
 
 __all__ = [
@@ -243,7 +247,9 @@ def _emit_aip_v3_webrtc_bind(binding: "WebRTCTaskBinding") -> None:
         )
         nats = get_nats_bus()
         if nats.is_connected():
-            asyncio.get_running_loop().create_task(nats.publish_webrtc_bind(msg))
+            _bt = asyncio.get_running_loop().create_task(nats.publish_webrtc_bind(msg))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         else:
             logger.debug("AIPV3-WEBRTC BIND: %s", msg.model_dump_json(exclude_none=True))
     except Exception as exc:
@@ -276,7 +282,9 @@ def _emit_aip_v3_webrtc_transport_state(
         )
         nats = get_nats_bus()
         if nats.is_connected():
-            asyncio.get_running_loop().create_task(nats.publish_webrtc_transport_state(msg))
+            _bt = asyncio.get_running_loop().create_task(nats.publish_webrtc_transport_state(msg))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         else:
             logger.debug("AIPV3-WEBRTC STATE: %s", msg.model_dump_json(exclude_none=True))
     except Exception as exc:
@@ -301,7 +309,9 @@ def _emit_aip_v3_webrtc_unbind(binding: "WebRTCTaskBinding") -> None:
         )
         nats = get_nats_bus()
         if nats.is_connected():
-            asyncio.get_running_loop().create_task(nats.publish_webrtc_unbind(msg))
+            _bt = asyncio.get_running_loop().create_task(nats.publish_webrtc_unbind(msg))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         else:
             logger.debug("AIPV3-WEBRTC UNBIND: %s", msg.model_dump_json(exclude_none=True))
     except Exception as exc:

--- a/fusion/unified_orchestrator.py
+++ b/fusion/unified_orchestrator.py
@@ -160,6 +160,10 @@ class UnifiedOrchestrator:
         self.task_queue = asyncio.Queue()
         self.is_running = False
         self._worker_task = None
+        # Strong refs to in-flight execute_task() tasks.  asyncio only keeps a
+        # weak ref to bare create_task() results, so a fire-and-forget task can
+        # be garbage-collected before it finishes; retain until each completes.
+        self._inflight_tasks: set = set()
         
         # 性能统计
         self.stats = {
@@ -217,8 +221,11 @@ class UnifiedOrchestrator:
                 task_id = await asyncio.wait_for(self.task_queue.get(), timeout=1.0)
                 task = self.tasks.get(task_id)
                 if task:
-                    # 异步执行任务，不阻塞循环
-                    asyncio.create_task(self.execute_task(task))
+                    # 异步执行任务，不阻塞循环。保留强引用直至完成,避免任务被 GC
+                    # 提前回收(事件循环只持有弱引用)。
+                    _exec = asyncio.create_task(self.execute_task(task))
+                    self._inflight_tasks.add(_exec)
+                    _exec.add_done_callback(self._inflight_tasks.discard)
                 self.task_queue.task_done()
             except asyncio.TimeoutError:
                 continue

--- a/fusion/unified_orchestrator.py
+++ b/fusion/unified_orchestrator.py
@@ -319,17 +319,22 @@ class UnifiedOrchestrator:
                 task.execution_path.append(node_id)
                 
                 logger.info(f"⚡ Executing subtask on node: {node_id}")
-                
-                # 更新节点负载
-                self.topology.update_load(node_id, 10)
+
+                # 标记节点忙碌 / 执行后恢复。TopologyManager.update_load 的语义是
+                # 【设置绝对归一化负载 (0.0-1.0)】,不是增量。此前传 +10 / -10 当作
+                # 增减量,会把负载先设成 10、执行后设成 -10;而 find_best_node 的
+                # LOAD_BALANCED 走 min(load),负载 -10 的节点反而永远最优、被反复选中
+                # ——负载均衡被彻底反转。改为:保存原负载 → 临时抬升(封顶 1.0)→
+                # finally 恢复原值,既能反映执行期忙碌,又不破坏 [0,1] 契约。
+                _prior_load = self.topology.get_load(node_id)
+                self.topology.update_load(node_id, min(1.0, _prior_load + 0.1))
 
                 # 真实执行逻辑，包含重试。用 try/finally 确保无论执行是否抛异常
-                # 都释放负载——此前 _execute_with_retry 抛异常会跳过下面的 -10，
-                # 导致该节点负载计数只增不减、最终被误判为过载而不再被调度。
+                # 都恢复原负载,避免节点负载被永久抬高而最终被误判为过载不再调度。
                 try:
                     res = await self._execute_with_retry(node_id, subtask, subtask_id=_st_id)
                 finally:
-                    self.topology.update_load(node_id, -10)
+                    self.topology.update_load(node_id, _prior_load)
 
                 if res.success:
                     results.append(res.data)

--- a/galaxy_gateway/android/handlers/goal_execution.py
+++ b/galaxy_gateway/android/handlers/goal_execution.py
@@ -410,7 +410,11 @@ async def handle_goal_execution(
     2. 通过 DesktopPresenceRuntime 处理
     3. 返回 task_assign（Android 据此执行本地 goal）
     """
-    payload = message.get("payload", {})
+    # get()'s {} default only applies when the key is absent; a present-but-None
+    # (or non-dict) payload from an Android sender would make payload.get(...) an
+    # AttributeError and crash this handler.  Normalise to a dict, and guard a
+    # present-but-None goal below (None.strip() would likewise crash).
+    payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
     device_id = message.get("device_id") or payload.get("device_id", "unknown")
     raw_session_id = payload.get("session_id") or message.get("session_id") or ""
     # 跨设备统一上下文:不再把所有无 session 的手机目标塞进单一全局 "android_default"
@@ -426,7 +430,7 @@ async def handle_goal_execution(
         session_id = raw_session_id or "android_default"
     trace_id = payload.get("trace_id") or message.get("trace_id") or f"trace_{uuid.uuid4().hex[:12]}"
     task_id = payload.get("task_id") or message.get("task_id") or str(uuid.uuid4())
-    goal = payload.get("goal", "").strip()
+    goal = (payload.get("goal") or "").strip()
 
     if not goal:
         return MessageBuilder.error(
@@ -637,7 +641,11 @@ async def handle_parallel_subtask(
     5. 向通过就绪检查的设备发送独立的 task_assign（包含 subtask_index）
     6. 返回 fan-out 结果（异步，不等待设备执行完成）
     """
-    payload = message.get("payload", {})
+    # get()'s {} default only applies when the key is absent; a present-but-None
+    # (or non-dict) payload from an Android sender would make payload.get(...) an
+    # AttributeError and crash this handler.  Normalise to a dict, and guard a
+    # present-but-None goal below (None.strip() would likewise crash).
+    payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
     device_id = message.get("device_id") or payload.get("device_id", "unknown")
     raw_session_id = payload.get("session_id") or message.get("session_id") or ""
     # 跨设备统一上下文:不再把所有无 session 的手机目标塞进单一全局 "android_default"
@@ -653,7 +661,7 @@ async def handle_parallel_subtask(
         session_id = raw_session_id or "android_default"
     trace_id = payload.get("trace_id") or message.get("trace_id") or f"trace_{uuid.uuid4().hex[:12]}"
     task_id = payload.get("task_id") or message.get("task_id") or str(uuid.uuid4())
-    goal = payload.get("goal", "").strip()
+    goal = (payload.get("goal") or "").strip()
     group_id = payload.get("group_id") or f"group_{uuid.uuid4().hex[:8]}"
     constraints = payload.get("constraints", [])
     max_steps = payload.get("max_steps", 10)
@@ -1060,7 +1068,9 @@ async def handle_goal_execution_result(bridge: "AndroidBridge", websocket: Any, 
     - 记录到 TaskMemory（供 LLM 上下文注入）
     - 触发 OpenClawd 反馈（如果有对话反馈路径）
     """
-    payload = message.get("payload", {})
+    # Normalise a present-but-None/non-dict payload to {} so payload.get(...)
+    # below can't raise AttributeError (get's default only covers absent keys).
+    payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
     device_id = message.get("device_id") or payload.get("device_id", "unknown")
     task_id = payload.get("task_id") or message.get("correlation_id") or "unknown"
     trace_id = payload.get("trace_id") or message.get("trace_id") or ""

--- a/galaxy_gateway/android/handlers/goal_execution.py
+++ b/galaxy_gateway/android/handlers/goal_execution.py
@@ -834,7 +834,10 @@ async def handle_parallel_subtask(
             # Android 设备判定:类型为 ANDROID/MOBILE/PHONE 或 id 前缀 android_。
             # 此前多了一个 `or d.get("online")`,会把【所有在线设备】(含 Windows PC)
             # 都算成 Android,使并行子任务扇出到非 Android 设备。
-            if d.get("device_type", "").upper() in ("ANDROID", "MOBILE", "PHONE")
+            # str()-coerce: a single device whose device_type is present-but-None
+            # would make None.upper() raise and abort the whole comprehension,
+            # silently yielding zero Android devices for the entire fan-out.
+            if str(d.get("device_type") or "").upper() in ("ANDROID", "MOBILE", "PHONE")
             or did.startswith("android_")
         ]
         logger.debug("PARALLEL_SUBTASK: 发现 %d 台 Android 设备", len(all_device_ids))

--- a/galaxy_gateway/android/handlers/registration.py
+++ b/galaxy_gateway/android/handlers/registration.py
@@ -25,6 +25,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Strong refs to fire-and-forget tasks so the event loop's weak ref can't let
+# them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 # ---------------------------------------------------------------------------
 # Registration completeness tracking
 # ---------------------------------------------------------------------------
@@ -188,7 +192,9 @@ def _schedule_pending_delivery_replay_on_canonical_reconnect(
                 exc,
             )
 
-    asyncio.create_task(_flush())
+    _bt = asyncio.create_task(_flush())
+    _BACKGROUND_TASKS.add(_bt)
+    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     return buffered_count
 
 

--- a/galaxy_gateway/android/handlers/state_event.py
+++ b/galaxy_gateway/android/handlers/state_event.py
@@ -52,13 +52,17 @@ async def handle_state_event(
     event_action = message.get("event_action", "")
     payload = message.get("payload", {}) if isinstance(message.get("payload"), dict) else {}
 
-    # Log the state event
+    # Log the state event.  Coerce session_id to str before slicing: get()'s ""
+    # default only applies when the key is absent, so a present-but-None (or
+    # non-string) session_id from an external sender would make ""[:8] a
+    # None[:8] TypeError and tear down the whole handler (no phase update, no ack).
+    session_id_short = str(message.get("session_id") or "")[:8]
     logger.info(
         "StateEvent: received %s/%s from %s (session=%s)",
         event_category,
         event_action,
         device_id,
-        message.get("session_id", "")[:8],
+        session_id_short,
     )
 
     # Handle phase category

--- a/galaxy_gateway/android/handlers/takeover_request.py
+++ b/galaxy_gateway/android/handlers/takeover_request.py
@@ -42,6 +42,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Strong refs to fire-and-forget tasks (event loop only holds a weak ref).
+_BACKGROUND_TASKS: set = set()
+
 # Lifecycle coordinator — handles session-state reduction, tracking, and audit.
 try:
     from core.android_delegated_runtime_lifecycle_coordinator import (
@@ -145,7 +148,9 @@ def _emit_aip_v3_takeover_request(
         )
         nats = get_nats_bus()
         if nats.is_connected():
-            asyncio.get_running_loop().create_task(nats.publish_takeover_request(msg))
+            _bt = asyncio.get_running_loop().create_task(nats.publish_takeover_request(msg))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         else:
             logger.debug("AIPV3 takeover_request: %s", msg.model_dump_json(exclude_none=True))
     except Exception:

--- a/galaxy_gateway/android/handlers/task_submit.py
+++ b/galaxy_gateway/android/handlers/task_submit.py
@@ -53,12 +53,16 @@ async def handle_task_submit(
     Gateway 内部通过 DesktopPresenceRuntime → OpenClawd 处理，
     然后返回 task_assign（Step 6: Gateway → Android）。
     """
-    payload = message.get("payload", {})
+    # get()'s {} default only applies when the key is absent; a present-but-None
+    # (or non-dict) payload from an Android sender would make payload.get(...)
+    # an AttributeError and crash this Step-3 handler.  Normalise to a dict.
+    payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
     device_id = message.get("device_id") or payload.get("device_id", "unknown")
     session_id = payload.get("session_id") or message.get("session_id") or "android_default"
     trace_id = message.get("trace_id") or f"trace_{uuid.uuid4().hex[:12]}"
     task_id = payload.get("task_id") or message.get("task_id") or str(uuid.uuid4())
-    task_text = payload.get("task_text", "").strip()
+    # Likewise guard a present-but-None task_text: None.strip() would crash.
+    task_text = (payload.get("task_text") or "").strip()
 
     if not task_text:
         return MessageBuilder.error(

--- a/galaxy_gateway/android_bridge.py
+++ b/galaxy_gateway/android_bridge.py
@@ -184,6 +184,17 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+# Strong refs to fire-and-forget tasks (event loop only holds a weak ref, so a
+# discarded create_task result can be GC'd mid-execution).
+_BACKGROUND_TASKS: set = set()
+
+
+def _track_bg_task(_t):
+    """Retain *_t* until it finishes so it can't be garbage-collected mid-run."""
+    _BACKGROUND_TASKS.add(_t)
+    _t.add_done_callback(_BACKGROUND_TASKS.discard)
+    return _t
+
 # =============================================================================
 # PR-3: Execution Spine Integration — bridge dispatch authority sentinel
 
@@ -1750,9 +1761,9 @@ class AndroidBridge:
                     },
                 }
                 try:
-                    asyncio.create_task(get_aip_transport().send(_phase_msg, device_id))
+                    _track_bg_task(asyncio.create_task(get_aip_transport().send(_phase_msg, device_id)))
                 except Exception:
-                    asyncio.create_task(websocket.send_json({
+                    _track_bg_task(asyncio.create_task(websocket.send_json({
                         "type": "state_event",
                         "event_category": "phase",
                         "event_action": current_phase,
@@ -1766,7 +1777,7 @@ class AndroidBridge:
                         "sync_type": "cross_device_reconnect_sync",
                     },
                     "phase": current_phase,
-                }))
+                })))
                 logger.info(
                     "CrossDeviceSync: phase=%s pushed to reconnected device=%s",
                     current_phase, device_id,

--- a/galaxy_gateway/bootstrap/lifecycle.py
+++ b/galaxy_gateway/bootstrap/lifecycle.py
@@ -20,6 +20,9 @@ from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
 
+# Strong refs to fire-and-forget tasks (event loop only holds a weak ref).
+_BACKGROUND_TASKS: set = set()
+
 
 async def init_gateway_core_services(app: FastAPI):
     """创建并启动 Gateway 的【必需】核心服务并写入 ``app.state``。
@@ -188,7 +191,9 @@ async def lifespan(app: FastAPI):  # noqa: C901  (acceptable complexity for a bo
                 logger.info("NodeCapability: loaded %d nodes", len(result))
             except Exception as _cl_err:
                 logger.debug("NodeCapability background load failed: %s", _cl_err, exc_info=True)  # H4 fixed
-        asyncio.create_task(_load_capabilities_bg())  # L3 fixed: use asyncio directly
+        _bt_cap = asyncio.create_task(_load_capabilities_bg())  # L3 fixed: use asyncio directly
+        _BACKGROUND_TASKS.add(_bt_cap)
+        _bt_cap.add_done_callback(_BACKGROUND_TASKS.discard)
         app.state.capability_loader = _loader
     except Exception as _cl_err:
         logger.debug("NodeCapability init skipped (non-fatal): %s", _cl_err, exc_info=True)  # H4 fixed
@@ -249,7 +254,9 @@ async def lifespan(app: FastAPI):  # noqa: C901  (acceptable complexity for a bo
                             logger.info("VoiceWake: 'Galaxy' detected → LIMINAL via handle_request")
                     except Exception as _we:
                         logger.debug("VoiceWake: handle_request failed: %s", _we)
-                asyncio.create_task(_wake_request())  # L3 fixed: use asyncio directly
+                _bt_wake = asyncio.create_task(_wake_request())  # L3 fixed: use asyncio directly
+                _BACKGROUND_TASKS.add(_bt_wake)
+                _bt_wake.add_done_callback(_BACKGROUND_TASKS.discard)
 
             started = _vw.start(callback=_on_wake_word)
             if started:

--- a/galaxy_gateway/handlers/message_handler.py
+++ b/galaxy_gateway/handlers/message_handler.py
@@ -27,8 +27,44 @@
 
 import logging
 import uuid
-from typing import Optional, Callable, Dict, Any, Set, Tuple
+from collections import OrderedDict
+from typing import Optional, Callable, Dict
 from datetime import datetime, timezone
+
+# Bounds for the in-memory idempotency caches / pending-task registry so a
+# long-lived gateway does not grow them without limit (they were previously
+# plain set()/dict() that only ever gained entries).
+_SEEN_ID_CACHE_MAXLEN = 50000
+_PENDING_TASKS_MAXLEN = 20000
+
+
+class _BoundedSeenSet:
+    """Membership cache with FIFO eviction, exposing the ``in`` / ``add`` API.
+
+    Used for idempotency dedup where only recent keys need to be remembered;
+    the oldest keys are evicted once ``maxlen`` is exceeded so memory stays
+    bounded.
+    """
+
+    __slots__ = ("_maxlen", "_data")
+
+    def __init__(self, maxlen: int):
+        self._maxlen = maxlen
+        self._data: "OrderedDict" = OrderedDict()
+
+    def __contains__(self, key) -> bool:
+        return key in self._data
+
+    def add(self, key) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+            return
+        self._data[key] = None
+        while len(self._data) > self._maxlen:
+            self._data.popitem(last=False)
+
+    def __len__(self) -> int:
+        return len(self._data)
 
 from ..protocol import (
     AIPMessage, MessageType, TaskStatus, ResultStatus,
@@ -72,10 +108,12 @@ class MessageHandler:
     def __init__(self, device_manager: DeviceManager):
         self.device_manager = device_manager
         self.task_handlers: Dict[str, Callable] = {}
-        self.pending_tasks: Dict[str, dict] = {}  # task_id -> task_info
-        # Idempotency: seen task-result IDs and parallel subtask keys.
-        self._seen_task_result_ids: Set[str] = set()
-        self._seen_parallel_keys: Set[Tuple[str, int]] = set()  # (group_id, subtask_index)
+        # OrderedDict + LRU eviction so the registry stays bounded (entries were
+        # inserted on submit and never deleted → unbounded growth).
+        self.pending_tasks: "OrderedDict[str, dict]" = OrderedDict()  # task_id -> task_info
+        # Idempotency: seen task-result IDs and parallel subtask keys (bounded).
+        self._seen_task_result_ids = _BoundedSeenSet(_SEEN_ID_CACHE_MAXLEN)
+        self._seen_parallel_keys = _BoundedSeenSet(_SEEN_ID_CACHE_MAXLEN)  # (group_id, subtask_index)
         # PR-S6: emit legacy guardrail — MessageHandler is the legacy chain B
         # ingress.  Canonical ingress is websocket_handler → DeviceRouter (chain A).
         try:
@@ -474,6 +512,11 @@ class MessageHandler:
             "callback": callback
         }
         self.pending_tasks[task_id] = task_info
+        self.pending_tasks.move_to_end(task_id)
+        # LRU eviction: drop the oldest pending-task entries once over the cap so
+        # the registry can't grow without bound on a long-lived gateway.
+        while len(self.pending_tasks) > _PENDING_TASKS_MAXLEN:
+            self.pending_tasks.popitem(last=False)
         return task_info
     
     def get_task(self, task_id: str) -> Optional[dict]:

--- a/galaxy_gateway/orchestrator/galaxy_orchestrator.py
+++ b/galaxy_gateway/orchestrator/galaxy_orchestrator.py
@@ -699,6 +699,8 @@ class GalaxyOrchestrator:
 
         # 运行状态
         self.is_running = False
+        # 后台循环任务的强引用(防 GC)+ 可取消句柄
+        self._bg_tasks: list = []
 
         # 统计信息
         self.stats = {
@@ -728,13 +730,19 @@ class GalaxyOrchestrator:
         self.stats["start_time"] = time.time()
         logger.info("GalaxyOrchestrator 已启动")
 
-        # 启动后台任务
-        asyncio.create_task(self._heartbeat_loop())
-        asyncio.create_task(self._task_processor_loop())
+        # 启动后台任务。保留强引用(事件循环只持弱引用),并给 stop() 一个可取消的句柄。
+        self._bg_tasks = [
+            asyncio.create_task(self._heartbeat_loop()),
+            asyncio.create_task(self._task_processor_loop()),
+        ]
 
     async def stop(self):
         """停止调度器"""
         self.is_running = False
+        # 取消后台循环任务并清引用(循环本身也会因 is_running=False 协作退出)。
+        for _t in self._bg_tasks:
+            _t.cancel()
+        self._bg_tasks = []
         logger.info("GalaxyOrchestrator 已停止")
 
     def _publish_event(self, event_type, data: dict):

--- a/galaxy_gateway/orchestrator/task_orchestrator.py
+++ b/galaxy_gateway/orchestrator/task_orchestrator.py
@@ -935,5 +935,15 @@ class MultiDeviceOrchestrator(TaskOrchestrator):
             )
             task.commands = [command]
             await self._send_task_to_device(task)
-        
+            # Populate the declared Dict[str, CommandResult] return.  The
+            # broadcast is fire-and-forget (the real outcome arrives later via
+            # the task lifecycle), so the synchronously-knowable per-device
+            # result is "dispatched, outcome pending" (ResultStatus.NONE).
+            # Previously `results` was returned empty regardless of dispatch.
+            results[device_id] = CommandResult(
+                command_id=getattr(command, "command_id", "") or task.task_id,
+                status=ResultStatus.NONE,
+                result={"dispatched": True, "task_id": task.task_id},
+            )
+
         return results

--- a/galaxy_gateway/routes/linux_agent.py
+++ b/galaxy_gateway/routes/linux_agent.py
@@ -305,12 +305,22 @@ class SSHExecutor:
         try:
             self._connect(client)
             escaped = content.replace("'", "'\"'\"'")
+            # Escape the path the same way as the content — it is interpolated
+            # into several single-quoted shell words below, so an unescaped
+            # single quote in the path would break the command / allow injection.
+            escaped_path = path.replace("'", "'\"'\"'")
             # exec_command returns immediately without waiting; block on the
             # remote exit status so (a) the write completes before client.close()
             # tears the connection down (otherwise a large write can be
             # truncated) and (b) we report real success instead of always True.
+            # NOTE: $(dirname ...) must sit inside DOUBLE quotes to be expanded;
+            # the previous single-quoted '$(dirname ...)' was taken literally, so
+            # the real parent dir was never created (a junk dir named
+            # "$(dirname <path>)" was made in the remote CWD instead).
             _stdin, stdout, stderr = client.exec_command(
-                f"mkdir -p '$(dirname {path})' && printf '%s' '{escaped}' > '{path}' && chmod {mode} '{path}'"
+                f"mkdir -p \"$(dirname '{escaped_path}')\" && "
+                f"printf '%s' '{escaped}' > '{escaped_path}' && "
+                f"chmod {mode} '{escaped_path}'"
             )
             exit_status = stdout.channel.recv_exit_status()
             if exit_status != 0:

--- a/galaxy_gateway/wake_event_bus.py
+++ b/galaxy_gateway/wake_event_bus.py
@@ -24,6 +24,9 @@ from typing import Dict, List, Optional, Callable, Any
 
 logger = logging.getLogger("UFO-Galaxy.WakeEventBus")
 
+# Strong refs to fire-and-forget tasks (event loop only holds a weak ref).
+_BACKGROUND_TASKS: set = set()
+
 # 导入 WakeRouter 类型（延迟导入避免循环引用）
 # from galaxy_gateway.wake_router import WakeEvent, WakeTaskType, wake_router
 
@@ -194,7 +197,9 @@ class WakeEventBus:
             loop = asyncio.get_running_loop()
             if loop.is_running():
                 # 事件循环正在运行，使用 create_task 调度
-                loop.create_task(self.publish(raw_event))
+                _bt = loop.create_task(self.publish(raw_event))
+                _BACKGROUND_TASKS.add(_bt)
+                _bt.add_done_callback(_BACKGROUND_TASKS.discard)
             else:
                 # 事件循环存在但未运行，使用线程池提交（避免 asyncio.run 在有循环的线程中崩溃）
                 self._get_executor().submit(self._run_publish_in_new_loop, raw_event)

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -134,6 +134,9 @@ from galaxy_gateway.ssot import udm_write_register, udm_write_heartbeat, udm_wri
 
 logger = logging.getLogger(__name__)
 
+# Strong refs to fire-and-forget tasks (event loop only holds a weak ref).
+_BACKGROUND_TASKS: set = set()
+
 # ---------------------------------------------------------------------------
 # PR-03-V2: Android business domain kinds
 #
@@ -256,7 +259,9 @@ class GatewayWSManager:
                     except RuntimeError:
                         pass
                     if loop is not None and loop.is_running():
-                        loop.create_task(ucm.unregister_connection(device_id))
+                        _bt = loop.create_task(ucm.unregister_connection(device_id))
+                        _BACKGROUND_TASKS.add(_bt)
+                        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
                     else:
                         ucm.mark_offline(device_id)
                 except Exception as _ucm_err:

--- a/integration/event_bus.py
+++ b/integration/event_bus.py
@@ -112,6 +112,10 @@ class EventType(Enum):
     # Persona / Spirit Engine 事件 (PR-3)
     PERSONA_STATE_UPDATED = auto()        # PersonaState 已更新（session_id + delta）
 
+    # DAG 节点生命周期（core.task_graph._emit_node_event 的目标通道；
+    # 追加在枚举末尾以保持既有成员的 auto() 数值不变）
+    TASK_LIFECYCLE = auto()               # DAG 节点状态变化 (pending/running/done/failed/...)
+
 
 @dataclass
 class UIGalaxyEvent:

--- a/nodes/Node_00_StateMachine/stale_lock_reaper.py
+++ b/nodes/Node_00_StateMachine/stale_lock_reaper.py
@@ -16,6 +16,10 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 import httpx
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger(__name__)
 
 class StaleLockReaper:
@@ -52,7 +56,9 @@ class StaleLockReaper:
         self.running = True
         logger.info(f"Starting Stale Lock Reaper (scan_interval={self.scan_interval}s, max_age={self.max_lock_age}s)")
         
-        asyncio.create_task(self._reaper_loop())
+        _bt = asyncio.create_task(self._reaper_loop())
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     
     async def stop(self):
         """停止清理器"""

--- a/nodes/Node_01_OneAPI/main.py
+++ b/nodes/Node_01_OneAPI/main.py
@@ -582,7 +582,7 @@ async def list_models():
     # 本地 LLM 模型
     if LOCAL_LLM_ENABLED:
         try:
-            resp = requests.get(f"{LOCAL_LLM_URL}/v1/models", timeout=2)
+            resp = await asyncio.to_thread(requests.get, f"{LOCAL_LLM_URL}/v1/models", timeout=2)
             if resp.status_code == 200:
                 local_models = resp.json().get("data", [])
                 for model in local_models:

--- a/nodes/Node_02_Tasker/main.py
+++ b/nodes/Node_02_Tasker/main.py
@@ -20,6 +20,10 @@ from pydantic import BaseModel
 import heapq
 from nodes.common.cors_config import get_cors_origins
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 app = FastAPI(title="Node 02 - Tasker", version="2.0.0")
 app.add_middleware(CORSMiddleware, allow_origins=get_cors_origins(), allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
 
@@ -336,7 +340,9 @@ async def list_handlers():
 @app.on_event("startup")
 async def startup():
     """启动后台任务处理"""
-    asyncio.create_task(task_manager.process_queue())
+    _bt = asyncio.create_task(task_manager.process_queue())
+    _BACKGROUND_TASKS.add(_bt)
+    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
 
 if __name__ == "__main__":
     import uvicorn

--- a/nodes/Node_09_Sandbox/main.py
+++ b/nodes/Node_09_Sandbox/main.py
@@ -6,6 +6,7 @@ Node 09: Sandbox - 安全的代码沙箱执行环境
 健康检查始终立即返回 HTTP 200，可用语言列表在启动时预计算并缓存。
 """
 
+import asyncio
 import os, subprocess, tempfile, signal
 import re
 import logging
@@ -300,7 +301,8 @@ async def execute_code(request: ExecuteRequest):
             def preexec_fn():
                 set_resource_limits(request.memory_limit_mb or 256, request.cpu_limit_seconds)
 
-            result = subprocess.run(
+            result = await asyncio.to_thread(
+                subprocess.run,
                 cmd,
                 capture_output=True,
                 text=True,
@@ -394,7 +396,8 @@ async def execute_files(request: FileExecuteRequest):
                 compile_err["language"] = lang
                 return compile_err
 
-            result = subprocess.run(
+            result = await asyncio.to_thread(
+                subprocess.run,
                 cmd, capture_output=True, text=True, timeout=request.timeout, input=request.stdin, cwd=tmpdir
             )
 
@@ -470,7 +473,9 @@ async def list_languages():
     languages = []
     for lang, config in LANGUAGE_CONFIG.items():
         try:
-            result = subprocess.run(config["version_check"], capture_output=True, text=True, timeout=5)
+            result = await asyncio.to_thread(
+                subprocess.run, config["version_check"], capture_output=True, text=True, timeout=5
+            )
             version = result.stdout.strip() if result.returncode == 0 else "unknown"
             available = result.returncode == 0
         except Exception as exc:

--- a/nodes/Node_100_MemorySystem/main.py
+++ b/nodes/Node_100_MemorySystem/main.py
@@ -26,7 +26,7 @@ import hashlib
 from datetime import datetime
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, asdict
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -52,7 +52,8 @@ default_db_path = "/app/data/galaxy_memory.db"
 if not os.path.isdir("/app/data"):
     default_db_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "data", "galaxy_memory.db")
 DB_PATH = os.getenv("MEMORY_DB_PATH", default_db_path)
-MAX_SHORT_TERM_SIZE = 100  # 短期记忆最大条目数
+MAX_SHORT_TERM_SIZE = 100  # 短期记忆最大条目数（每会话）
+MAX_SHORT_TERM_SESSIONS = 1000  # 短期记忆最大会话数（LRU 淘汰，防止无界增长）
 
 # ============================================================================
 # 数据模型
@@ -401,22 +402,35 @@ db = MemoryDatabase(DB_PATH)
 class ShortTermMemory:
     """短期记忆（会话级别）"""
     
-    def __init__(self, max_size: int = MAX_SHORT_TERM_SIZE):
+    def __init__(self, max_size: int = MAX_SHORT_TERM_SIZE, max_sessions: int = MAX_SHORT_TERM_SESSIONS):
         self.max_size = max_size
-        self.memory: Dict[str, List[Experience]] = defaultdict(list)
-    
+        self.max_sessions = max_sessions
+        # OrderedDict 作 LRU:每条经验按 session 存储并限长,但 session 本身也要
+        # 有上限——此前 defaultdict 从不淘汰 session,长期运行下每个新 session_id
+        # 都会永久占用内存(无界增长)。超过 max_sessions 时淘汰最久未使用的会话。
+        self.memory: "OrderedDict[str, List[Experience]]" = OrderedDict()
+
     def add(self, session_id: str, experience: Experience):
         """添加经验"""
+        if session_id in self.memory:
+            self.memory.move_to_end(session_id)
+        else:
+            self.memory[session_id] = []
+            while len(self.memory) > self.max_sessions:
+                self.memory.popitem(last=False)  # 淘汰最旧会话
         self.memory[session_id].append(experience)
-        
-        # 限制大小
+
+        # 限制单会话大小
         if len(self.memory[session_id]) > self.max_size:
             self.memory[session_id] = self.memory[session_id][-self.max_size:]
-    
+
     def get(self, session_id: str, limit: int = 10) -> List[Experience]:
         """获取经验"""
+        if session_id not in self.memory:
+            return []
+        self.memory.move_to_end(session_id)
         return self.memory[session_id][-limit:]
-    
+
     def clear(self, session_id: str):
         """清空会话记忆"""
         if session_id in self.memory:

--- a/nodes/Node_110_SmartOrchestrator/core/orchestrator_engine.py
+++ b/nodes/Node_110_SmartOrchestrator/core/orchestrator_engine.py
@@ -404,7 +404,18 @@ class SmartOrchestrator:
         
         # 更新节点能力
         await self._update_node_capabilities()
-        
+
+        # _update_node_capabilities() swallows probe failures and can leave
+        # node_capabilities empty; max() over an empty sequence raises ValueError
+        # (surfaced as a 500).  Degrade gracefully instead of crashing.
+        if not self.node_capabilities:
+            return {
+                "task_id": task_id,
+                "optimized": False,
+                "reason": "no_node_capabilities_available",
+                "steps": plan.steps,
+            }
+
         # 重新分配节点
         optimized_steps = []
         for step in plan.steps:

--- a/nodes/Node_110_SmartOrchestrator/main.py
+++ b/nodes/Node_110_SmartOrchestrator/main.py
@@ -256,6 +256,17 @@ class SmartOrchestrator:
         self.is_running = False
         self._lock = asyncio.Lock()
         self._task_handlers: Dict[str, Callable] = {}
+        # Strong refs to fire-and-forget background tasks.  asyncio keeps only a
+        # weak reference to a bare create_task() result, so a discarded task can
+        # be garbage-collected mid-execution; retain until each finishes.
+        self._bg_tasks: set = set()
+
+    def _spawn_bg(self, coro) -> "asyncio.Task":
+        """Schedule *coro* as a tracked background task (GC-safe)."""
+        t = asyncio.create_task(coro)
+        self._bg_tasks.add(t)
+        t.add_done_callback(self._bg_tasks.discard)
+        return t
     
     def register_node(self, node: NodeCapability) -> bool:
         """注册执行节点"""
@@ -349,8 +360,8 @@ class SmartOrchestrator:
                     
                     logger.info(f"Task {task.task_id} assigned to node {node_id}")
                     
-                    # 执行任务
-                    asyncio.create_task(self._execute_task(task))
+                    # 执行任务（保留强引用,避免任务被 GC 提前回收）
+                    self._spawn_bg(self._execute_task(task))
                 else:
                     # 没有可用节点，放回队列
                     heapq.heappush(self.task_queue, task)
@@ -420,8 +431,8 @@ class SmartOrchestrator:
         
         self.executions[execution.execution_id] = execution
         
-        # 启动工作流执行
-        asyncio.create_task(self._run_workflow(execution))
+        # 启动工作流执行（保留强引用,避免任务被 GC 提前回收）
+        self._spawn_bg(self._run_workflow(execution))
         
         return execution.execution_id
     
@@ -458,11 +469,20 @@ class SmartOrchestrator:
                 )
                 
                 await self.submit_task(task)
-                
-                # 等待任务完成
+
+                # 等待任务完成,并强制执行 task.timeout。此前该字段被声明却从未生效:
+                # 若某步骤的 task_type 匹配不到任何已注册节点,任务会永远停留在
+                # QUEUED,此循环便无限空转、整个工作流永久挂起。用事件循环单调时钟
+                # 设定截止时间,超时则将任务判失败并跳出。
+                _timeout_s = max(1, int(getattr(task, "timeout", 300) or 300))
+                _deadline = asyncio.get_event_loop().time() + _timeout_s
                 while task.status not in [TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED]:
+                    if asyncio.get_event_loop().time() > _deadline:
+                        task.status = TaskStatus.FAILED
+                        task.error = f"step timed out after {_timeout_s}s (no terminal status)"
+                        break
                     await asyncio.sleep(0.5)
-                
+
                 if task.status == TaskStatus.FAILED:
                     if step.on_error == "fail":
                         raise Exception(f"Step {step.step_id} failed: {task.error}")

--- a/nodes/Node_112_SelfHealing/core/healing_engine.py
+++ b/nodes/Node_112_SelfHealing/core/healing_engine.py
@@ -8,6 +8,7 @@ Node_112_SelfHealing - 节点自愈引擎
 4. 故障预测 - 预测潜在故障（集成 Node_73）
 """
 
+import asyncio
 import logging
 import requests
 from typing import Dict, List, Any, Optional
@@ -80,7 +81,7 @@ class SelfHealingEngine:
     async def get_health_status(self) -> Dict[str, Any]:
         """获取系统健康状态（调用 Node_67）"""
         try:
-            response = requests.get(f"{self.node_67_url}/api/v1/health", timeout=10)
+            response = await asyncio.to_thread(requests.get, f"{self.node_67_url}/api/v1/health", timeout=10)
             
             if response.status_code == 200:
                 health_data = response.json()
@@ -138,7 +139,8 @@ class SelfHealingEngine:
             
             node = self.node_health[node_id]
             
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 f"{self.node_65_url}/api/v1/logs/analyze",
                 json={"node_id": node_id, "time_range": "last_1h", "log_level": ["ERROR", "CRITICAL"]},
                 timeout=30
@@ -289,7 +291,8 @@ class SelfHealingEngine:
     async def _restart_node(self, node_id: str) -> Dict[str, Any]:
         """重启节点（通过 Node_02）"""
         try:
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 f"{self.node_02_url}/api/v1/tasks",
                 json={"action": "restart_node", "node_id": node_id},
                 timeout=60
@@ -306,7 +309,8 @@ class SelfHealingEngine:
     async def _reload_config(self, node_id: str) -> Dict[str, Any]:
         """重新加载配置"""
         try:
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 f"{self.node_02_url}/api/v1/tasks",
                 json={"action": "reload_config", "node_id": node_id},
                 timeout=30
@@ -318,7 +322,8 @@ class SelfHealingEngine:
     async def _clear_cache(self, node_id: str) -> Dict[str, Any]:
         """清理缓存"""
         try:
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 f"{self.node_02_url}/api/v1/tasks",
                 json={"action": "clear_cache", "node_id": node_id},
                 timeout=30
@@ -367,7 +372,8 @@ class SelfHealingEngine:
                 for node_id, node in self.node_health.items()
             ]
             
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 f"{self.node_73_url}/api/v1/predict",
                 json={"model": "failure_prediction", "data": historical_data},
                 timeout=30

--- a/nodes/Node_116_ExternalToolWrapper/main.py
+++ b/nodes/Node_116_ExternalToolWrapper/main.py
@@ -18,6 +18,10 @@ from pydantic import BaseModel
 import uuid
 from nodes.common.cors_config import get_cors_origins
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -152,7 +156,9 @@ class ExternalToolWrapper:
         # 检查工具可用性（延迟到事件循环可用时）
         try:
             asyncio.get_running_loop()
-            asyncio.create_task(self._check_all_tools())
+            _bt = asyncio.create_task(self._check_all_tools())
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except RuntimeError:
             pass  # 无事件循环时跳过，待服务器启动后手动调用
     

--- a/nodes/Node_118_NodeFactory/main.py
+++ b/nodes/Node_118_NodeFactory/main.py
@@ -359,7 +359,9 @@ class NodeFactory:
         instance = self.instances[instance_id]
         
         if instance.state == NodeState.RUNNING:
-            asyncio.create_task(self.stop_instance(instance_id))
+            _bt = asyncio.create_task(self.stop_instance(instance_id))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         
         del self.instances[instance_id]
         logger.info(f"Deleted instance: {instance_id}")
@@ -379,6 +381,10 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from nodes.common.cors_config import get_cors_origins
+
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/nodes/Node_125_MediaGen/main.py
+++ b/nodes/Node_125_MediaGen/main.py
@@ -166,7 +166,9 @@ class MediaGenService:
         logger.info(f"已接受新任务 {task.task_id} ({media_type.value})。")
         
         # 异步执行任务
-        asyncio.create_task(self._process_task(task.task_id))
+        _bt = asyncio.create_task(self._process_task(task.task_id))
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         return task.task_id
 
     async def _process_task(self, task_id: str):
@@ -382,6 +384,10 @@ async def main():
 # HTTP 健康检查服务器
 # ---------------------------------------------------------------------------
 import threading as _threading
+
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
 try:
     from fastapi import FastAPI as _FastAPI
     import uvicorn as _uvicorn

--- a/nodes/Node_127_BambuLab/enhanced_bambu_controller.py
+++ b/nodes/Node_127_BambuLab/enhanced_bambu_controller.py
@@ -135,8 +135,24 @@ class EnhancedBambuController:
         progress = print_data.get("mc_percent", 0)
         current_layer = print_data.get("layer_num", 0)
         total_layers = print_data.get("total_layer_num", 0)
-        print_time = print_data.get("mc_remaining_time", 0)
         remaining_time = print_data.get("mc_remaining_time", 0)
+        # Bambu 的 print 报文只提供剩余时间 mc_remaining_time 与进度 mc_percent,
+        # 没有独立的"已打印时间"字段。此前 print_time 也读 mc_remaining_time,
+        # 使"已打印时间"恒等于"剩余时间"(明显错误)。剩余时间对应剩余的
+        # (100 - progress)%,故按进度反推已打印时间:
+        #   elapsed ≈ remaining * progress / (100 - progress)
+        try:
+            _progress_pct = float(progress or 0)
+        except (TypeError, ValueError):
+            _progress_pct = 0.0
+        try:
+            _remaining = float(remaining_time or 0)
+        except (TypeError, ValueError):
+            _remaining = 0.0
+        if 0 < _progress_pct < 100:
+            print_time = int(round(_remaining * _progress_pct / (100 - _progress_pct)))
+        else:
+            print_time = 0
         
         # 解析文件信息
         file_name = print_data.get("gcode_file", "")

--- a/nodes/Node_128_MediaGen/main.py
+++ b/nodes/Node_128_MediaGen/main.py
@@ -31,6 +31,10 @@ from typing import Dict, Optional, Type
 from fastapi import FastAPI, HTTPException
 import uvicorn
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 # --- 常量定义 ---
 DEFAULT_OUTPUT_DIR = os.getenv("MEDIA_GEN_OUTPUT_DIR", "./media_gen_output")
 DEFAULT_LOG_LEVEL = "INFO"
@@ -122,7 +126,9 @@ class MediaGenService:
         self.tasks[task.task_id] = task
         self.logger.info(f"接收到新的生成任务: {task.task_id} (类型: {media_type.value})")
         # 异步执行任务
-        asyncio.create_task(self._process_task(task.task_id))
+        _bt = asyncio.create_task(self._process_task(task.task_id))
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         return task
 
     async def _process_task(self, task_id: str):

--- a/nodes/Node_21_Notion/main.py
+++ b/nodes/Node_21_Notion/main.py
@@ -7,6 +7,7 @@ Notion API 集成
 工具: create_page, query_database, update_page
 """
 
+import asyncio
 import os
 import requests
 from datetime import datetime
@@ -140,7 +141,8 @@ class NotionTools:
             if isinstance(properties, dict):
                 page_data["properties"].update(properties)
             
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 url,
                 headers=self._get_headers(),
                 json=page_data,
@@ -180,7 +182,8 @@ class NotionTools:
             if sorts:
                 query_data["sorts"] = sorts
             
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 url,
                 headers=self._get_headers(),
                 json=query_data,
@@ -228,7 +231,8 @@ class NotionTools:
                 "properties": properties
             }
             
-            response = requests.patch(
+            response = await asyncio.to_thread(
+                requests.patch,
                 url,
                 headers=self._get_headers(),
                 json=update_data,
@@ -259,7 +263,8 @@ class NotionTools:
         try:
             url = f"{self.base_url}/pages/{page_id}"
             
-            response = requests.get(
+            response = await asyncio.to_thread(
+                requests.get,
                 url,
                 headers=self._get_headers(),
                 timeout=15

--- a/nodes/Node_34_Scrcpy/main.py
+++ b/nodes/Node_34_Scrcpy/main.py
@@ -14,6 +14,7 @@ mcp/call) are intentionally kept here so Node_34 remains self-contained and can 
 deployed independently.  If consolidation is ever needed, those endpoints should be
 ported to Node_33 first, and Node_34 refocused exclusively on scrcpy screen mirroring.
 """
+import asyncio
 import os
 import subprocess
 import shutil
@@ -154,7 +155,7 @@ async def screenshot(request: ScreenshotRequest):
     cmd.extend(["exec-out", "screencap", "-p"])
     
     try:
-        result = subprocess.run(cmd, capture_output=True, timeout=10)
+        result = await asyncio.to_thread(subprocess.run, cmd, capture_output=True, timeout=10)
         if result.returncode == 0 and result.stdout:
             with open(output_path, "wb") as f:
                 f.write(result.stdout)

--- a/nodes/Node_35_AppleScript/main.py
+++ b/nodes/Node_35_AppleScript/main.py
@@ -5,6 +5,7 @@ Node 35: AppleScript - macOS Automation
 import logging  # auto: ensure module logger is defined
 logger = logging.getLogger(__name__)
 
+import asyncio
 import os
 import sys
 import subprocess
@@ -95,7 +96,8 @@ async def execute_file(request: ExecuteFileRequest):
     if not os.path.exists(request.file_path):
         return {"success": False, "error": f"File not found: {request.file_path}"}
     try:
-        result = subprocess.run(
+        result = await asyncio.to_thread(
+            subprocess.run,
             ["osascript", request.file_path],
             capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=request.timeout
         )

--- a/nodes/Node_36_UIAWindows/ufo_deep_integration.py
+++ b/nodes/Node_36_UIAWindows/ufo_deep_integration.py
@@ -552,7 +552,7 @@ class UFODeepIntegration:
             # 验证进程名只含安全字符
             if not re.match(r'^[a-zA-Z0-9_.\-]+$', process_name):
                 return {"success": False, "error": f"Invalid process name: {process_name!r}"}
-            subprocess.run(["taskkill", "/f", "/im", process_name], capture_output=True)
+            await asyncio.to_thread(subprocess.run, ["taskkill", "/f", "/im", process_name], capture_output=True)
             return {"success": True, "process": process_name}
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/nodes/Node_56_Planning/main.py
+++ b/nodes/Node_56_Planning/main.py
@@ -156,13 +156,34 @@ async def critical_path(request: PlanRequest):
     
     project_duration = max(earliest_finish.values())
     
+    # Backward pass (CPM latest start/finish).  The previous version set every
+    # task's latest_finish to project_duration, ignoring successor dependencies,
+    # so only the last task(s) ever showed zero slack and the critical path
+    # dropped genuinely-critical predecessors.  Compute successors (inverting the
+    # dependency edges) and propagate latest_finish = min(latest_start[succ]).
+    successors: Dict[str, List[str]] = {tid: [] for tid in tasks}
+    for tid, task in tasks.items():
+        for dep in task.dependencies:
+            if dep in successors:
+                successors[dep].append(tid)
+
     latest_finish = {}
     latest_start = {}
-    
+
+    def calc_latest(tid):
+        if tid in latest_start:
+            return latest_start[tid]
+        succ = successors[tid]
+        if not succ:
+            latest_finish[tid] = project_duration
+        else:
+            latest_finish[tid] = min(calc_latest(s) for s in succ)
+        latest_start[tid] = latest_finish[tid] - tasks[tid].duration
+        return latest_start[tid]
+
     for tid in tasks:
-        latest_finish[tid] = project_duration
-        latest_start[tid] = project_duration - tasks[tid].duration
-    
+        calc_latest(tid)
+
     critical = [tid for tid in tasks if earliest_start[tid] == latest_start[tid]]
     
     return {"success": True, "project_duration": project_duration, "critical_path": critical, "earliest_start": earliest_start, "earliest_finish": earliest_finish}

--- a/nodes/Node_71_MultiDeviceCoordination/core/task_scheduler.py
+++ b/nodes/Node_71_MultiDeviceCoordination/core/task_scheduler.py
@@ -39,6 +39,10 @@ from models.task import (
     SchedulingStrategy
 )
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 logger = logging.getLogger(__name__)
 
 
@@ -596,7 +600,9 @@ class TaskScheduler:
         ))
         
         # 启动任务执行
-        asyncio.create_task(self._execute_task(task, device))
+        _bt = asyncio.create_task(self._execute_task(task, device))
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         
         return True
     

--- a/nodes/Node_73_Learning/main.py
+++ b/nodes/Node_73_Learning/main.py
@@ -26,6 +26,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 # ---------------------------------------------------------------------------
 # Port / CORS config (optional dependencies)
 # ---------------------------------------------------------------------------
@@ -184,7 +188,9 @@ class LearningService:
         job = TrainingJob(job_id=job_id, model_name=model_name, dataset=dataset, hyperparams=hyperparams)
         self._jobs[job_id] = job
         # Run asynchronously in background
-        asyncio.create_task(self._run_training(job))
+        _bt = asyncio.create_task(self._run_training(job))
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         return job
 
     async def _run_training(self, job: TrainingJob):
@@ -284,7 +290,9 @@ class LearningService:
         if len(self._results) > self._max_results:
             self._results = self._results[-self._max_results:]
         # Run asynchronously in background
-        asyncio.create_task(self._run_inference_task(result))
+        _bt = asyncio.create_task(self._run_inference_task(result))
+        _BACKGROUND_TASKS.add(_bt)
+        _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         return result
 
     async def _run_inference_task(self, result: InferenceResult):

--- a/nodes/Node_75_DataPipeline/main.py
+++ b/nodes/Node_75_DataPipeline/main.py
@@ -17,6 +17,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from nodes.common.cors_config import get_cors_origins
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 try:
     from core.port_config import get_node_port
     PORT = get_node_port("Node_75_DataPipeline")
@@ -265,7 +269,9 @@ async def pipeline_run(request: PipelineRunRequest):
     pipeline["current_step"] = 0
     pipeline["error"] = None
 
-    asyncio.create_task(_execute_pipeline(request.pipeline_id))
+    _bt = asyncio.create_task(_execute_pipeline(request.pipeline_id))
+    _BACKGROUND_TASKS.add(_bt)
+    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     return {
         "success": True,
         "pipeline_id": request.pipeline_id,

--- a/nodes/Node_77_TaskScheduler/main.py
+++ b/nodes/Node_77_TaskScheduler/main.py
@@ -101,6 +101,10 @@ _jobs: Dict[str, Dict[str, Any]] = {}
 _history: List[Dict[str, Any]] = []
 _scheduler_running = False
 _scheduler_task: Optional[asyncio.Task] = None
+# Strong refs to in-flight fired-job tasks.  asyncio keeps only a weak reference
+# to a bare create_task() result, so a fired scheduled job could be GC'd before
+# it finishes — silently dropping the execution (the scheduler's core purpose).
+_bg_tasks: set = set()
 
 
 async def _run_job(job: Dict[str, Any]) -> None:
@@ -184,7 +188,11 @@ async def _scheduler_loop() -> None:
                 fire_key = (now.year, now.month, now.day, now.hour, now.minute)
                 if job.get("_last_fire_key") != fire_key:
                     job["_last_fire_key"] = fire_key
-                    asyncio.create_task(_run_job(job))
+                    # Retain a strong ref until the fired job completes so it
+                    # cannot be garbage-collected mid-execution.
+                    _t = asyncio.create_task(_run_job(job))
+                    _bg_tasks.add(_t)
+                    _t.add_done_callback(_bg_tasks.discard)
         await asyncio.sleep(30)
 
 

--- a/nodes/Node_77_TaskScheduler/main.py
+++ b/nodes/Node_77_TaskScheduler/main.py
@@ -339,7 +339,9 @@ async def job_run_now(job_id: str):
     job = _jobs.get(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
-    asyncio.create_task(_run_job(job))
+    _t = asyncio.create_task(_run_job(job))
+    _bg_tasks.add(_t)
+    _t.add_done_callback(_bg_tasks.discard)
     return {"success": True, "job_id": job_id, "message": "Job triggered for immediate execution"}
 
 

--- a/nodes/Node_88_WorkflowEngine/main.py
+++ b/nodes/Node_88_WorkflowEngine/main.py
@@ -357,7 +357,10 @@ class WorkflowEngine:
 
         elif stype == "log":
             msg = self._resolve(params.get("message", ""), ctx)
-            level = params.get("level", "info").lower()
+            # str()-coerce: a step defined with params {"level": null} would make
+            # the "info" default (only used for an ABSENT key) a None.lower() crash
+            # that fails the whole workflow execution.
+            level = str(params.get("level") or "info").lower()
             getattr(logger, level, logger.info)(f"[workflow log] {msg}")
             return None
 

--- a/nodes/Node_95_WebRTC_Receiver/main.py
+++ b/nodes/Node_95_WebRTC_Receiver/main.py
@@ -43,6 +43,10 @@ from aiortc import RTCPeerConnection, RTCSessionDescription, RTCIceCandidate, Vi
 from aiortc.contrib.media import MediaRecorder
 import av
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 # 配置日志
 logging.basicConfig(
     level=logging.INFO,
@@ -338,7 +342,9 @@ async def handle_offer(device_id: str, websocket: WebSocket, message: dict):
     async def on_track(track):
         logger.info(f"[{device_id}] Track received: {track.kind}")
         if track.kind == "video":
-            asyncio.create_task(receiver.on_track(track))
+            _bt = asyncio.create_task(receiver.on_track(track))
+            _BACKGROUND_TASKS.add(_bt)
+            _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     
     # 监听 ICE 连接状态
     @pc.on("iceconnectionstatechange")

--- a/nodes/Node_96_SmartTransportRouter/main.py
+++ b/nodes/Node_96_SmartTransportRouter/main.py
@@ -22,6 +22,10 @@ from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel
 import uvicorn
 
+# RUF006: retain fire-and-forget create_task results so the event loop's weak
+# reference can't let them be garbage-collected mid-execution.
+_BACKGROUND_TASKS: set = set()
+
 # --- 1. 日志配置 ---
 # 配置日志记录器，用于输出程序运行信息和错误
 logging.basicConfig(
@@ -343,7 +347,9 @@ async def startup_event():
     )
     router = SmartTransportRouter(config=default_config)
     # 在后台运行节点的主循环
-    asyncio.create_task(router.run())
+    _bt = asyncio.create_task(router.run())
+    _BACKGROUND_TASKS.add(_bt)
+    _bt.add_done_callback(_BACKGROUND_TASKS.discard)
     logger.info("FastAPI 应用启动，路由器已初始化并运行")
 
 @app.get("/health", summary="健康检查接口", tags=["Monitoring"])

--- a/tests/test_pr33_mesh_session.py
+++ b/tests/test_pr33_mesh_session.py
@@ -74,11 +74,16 @@ def _make_routing_summary(
 ) -> Any:
     m = MagicMock()
     m.source_device_id = source_device_id
-    m.primary_device_id = primary_device_id
+    # Canonical CrossDeviceAssignmentSummary attribute names.  The adapter reads
+    # primary_execution_device_id / posture / is_cross_device /
+    # confirmation_required_before_expansion — NOT the old primary_device_id /
+    # routing_posture / multi_device_required / merge_confirmation_required,
+    # which do not exist on the real summary dataclass.
+    m.primary_execution_device_id = primary_device_id
     m.mesh_id = mesh_id
-    m.routing_posture = routing_posture
-    m.multi_device_required = multi_req
-    m.merge_confirmation_required = merge_req
+    m.posture = routing_posture
+    m.is_cross_device = multi_req
+    m.confirmation_required_before_expansion = merge_req
     m.assigned_device_ids = assigned_device_ids or []
     m.fallback_device_ids = fallback_device_ids or []
     m.merge_owner_device_id = None

--- a/tests/test_scheduling_truth_harness.py
+++ b/tests/test_scheduling_truth_harness.py
@@ -129,23 +129,23 @@ class TestSchedulingTruthHarness:
 
         harness = SchedulingTruthHarness()
         mock_tgr = MagicMock()
-        mock_tgr.get_task.return_value = None
-        mock_tgr.register_task.return_value = None
+        mock_tgr.get_node_by_task_id.return_value = None
+        mock_tgr.register_canonical_task.return_value = None
         harness._task_graph_runtime = mock_tgr
         result = harness.ensure_task_registered(_make_task("new-task"))
         assert result is True
-        mock_tgr.register_task.assert_called_once()
+        mock_tgr.register_canonical_task.assert_called_once()
 
     def test_ensure_task_already_registered(self):
         from core.scheduling_truth_harness import SchedulingTruthHarness
 
         harness = SchedulingTruthHarness()
         mock_tgr = MagicMock()
-        mock_tgr.get_task.return_value = {"task_id": "existing"}
+        mock_tgr.get_node_by_task_id.return_value = {"task_id": "existing"}
         harness._task_graph_runtime = mock_tgr
         result = harness.ensure_task_registered(_make_task("existing"))
         assert result is True
-        mock_tgr.register_task.assert_not_called()
+        mock_tgr.register_canonical_task.assert_not_called()
 
     def test_query_routable_executors_no_policy(self):
         from core.scheduling_truth_harness import SchedulingTruthHarness
@@ -177,7 +177,7 @@ class TestSchedulingTruthHarness:
 
         harness = SchedulingTruthHarness()
         mock_tgr = MagicMock()
-        mock_tgr.get_task.return_value = None
+        mock_tgr.get_node_by_task_id.return_value = None
         harness._task_graph_runtime = mock_tgr
         result = harness.assert_convergence(_make_task("unregistered-task"))
         # Should note that task is not registered


### PR DESCRIPTION
Follow-up bug-sweep work after #1524 merged. Restarted the branch from the latest `main` and swept, in order, the contract layer, gateway handlers/routes/orchestrator/protocol, node runtimes, cross-device sync, the fusion dispatch layer, the core result-ingress/session subsystem, and the mesh/event-bus coordination modules. Every fix was verified against the real producer/consumer definitions (and, for algorithmic fixes, with a standalone runtime check) before committing.

## Contract logic &amp; drift fixes

**`contracts/source_posture_contract.py`** — `build_source_posture_field()` ignored its `default`, so an unrecognised/absent hint always resolved to `CONTROL_ONLY`.
**`contracts/cross_runtime_result_merge.py`** — unreachable `role == fallback` branch; `fallback_applied` never set.
**`contracts/cross_repo_schema_version_gate.py`** — `payload_present` computed from the `{}`-fallback, so always `True`.
**`contracts/runtime_session_snapshot.py`** — four drift fixes (`source_runtime_posture` dropped; `has_barrier` vs `barrier_state.blocking`; coordinator `barrier_active`/`event_count` read keys no producer emits; merged-result classification used non-existent `RuntimeResultStatus` values).
**`contracts/multi_device_runtime_projection.py`** — `connection_summary` vs canonical `connection.state`; `accepts_handoff` falls back to `supports_remote_handoff_receive`.
**`contracts/mesh_session_coordinator.py`** — `barrier_posture` matched substrings absent from every `MeshBarrierPosture` value.
**`contracts/distributed_subject_contract_v1.py`** — corrected `continuity_class` audit description.

## Gateway handlers / routes / orchestrator

**`android/handlers/state_event.py`**, **`task_submit.py`**, **`goal_execution.py`** (goal_execution trio) — present-but-`None` `session_id`/`payload`/`task_text`/`goal` crashed handlers.
**`android/handlers/goal_execution.py`** + **`core/routes/system.py`** — a single `device_type=None` collapsed the whole device comprehension to zero.
**`routes/linux_agent.py`** — remote `mkdir -p '$(dirname …)'` never expanded (junk dir, real parent never made); fixed quoting + path escaping.
**`handlers/message_handler.py`** — unbounded dedup sets + `pending_tasks`; bounded FIFO set + LRU `OrderedDict`.
**`orchestrator/task_orchestrator.py`** — `broadcast_command` always returned `{}`; populate per-device results.

## Cross-device, fusion, mesh, node &amp; core runtime fixes

**`core/cross_device_sync.py`** + **`fusion/unified_orchestrator.py`** — discarded fire-and-forget `create_task` (GC footgun); retain refs. `unified_orchestrator` also had inverted load balancing (`update_load` deltas vs a set-absolute `[0,1]` API); fixed with save/bump/restore.
**`core/connection_manager.py`** — `reconnect()` never reset `retry_count`, so after one exhaustion a connection was stuck `ERROR` forever; reset the budget at reconnect entry.
**`core/attached_runtime_session_registry.py`** — bounded ring buffer FIFO-evicts but the session/attachment index dicts were never pruned; prune evicted keys (guarded).
**`core/mesh/mesh_session_lifecycle.py`** — `_sessions` leaked one record per terminated session (no removal path; swarm_coordinator terminates one per `dispatch_team()`). Fixed with **bounded terminal retention**: terminal records stay queryable (`get_record`, `find_sessions_for_device(only_non_terminal=False)`) up to a 512-record cap, oldest evicted beyond that. (An earlier commit on this branch evicted immediately on terminate, which broke 4 `test_prb_mesh_session_runtime_integration` tests — caught by diffing CI `test`-job counts across commits, corrected here.)
**`core/mesh/mesh_session_persistence.py`** — `_memory_cache` was an unbounded dict (terminal sessions never removed); LRU-bound it (durable file remains, `load()` reloads on miss).
**`core/network_graph_runtime.py`** — `restore_durable_state()` parsed persisted `role`/`kind` with raw enum constructors; one corrupt value raised `ValueError` and aborted the entire topology recovery. Per-item safe parse with `UNKNOWN`/`FABRIC_LINK` fallback.
**`nodes/Node_56_Planning/main.py`** — broken CPM backward pass; implemented the real successor-driven pass.
**`nodes/Node_110_SmartOrchestrator/main.py`** — discarded `create_task` (GC) + unenforced per-task `timeout` (workflow hung forever); tracked set + monotonic deadline.
**`nodes/Node_110_SmartOrchestrator/core/orchestrator_engine.py`** — `max()` over empty `node_capabilities` → HTTP 500; guard.
**`nodes/Node_88_WorkflowEngine/main.py`** — `log` step `level` None crash.
**`nodes/Node_100_MemorySystem/main.py`** — `ShortTermMemory` leaked per new `session_id`; LRU-bounded.
**`nodes/Node_77_TaskScheduler/main.py`** — fired jobs launched via discarded `create_task` could be GC-dropped mid-run; retain in a tracked set.
**`nodes/Node_127_BambuLab/enhanced_bambu_controller.py`** — elapsed print time read the remaining-time field; derive from progress + remaining.
**`core/academic_retrieval.py`** — null API title crashed the ingest log, reporting success as failure.

## Orchestration wiring fixes (loop+graph convergence)

Three long-broken wires between the orchestration subsystems (static DAG engine, replan loop, ReAct loop, and the TaskGraphRuntime spine), found while auditing the repo's LangGraph-equivalent architecture:

**`integration/event_bus.py`** — `core/task_graph._emit_node_event` has published per-node DAG lifecycle events to `EventType.TASK_LIFECYCLE` since PR-5, but that enum member never existed; the `getattr(..., None)` guard silently dropped every event, leaving the channel dead since birth. Registered the member (appended at enum end so existing `auto()` values are unchanged); node `running`/`done`/`failed` events now actually flow.
**`core/scheduling_truth_harness.py`** — the GAP-512-002 closure module called phantom methods (`tgr.get_task` / `tgr.register_task`) that don't exist on `TaskGraphRuntime`; every call fell into the suppressed-exception path, so the harness NEVER successfully registered a task and its production caller (`multi_device_runtime_harness`) silently degraded on every task. Pointed all three sites at the real API (`get_node_by_task_id` / `register_canonical_task`).
**`core/task_graph_resume_dispatch.py`** (new) + **`core/task_graph_runtime.py`** + **`core/startup.py`** — `TaskGraphRuntime.resume_pending_dispatch()` (Feature ① restart re-dispatch) had zero production callers: recovery Step 12 only logged the resume classification. Also, `GraphNode` retains no envelope `args`, so a naive rebuild would re-run tools with empty parameters. Fixed both halves: `envelope_to_graph_node` now retains a bounded JSON-safe re-dispatch payload (`resume_args` ≤32KB + timeout/priority) in node metadata, and a new startup step 20b (gated on `GALAXY_DURABLE_EXEC`, default off = zero behavior change) re-dispatches resumable nodes through the canonical `CommandRouter.route_envelope`, consulting the durable dispatch-idempotency guard first (pre-crash side effects are never re-triggered) and refusing to dispatch nodes whose payload is unrecoverable (left pending for operator review).

## Systematic pattern cleanup (completed)

**Blocking IO inside `async def` endpoints — 17 sites** wrapped in `await asyncio.to_thread(...)`: `Node_09_Sandbox` (3× `subprocess.run`), `Node_112_SelfHealing/core/healing_engine.py` (6× `requests`), `Node_21_Notion` (4×), `Node_01_OneAPI`, `Node_34_Scrcpy`, `Node_35_AppleScript`, `Node_36_UIAWindows/ufo_deep_integration.py` (1× each). Sites already routed through `run_in_executor` were left alone.

**Discarded fire-and-forget `create_task` (RUF006 GC footgun) — all 76 real sites repo-wide** now retain the task (module-level `_BACKGROUND_TASKS` set + `add_done_callback(discard)`, or instance lists cancelled in `stop()`): 11 gateway sites (`registration`, `takeover_request`, `wake_event_bus`, `websocket_handler`, `bootstrap/lifecycle`, `android_bridge`, `galaxy_orchestrator`), 53 core sites across 28 files (incl. `lumiv_websocket_bridge`, `live_mesh_runtime_engine`, `speech_output`, `webrtc_task_lifecycle`, `unified/device_manager`, `task_graph`, `swarm_coordinator`, …), and 12 node sites (`Node_00`, `Node_02`, `Node_116`, `Node_118`, `Node_125`, `Node_128`, `Node_71`, `Node_73`, `Node_75`, `Node_95`, `Node_96`, `Node_77`). A follow-up repo-wide AST scan reports 0 remaining discarded sites (custom non-asyncio `create_task` methods excluded as false positives).

## Lint / test hygiene

**`core/unified_system_state_narrative.py`** — fixed a pre-existing isort issue failing the `lint` gate.
**`tests/test_pr33_mesh_session.py`** — aligned `_make_routing_summary` mock with the canonical `CrossDeviceAssignmentSummary` fields, reviving 4 tests.

_Verified clean (no change): the cross-device/routing/coordination core, the result-ingress → truth-chain → acceptance-gate → session-registry chain, `session_identity`, the unified connection/device managers, the live mesh runtime engine, `task_graph` (Kahn's algorithm), the state/sync/wake event buses, `node_registry`, `monitoring` (circuit-breaker), `desktop_projection`, the protocol layer, and most gateway routes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_