### PR TITLE
fix(desktop): Windows 真机四问题全链修复——Electron 崩溃循环 / 保存悬挂→UVStream 连锁 / NATS 假成功

### DIFF
--- a/core/electron_launch_guard.py
+++ b/core/electron_launch_guard.py
@@ -168,8 +168,11 @@ def repair_electron_binary(electron_dir: str) -> bool:
         env = os.environ.copy()
         if mirror:
             env["ELECTRON_MIRROR"] = mirror
-        _log("检测到 Electron 运行时二进制缺失,正在补下载(node electron/install.js"
-             + (", npmmirror 镜像" if mirror else "") + ",可能数分钟)…")
+        _log(
+            "检测到 Electron 运行时二进制缺失,正在补下载(node electron/install.js"
+            + (", npmmirror 镜像" if mirror else "")
+            + ",可能数分钟)…"
+        )
         try:
             subprocess.run([node, install_js], cwd=pkg, env=env, timeout=900)
         except Exception:  # noqa: BLE001 —— 尽力而为,以复检结果为准
@@ -184,8 +187,11 @@ def electron_binary_fix_hint(electron_dir: str = "electron") -> str:
     """自动修复失败时,给用户一条【可直接照抄执行】的修复指令(而不是让用户猜)。"""
     win = os.name == "nt"
     rm = r"rmdir /s /q node_modules\electron" if win else "rm -rf node_modules/electron"
-    setm = ("set ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/&& "
-            if win else "ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/ ")
+    setm = (
+        "set ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/&& "
+        if win
+        else "ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/ "
+    )
     return (
         "Electron 运行时二进制缺失/损坏(node_modules/electron/dist 未下载完整),自动修复未成功。\n"
         f"手动修复(任选其一,在 {electron_dir}/ 目录下执行):\n"

--- a/core/electron_launch_guard.py
+++ b/core/electron_launch_guard.py
@@ -123,9 +123,76 @@ def electron_package_intact(electron_dir: str) -> bool:
     尝试过真正的修复动作(重跑 npm install)。
 
     这里检查 electron 包的两个关键文件都在,任何一个缺失都视为"需要修复安装"。
+
+    真机复现第二种残局("依赖残缺后补齐"仍崩溃循环的根因):js 文件都齐了,但
+    postinstall 下载的 **运行时二进制**(node_modules/electron/dist/electron.exe,
+    由 path.txt 指路)缺失——npm install 中断在下载阶段、或网络被断的典型残局。
+    此时 electron.cmd 一启动就打印 "Electron failed to install correctly" 立即退出:
+    表现正是"启动后立即退出"的闪退循环,且 GPU/软件渲染怎么切都一样崩(根本没
+    走到渲染);更坑的是 electron 包目录已存在时,重跑 npm install 会【跳过
+    postinstall】,永远补不回二进制。故完整性必须核到 path.txt 指向的真实二进制。
     """
     pkg = os.path.join(electron_dir, "node_modules", "electron")
-    return os.path.isfile(os.path.join(pkg, "package.json")) and os.path.isfile(os.path.join(pkg, "cli.js"))
+    if not (os.path.isfile(os.path.join(pkg, "package.json")) and os.path.isfile(os.path.join(pkg, "cli.js"))):
+        return False
+    path_txt = os.path.join(pkg, "path.txt")
+    if not os.path.isfile(path_txt):
+        return False
+    try:
+        with open(path_txt, encoding="utf-8") as f:
+            rel = f.read().strip()
+        return bool(rel) and os.path.isfile(os.path.join(pkg, "dist", rel))
+    except OSError:
+        return False
+
+
+def repair_electron_binary(electron_dir: str) -> bool:
+    """electron 包 js 齐、但运行时二进制缺失时,直接跑包自带的 install.js 补下二进制。
+
+    为什么不能靠 npm install:包目录已存在时 npm 会跳过 postinstall(见
+    electron_package_intact 的说明),二进制永远补不回来。install.js 就是 electron
+    的 postinstall 脚本,单独跑它即可只补二进制。先官方源,失败再换 npmmirror 镜像
+    (国内网络最常见的下载失败因)。返回修复后的完整性检查结果。
+    """
+    import shutil
+    import subprocess
+
+    if electron_package_intact(electron_dir):
+        return True
+    node = shutil.which("node")
+    pkg = os.path.join(electron_dir, "node_modules", "electron")
+    install_js = os.path.join(pkg, "install.js")
+    if not node or not os.path.isfile(install_js):
+        return False
+    for mirror in (None, "https://npmmirror.com/mirrors/electron/"):
+        env = os.environ.copy()
+        if mirror:
+            env["ELECTRON_MIRROR"] = mirror
+        _log("检测到 Electron 运行时二进制缺失,正在补下载(node electron/install.js"
+             + (", npmmirror 镜像" if mirror else "") + ",可能数分钟)…")
+        try:
+            subprocess.run([node, install_js], cwd=pkg, env=env, timeout=900)
+        except Exception:  # noqa: BLE001 —— 尽力而为,以复检结果为准
+            pass
+        if electron_package_intact(electron_dir):
+            _log("Electron 二进制补下载成功 ✓")
+            return True
+    return False
+
+
+def electron_binary_fix_hint(electron_dir: str = "electron") -> str:
+    """自动修复失败时,给用户一条【可直接照抄执行】的修复指令(而不是让用户猜)。"""
+    win = os.name == "nt"
+    rm = r"rmdir /s /q node_modules\electron" if win else "rm -rf node_modules/electron"
+    setm = ("set ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/&& "
+            if win else "ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/ ")
+    return (
+        "Electron 运行时二进制缺失/损坏(node_modules/electron/dist 未下载完整),自动修复未成功。\n"
+        f"手动修复(任选其一,在 {electron_dir}/ 目录下执行):\n"
+        "  1. node node_modules/electron/install.js\n"
+        f"  2. 网络受限用镜像: {setm}node node_modules/electron/install.js\n"
+        f"  3. 彻底重装该包: {rm} && npm install"
+    )
 
 
 def tauri_build_prereqs_hint():

--- a/core/error_framework.py
+++ b/core/error_framework.py
@@ -373,6 +373,47 @@ def error_boundary(
     return decorator
 
 
+# ───────────────────── 客户端断开识别 ─────────────────────
+
+# 根因(Windows 真机日志):面板保存请求被 Electron 主进程的 8s 单次尝试超时
+# (AbortController)提前中断后,BaseHTTPMiddleware 仍继续向已关闭的 transport
+# 写响应体,winloop 抛 "RuntimeError: Cannot call write() when UVStream is
+# closing",被通用异常处理器记为「[internal] 未处理的异常 (recovery=abort)」
+# 连刷 5+ 次——但客户端提前断开是正常网络事件,不是内部错误,不应制造恐慌。
+# 这里集中定义「明确的断开特征」,供异常处理器与 ASGI 发送护栏共用一份判定,
+# 刻意保持窄匹配,避免吞掉真实的内部 RuntimeError。
+_CLIENT_DISCONNECT_RUNTIME_MARKERS = (
+    "uvstream is closing",  # winloop/uvloop: Cannot call write() when UVStream is closing
+    "cannot call write()",  # 同上前缀变体 / write after write_eof()
+    "handler is closed",  # uvloop: unable to perform operation ... handler is closed
+    "client disconnected",  # uvicorn h11/httptools 的断开文案
+)
+
+
+def is_client_disconnect_error(exc: BaseException) -> bool:
+    """判断异常是否为「客户端提前断开连接」类瞬态传输错误。
+
+    命中条件(任一):
+      1. starlette 的 ClientDisconnect(读请求体时客户端已断开);
+      2. ConnectionResetError / BrokenPipeError(OS 层连接被对端重置);
+      3. RuntimeError 且消息含明确的 transport 已关闭特征(见上表)。
+    只匹配确定无疑的断开特征——其余异常一律不视为断开,不吞真实错误。
+    """
+    try:
+        from starlette.requests import ClientDisconnect
+
+        if isinstance(exc, ClientDisconnect):
+            return True
+    except ImportError:  # starlette 不可用的极端环境:退化为仅按类型/消息判定
+        pass
+    if isinstance(exc, (ConnectionResetError, BrokenPipeError)):
+        return True
+    if isinstance(exc, RuntimeError):
+        msg = str(exc).lower()
+        return any(marker in msg for marker in _CLIENT_DISCONNECT_RUNTIME_MARKERS)
+    return False
+
+
 # ───────────────────── FastAPI 集成 ─────────────────────
 
 
@@ -489,6 +530,22 @@ def create_error_handlers(app):
 
     @app.exception_handler(Exception)
     async def generic_error_handler(request: Request, exc: Exception):
+        # 已知瞬态错误:客户端提前断开(保存请求被前端超时中断等)后向已关闭
+        # transport 写响应触发的 RuntimeError/ClientDisconnect。这是正常网络
+        # 事件,不记入 ErrorTracker、不再按「[internal] 未处理的异常
+        # (recovery=abort)」告警刷屏,静默降级为 debug 日志。
+        if is_client_disconnect_error(exc):
+            from starlette.responses import Response as _PlainResponse
+
+            logger.debug(
+                "客户端提前断开(%s %s),丢弃响应: %s",
+                request.method,
+                request.url.path,
+                exc,
+            )
+            # 客户端已不在,响应体写不出去;返回空响应仅为满足处理器契约。
+            return _PlainResponse(status_code=204)
+
         ufo_err = GalaxyError(
             message=f"未处理的异常: {exc}",
             category=ErrorCategory.INTERNAL,

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -3925,3 +3925,49 @@ async def refresh_llm_router() -> Dict[str, Any]:
     """便捷函数：刷新全局 LLM 路由器的提供商列表"""
     router = get_llm_router()
     return await router.refresh_providers()
+
+
+# ── 后台刷新调度(保存配置路由的快速返回依赖此处)──────────────────────────
+# 根因(Windows 真机日志实证):POST /api/config 此前同步 await refresh_llm_router()
+# ——内部对 Ollama/OneAPI 等做 2~5s/个的真实网络探测,离线机器上整个刷新轻松
+# 超过 8s。而 Electron 主进程 fetchWithRetry 的单次尝试硬上限恰是 8s(abort 后
+# 2.5s 重试、60s 总预算)——于是保存请求永远在"后端还没答完就被掐断重发"里
+# 打转:面板卡在「保存中…/仍在保存中」直至 60s 预算耗尽报错;每次 abort 都留下
+# 一个已断开的连接,后端稍后写响应体就炸出 "Cannot call write() when UVStream
+# is closing"(与断开写错误连锁,时间线完全吻合)。
+# 修复:保存路由只【调度】刷新立即返回;需要刷新结果的端点(verify-provider)
+# 用 wait_llm_router_refresh() 有界等待,两边都不会无限悬挂。
+_refresh_task: Optional["asyncio.Task"] = None
+
+
+def schedule_llm_router_refresh() -> "asyncio.Task":
+    """在后台调度一次路由器热刷新(去重:已有进行中的任务则直接复用)。"""
+    global _refresh_task
+    if _refresh_task is not None and not _refresh_task.done():
+        return _refresh_task
+
+    async def _run():
+        try:
+            return await refresh_llm_router()
+        except Exception as exc:  # noqa: BLE001 — 后台任务,异常只记日志不上抛
+            logger.warning("LLM 路由后台刷新失败(下次保存/探测会重试): %s", exc)
+            return None
+
+    _refresh_task = asyncio.get_running_loop().create_task(_run())
+    return _refresh_task
+
+
+async def wait_llm_router_refresh(timeout: float = 8.0) -> bool:
+    """有界等待进行中的后台刷新完成;无进行中任务视为已完成。
+
+    返回 True=刷新已完成(或本就没有待完成的刷新);False=超时仍未完成
+    (shield 保护任务本体继续在后台跑完,不因等待方超时而被取消)。
+    """
+    task = _refresh_task
+    if task is None or task.done():
+        return True
+    try:
+        await asyncio.wait_for(asyncio.shield(task), timeout)
+        return True
+    except asyncio.TimeoutError:
+        return False

--- a/core/nats_server.py
+++ b/core/nats_server.py
@@ -23,6 +23,12 @@ class EmbeddedNATSServer:
         self.port = port
         self.process = None
         self.data_dir = Path.home() / ".lumiv" / "nats"
+        # 诚实性修复(所有者 Windows 真机实证):start() 失败时只 return False,
+        # 具体原因(如 WinError 4551 被 WDAC 拦截)只进日志,调用方无从得知、
+        # 启动横幅照打 ✓。这里把"失败原因 + 专属修复指引"暴露成实例属性,
+        # 供 unified_launcher 启动横幅如实降级展示。
+        self.last_error: str = ""
+        self.last_error_hint: str = ""
 
     async def start(self) -> bool:
         """启动内置NATS服务器"""
@@ -35,6 +41,10 @@ class EmbeddedNATSServer:
                 logger.warning(
                     "nats-server not available — cross-device bus disabled. "
                     "Install nats-server manually or set GALAXY_NATS_ENABLED=false"
+                )
+                self.last_error = "nats-server 未安装且自动安装失败"
+                self.last_error_hint = (
+                    "手动安装 nats-server(https://nats.io)或设 GALAXY_NATS_ENABLED=false 关闭"
                 )
                 return False
 
@@ -63,6 +73,7 @@ class EmbeddedNATSServer:
                 if self.process.poll() is not None:
                     stderr = self.process.stderr.read().decode() if self.process.stderr else ""
                     logger.error("NATS server exited: %s", stderr[:200])
+                    self.last_error = f"nats-server 进程启动后立即退出 {stderr[:200]}".strip()
                     return False
                 # 测试连接
                 try:
@@ -74,6 +85,7 @@ class EmbeddedNATSServer:
                     continue
             else:
                 logger.error("NATS server failed to start within 15s")
+                self.last_error = "nats-server 15 秒内未就绪(端口未接受连接)"
                 return False
 
             os.environ["GALAXY_NATS_URL"] = f"nats://localhost:{self.port}"
@@ -82,6 +94,19 @@ class EmbeddedNATSServer:
 
         except Exception as exc:
             logger.error("Failed to start NATS server: %s", exc)
+            # 根因(所有者 Windows 真机日志):Popen 抛 [WinError 4551]"应用程序
+            # 控制策略已阻止此文件"—— Windows 智能应用控制(Smart App Control)/
+            # WDAC 拦截了未签名的 nats-server.exe,二进制根本没被允许执行。
+            # 此前该原因只进日志就 return False,启动横幅仍打 "✓ 消息总线"。
+            self.last_error = str(exc) or repr(exc)
+            _msg = str(exc)
+            if getattr(exc, "winerror", None) == 4551 or "WinError 4551" in _msg or "应用程序控制策略" in _msg:
+                _exe = shutil.which("nats-server") or str(Path.home() / ".lumiv" / "bin" / "nats-server.exe")
+                self.last_error_hint = (
+                    "Windows 智能应用控制(Smart App Control)/WDAC 拦截了未签名的 nats-server.exe。"
+                    f"修复:Windows 安全中心 → 应用和浏览器控制 → 允许 {_exe} 运行后重启;"
+                    "或单机使用保持 GALAXY_NATS_ENABLED=false(系统自动降级为进程内总线,仅跨设备分发不可用)"
+                )
             return False
 
     async def _install(self) -> bool:

--- a/core/nats_server.py
+++ b/core/nats_server.py
@@ -43,9 +43,7 @@ class EmbeddedNATSServer:
                     "Install nats-server manually or set GALAXY_NATS_ENABLED=false"
                 )
                 self.last_error = "nats-server 未安装且自动安装失败"
-                self.last_error_hint = (
-                    "手动安装 nats-server(https://nats.io)或设 GALAXY_NATS_ENABLED=false 关闭"
-                )
+                self.last_error_hint = "手动安装 nats-server(https://nats.io)或设 GALAXY_NATS_ENABLED=false 关闭"
                 return False
 
         # 启动

--- a/core/performance.py
+++ b/core/performance.py
@@ -36,6 +36,69 @@ logger = logging.getLogger("Galaxy.Performance")
 
 
 # ============================================================================
+# 0. 客户端断开写保护(纯 ASGI,必须位于中间件链最外层)
+# ============================================================================
+
+
+class ClientDisconnectGuardMiddleware:
+    """吞掉「客户端提前断开」后的响应写失败——挂在中间件链最外层的纯 ASGI 护栏。
+
+    根因(Windows 真机日志实证):面板保存 API Key 时,Electron 主进程的
+    fetchWithRetry 单次尝试 8s 即 abort 断开重试,而后端 POST /api/config 此前
+    要同步等 LLM 路由网络探测(>8s)才返回——BaseHTTPMiddleware 链(压缩/缓存/
+    计时等)在客户端已断开后仍向 transport 写响应体,winloop 抛
+    "RuntimeError: Cannot call write() when UVStream is closing" 连刷 5+ 次,
+    还被通用异常处理器记成内部错误制造恐慌。
+
+    此护栏包裹底层 send:仅当异常命中 core.error_framework.
+    is_client_disconnect_error() 的【明确断开特征】时静默降级为 debug 日志并
+    丢弃后续写入;其余异常原样上抛,不吞真实错误。必须用纯 ASGI 实现(而非
+    BaseHTTPMiddleware),否则它自己也会经由 send 写响应、重蹈覆辙。
+    """
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        client_gone = False
+
+        async def guarded_send(message):
+            nonlocal client_gone
+            if client_gone:
+                return  # transport 已确认关闭,静默丢弃剩余帧,不再触发写异常
+            try:
+                await send(message)
+            except Exception as exc:  # noqa: BLE001 — 仅窄匹配断开特征,其余照抛
+                from core.error_framework import is_client_disconnect_error
+
+                if is_client_disconnect_error(exc):
+                    client_gone = True
+                    logger.debug(
+                        "客户端提前断开,丢弃响应写入 (%s %s): %s",
+                        scope.get("method"), scope.get("path"), exc,
+                    )
+                    return
+                raise
+
+        try:
+            await self.app(scope, receive, guarded_send)
+        except Exception as exc:  # noqa: BLE001 — 同上,窄匹配
+            from core.error_framework import is_client_disconnect_error
+
+            if is_client_disconnect_error(exc):
+                logger.debug(
+                    "客户端提前断开,请求提前终止 (%s %s): %s",
+                    scope.get("method"), scope.get("path"), exc,
+                )
+                return
+            raise
+
+
+# ============================================================================
 # 1. 响应压缩中间件
 # ============================================================================
 

--- a/core/performance.py
+++ b/core/performance.py
@@ -79,7 +79,9 @@ class ClientDisconnectGuardMiddleware:
                     client_gone = True
                     logger.debug(
                         "客户端提前断开,丢弃响应写入 (%s %s): %s",
-                        scope.get("method"), scope.get("path"), exc,
+                        scope.get("method"),
+                        scope.get("path"),
+                        exc,
                     )
                     return
                 raise
@@ -92,7 +94,9 @@ class ClientDisconnectGuardMiddleware:
             if is_client_disconnect_error(exc):
                 logger.debug(
                     "客户端提前断开,请求提前终止 (%s %s): %s",
-                    scope.get("method"), scope.get("path"), exc,
+                    scope.get("method"),
+                    scope.get("path"),
+                    exc,
                 )
                 return
             raise

--- a/core/routes/config.py
+++ b/core/routes/config.py
@@ -741,12 +741,21 @@ async def update_config(req: ConfigUpdateRequest):
         pass
 
     # 若改动涉及模型 API（llm 类），热刷新 LLM 路由器，让新填的 key 即时生效（无需重启）。
+    # 根因修复(真机"保存悬挂"):此前这里同步 await refresh_llm_router()——内部对
+    # Ollama/OneAPI 等做 2~5s/个的真实网络探测,离线机器上整体轻松 >8s,而 Electron
+    # 主进程 fetchWithRetry 单次尝试 8s 即 abort 重发,保存请求永远答不完:面板卡死
+    # 在「保存中…/仍在保存中,后端可能仍在启动…」直到 60s 预算耗尽;每次 abort 的
+    # 断开连接还连锁触发后端 "Cannot call write() when UVStream is closing" 刷屏。
+    # 保存路由必须快速返回:此刻配置已落盘、已进 os.environ(持久化真相已成立),
+    # 慢的网络探测改为后台调度;需要探测结果的 verify-provider 端点自己有界等待
+    # (wait_llm_router_refresh),新 key 依然"保存后即可验证",不牺牲功能。
     refreshed = None
     if any(CONFIG_SCHEMA.get(k, {}).get("category") == "llm" for k in final):
         try:
-            from core.multi_llm_router import refresh_llm_router
+            from core.multi_llm_router import schedule_llm_router_refresh
 
-            refreshed = await refresh_llm_router()
+            schedule_llm_router_refresh()
+            refreshed = "scheduled"
         except Exception:
             refreshed = None
 

--- a/core/routes/models.py
+++ b/core/routes/models.py
@@ -249,7 +249,14 @@ async def verify_provider(req: ProviderVerifyRequest) -> Dict[str, Any]:
     此前保存只代表写进了 .env,Key 错的/网络不通的要等到真正对话失败才暴露,
     用户没法判断"到底好了没有"。试调成本≈零(max_tokens=1),15s 封顶。
     """
-    from core.multi_llm_router import PROVIDER_REGISTRY, get_llm_router
+    from core.multi_llm_router import PROVIDER_REGISTRY, get_llm_router, wait_llm_router_refresh
+
+    # 保存配置(POST /api/config)现在只【后台调度】路由刷新就立即返回(否则同步
+    # 网络探测 >8s 会撞上 Electron 的单次尝试超时,保存悬挂——见 config.py 注释)。
+    # 这里是刷新结果的真正消费方:有界等待进行中的刷新完成,保证"保存后立刻
+    # 验证"仍能看到新 key 对应的 adapter;8s 等不到就按当前快照如实作答,
+    # 不无限悬挂(前端对本请求另有 12s 超时)。
+    await wait_llm_router_refresh(timeout=8.0)
 
     router_ = get_llm_router()
 

--- a/core/startup.py
+++ b/core/startup.py
@@ -450,13 +450,14 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
     try:
         from core.performance import (
             CachingMiddleware,
+            ClientDisconnectGuardMiddleware,
             RateLimitMiddleware,
             RequestTimerMiddleware,
             ResponseCompressor,
         )
 
         # 中间件按添加的逆序执行（最后添加的最先执行）
-        # 执行顺序：Timer → RateLimit → Compress → Cache → Handler
+        # 执行顺序：DisconnectGuard → Timer → RateLimit → Compress → Cache → Handler
 
         if cache:
             default_ttl = int(os.environ.get("REDIS_HTTP_CACHE_TTL", "30"))
@@ -476,7 +477,14 @@ async def bootstrap_subsystems(app: FastAPI, config: Any = None) -> dict:
         app.add_middleware(RequestTimerMiddleware, slow_threshold_ms=slow_threshold)
         logger.info("请求计时中间件已加载")
 
-        results["performance"] = {"status": "ok", "middlewares": 4 if cache else 3}
+        # 最后添加 = 最外层执行:客户端断开写保护必须包住整条 BaseHTTPMiddleware
+        # 链(压缩/缓存/计时都会向 transport 写响应体),否则客户端提前断开后
+        # winloop 的 "Cannot call write() when UVStream is closing" 会作为未处理
+        # 异常刷屏(Windows 真机日志实证,详见 ClientDisconnectGuardMiddleware)。
+        app.add_middleware(ClientDisconnectGuardMiddleware)
+        logger.info("客户端断开写保护中间件已加载(最外层)")
+
+        results["performance"] = {"status": "ok", "middlewares": 5 if cache else 4}
     except Exception as e:
         logger.debug("Fallback triggered: %s", e)
         results["performance"] = {"status": "degraded", "error": str(e)}

--- a/core/system_orchestrator.py
+++ b/core/system_orchestrator.py
@@ -666,6 +666,25 @@ class SystemOrchestrator:
                     detail="npm install timed out after 120s",
                 )
 
+        # 拉起前核实到【运行时二进制】——真机根因("依赖残缺后补齐"仍闪退循环):
+        # electron 包目录已存在时 npm install 会【跳过 postinstall】,缺失的
+        # dist/electron.exe 永远补不回来,electron 启动即打印 "Electron failed to
+        # install correctly" 退出。repair_electron_binary 直接跑包自带 install.js
+        # (官方源失败换 npmmirror 镜像)补二进制;仍失败则降级并给出可照抄执行的
+        # 确切修复指令,而不是拉起一个必然立即退出的进程进崩溃循环。
+        if not electron_package_intact(electron_dir):
+            from core.electron_launch_guard import (
+                electron_binary_fix_hint,
+                repair_electron_binary,
+            )
+
+            if not repair_electron_binary(electron_dir):
+                return PhaseResult(
+                    phase=StartupPhase.DESKTOP_SURFACE,
+                    status=PhaseStatus.DEGRADED,
+                    detail=electron_binary_fix_hint("electron"),
+                )
+
         # Launch Electron as detached subprocess
         try:
             env = os.environ.copy()

--- a/core/unified_system_state_narrative.py
+++ b/core/unified_system_state_narrative.py
@@ -323,7 +323,7 @@ def _build_overall_runtime_state() -> NarrativeDimension:
     is_canonical = False
 
     try:
-        from core.runtime_readiness_matrix import ReadinessMatrix, MatrixVerdict
+        from core.runtime_readiness_matrix import MatrixVerdict, ReadinessMatrix
 
         matrix = ReadinessMatrix()
         verdict = matrix.evaluate()

--- a/electron/main.js
+++ b/electron/main.js
@@ -21,11 +21,25 @@ if (process.platform === 'win32') {
 // 策略：默认【开启】硬件加速（有独显的机器走 GPU、更流畅）；只有当启动器在检测到
 // GPU 模式反复崩溃后注入 GALAXY_ELECTRON_GPU=0 时，才禁用硬件加速（软件渲染兜底）。
 // 这样按机器实际情况自适应，无需用户手动判断有没有 GPU。
-if (['0', 'false', 'no', 'off'].includes(
-        String(process.env.GALAXY_ELECTRON_GPU || '').trim().toLowerCase())) {
+const SOFTWARE_RENDER = ['0', 'false', 'no', 'off'].includes(
+    String(process.env.GALAXY_ELECTRON_GPU || '').trim().toLowerCase());
+// 第三级降级：GALAXY_ELECTRON_BASIC=1 时放弃透明特效，用不透明小窗承载三态覆盖层
+// （由启动器在"软件渲染也反复崩溃"后注入 —— 功能保留，只丢透明合成）。
+const BASIC_MODE = ['1', 'true', 'yes', 'on'].includes(
+    String(process.env.GALAXY_ELECTRON_BASIC || '').trim().toLowerCase());
+if (SOFTWARE_RENDER || BASIC_MODE) {
     try {
+        // 根因修复（真机日志：切"软件渲染"后 60s 内又崩 5 次 → 放弃）：
+        // app.disableHardwareAcceleration() 只是关掉渲染层的硬件加速，Chromium 仍会
+        // 拉起 GPU 进程做窗口【合成】(compositing)。在无独显的 Windows 上，透明窗口 +
+        // GPU 合成正是崩溃点 —— 所以之前的"软件渲染模式"其实没退出 GPU 合成路径，
+        // 崩的还是同一个地方。必须同时追加 --disable-gpu 与 --disable-gpu-compositing
+        // 命令行开关（等价于用户手动 electron --disable-gpu），才是真正的纯软件渲染。
         app.disableHardwareAcceleration();
-        console.error('[Main] 硬件加速已禁用（软件渲染模式，GALAXY_ELECTRON_GPU=0）');
+        app.commandLine.appendSwitch('disable-gpu');
+        app.commandLine.appendSwitch('disable-gpu-compositing');
+        console.error('[Main] 已禁用硬件加速 + GPU 合成（纯软件渲染' +
+            (BASIC_MODE ? '，且启用不透明 basic 窗口降级' : '，GALAXY_ELECTRON_GPU=0') + '）');
     } catch (_e) { /* older electron may not support; non-fatal */ }
 }
 
@@ -263,16 +277,28 @@ function _isValidPerceptionBase64(data) {
     return typeof data === 'string' && data.length > 0 && data.length <= MAX_PERCEPTION_PAYLOAD_SIZE;
 }
 
+// 覆盖层几何：透明模式=整块主屏；basic 模式=右下角不透明小窗（不遮桌面）。
+// setOverlayPhase 的重定位也复用这里，保证两处几何永远一致。
+function _overlayBounds() {
+    let b = { x: 0, y: 0, width: 1920, height: 1080 };
+    try {
+        b = screen.getPrimaryDisplay().bounds;
+    } catch (e) { /* app 未就绪时兜底；实际调用都在 whenReady 后 */ }
+    if (BASIC_MODE) {
+        // 不透明窗口若还整屏覆盖会把桌面全挡死，故收缩为右下角挂件尺寸。
+        const W = Math.min(460, b.width), H = Math.min(280, b.height);
+        return { x: b.x + b.width - W - 16, y: b.y + b.height - H - 16, width: W, height: H };
+    }
+    return b;
+}
+
 function createWindow() {
     // ── 覆盖层尺寸：用主显示器实际 bounds，而非 fullscreen:true ──
     // 关键修复（「唤不起来/打不开」根因之一）：在 Windows 上 transparent:true 与
     // fullscreen:true 同时开启极易出问题——尤其笔记本双显卡/混合输出，OS 独占全屏与
     // 透明合成冲突，窗口经常【全黑】或【根本不显示】。改成「无边框 + 覆盖整块屏幕 bounds」
     // 的覆盖层（视觉上等同全屏，但不触发 OS 独占全屏），是透明置顶覆盖层的稳健做法。
-    let bounds = { x: 0, y: 0, width: 1920, height: 1080 };
-    try {
-        bounds = screen.getPrimaryDisplay().bounds;
-    } catch (e) { /* app 未就绪时兜底；createWindow 实际在 whenReady 后调用 */ }
+    const bounds = _overlayBounds();
 
     mainWindow = new BrowserWindow({
         x: bounds.x,
@@ -281,17 +307,20 @@ function createWindow() {
         height: bounds.height,
         icon: ICON_PATH,
         frame: false,
-        transparent: true,
+        // 第三级降级根因：透明窗口在部分无独显 Windows 上连纯软件渲染都撑不住
+        //（DWM 分层窗口路径本身出问题）。BASIC 模式改用不透明窗口 —— 三态覆盖层
+        // 功能全部保留，只丢"透明特效"这一层，绝不因此放弃整个桌面壳。
+        transparent: !BASIC_MODE,
         alwaysOnTop: true,
         fullscreen: false,          // 见上：不用 OS 独占全屏，改用 bounds 覆盖
         skipTaskbar: true,
-        hasShadow: false,
+        hasShadow: BASIC_MODE,
         resizable: false,
         movable: false,
         closable: true,
         focusable: true,
         show: false,
-        backgroundColor: '#00000000',
+        backgroundColor: BASIC_MODE ? '#0b0d14' : '#00000000',
         webPreferences: {
             nodeIntegration: false,
             contextIsolation: true,
@@ -757,7 +786,9 @@ function setOverlayPhase(awake) {
             // 幂等地「显示并置顶」：重定位到主屏 bounds（防止被移到屏外）、显示、全工作区可见、
             // 顶到 screen-saver 层。即使本来就可见，再调用一次也只是确保它在最前、看得见。
             try {
-                mainWindow.setBounds(screen.getPrimaryDisplay().bounds);
+                // 复用 _overlayBounds()：basic(不透明)模式是右下角小窗，不能在唤醒时
+                // 被错误地拉成整屏不透明把桌面全挡死。
+                mainWindow.setBounds(_overlayBounds());
             } catch (e) { /* ignore */ }
             mainWindow.show();
             mainWindow.setAlwaysOnTop(true, 'screen-saver');

--- a/launch_desktop.py
+++ b/launch_desktop.py
@@ -502,6 +502,18 @@ def start_electron_frontend() -> Optional[subprocess.Popen]:
         rc, _, err = run([npm, "install"], cwd=ELECTRON_DIR, timeout=300)
         if rc != 0:
             raise RuntimeError(f"npm install 失败: {err[:200]}")
+        # 启动前核实到【运行时二进制】——真机根因:"依赖残缺后补齐"只重跑了
+        # npm install,但 electron 包目录已存在时 npm 会跳过 postinstall,
+        # dist/electron.exe 永远补不回来 → electron.cmd 启动即打印
+        # "Electron failed to install correctly" 退出,表现为闪退循环。
+        # repair_electron_binary 直接跑包自带 install.js(官方源失败换 npmmirror)补二进制;
+        # 仍失败则给出可照抄执行的确切修复指令,而不是放任 Electron 去崩。
+        if not electron_package_intact(str(ELECTRON_DIR)):
+            from core.electron_launch_guard import (
+                electron_binary_fix_hint, repair_electron_binary,
+            )
+            if not repair_electron_binary(str(ELECTRON_DIR)):
+                raise RuntimeError("Electron 依赖修复失败:\n" + electron_binary_fix_hint("electron"))
 
     npx = shutil.which("npx") or npm
     env = os.environ.copy()

--- a/tests/test_env_empty_values_and_electron_intact.py
+++ b/tests/test_env_empty_values_and_electron_intact.py
@@ -102,9 +102,27 @@ class TestElectronPackageIntact:
         # 故意不创建 cli.js
         assert electron_package_intact(str(tmp_path)) is False
 
+    def test_binary_missing_is_not_intact(self, tmp_path):
+        """真机残局复刻("依赖残缺后补齐"仍闪退循环):js 文件齐全,但 postinstall
+        下载的 dist/electron.exe 运行时二进制缺失 —— electron.cmd 启动即打印
+        "Electron failed to install correctly" 退出。必须判不完整,否则启动器
+        会放任它进入 GPU 崩 3 次→软件渲染崩 5 次→放弃的死循环。"""
+        pkg = tmp_path / "node_modules" / "electron"
+        pkg.mkdir(parents=True)
+        (pkg / "package.json").write_text("{}")
+        (pkg / "cli.js").write_text("// cli")
+        # 故意不创建 path.txt / dist/electron.exe
+        assert electron_package_intact(str(tmp_path)) is False
+        # path.txt 在但二进制文件本体缺失 → 同样不完整
+        (pkg / "path.txt").write_text("electron.exe")
+        assert electron_package_intact(str(tmp_path)) is False
+
     def test_complete_install_is_intact(self, tmp_path):
         pkg = tmp_path / "node_modules" / "electron"
         pkg.mkdir(parents=True)
         (pkg / "package.json").write_text("{}")
         (pkg / "cli.js").write_text("// cli")
+        (pkg / "path.txt").write_text("electron.exe")
+        (pkg / "dist").mkdir()
+        (pkg / "dist" / "electron.exe").write_text("bin")
         assert electron_package_intact(str(tmp_path)) is True

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -653,6 +653,11 @@ class UnifiedWebUI:
 
         except ImportError as e:
             logger.error("API 服务依赖未安装: %s", e)
+            # 同族诚实性修复:此前这里吞掉 ImportError 正常返回,调用方
+            # launch_web_ui 的 try/except 看不到失败,启动横幅照打 "✓ API 网关"
+            # —— 而 fastapi/uvicorn 缺失时网关根本没起。重新抛出,让横幅走
+            # except 分支如实显示 "API 网关 · 启动失败"。
+            raise
 
     # Minimal fallback HTML — points to the API docs.
     # dashboard/frontend is a LEGACY UI SURFACE (PR-8) and is not the current primary surface.
@@ -965,12 +970,18 @@ class GalaxyUnified:
                     )
                     return False
                 if not electron_package_intact(str(electron_dir)):
-                    logger.error(
-                        "npm install 完成但 electron 包仍不完整(node_modules/electron/"
-                        "cli.js 缺失)。请手动执行: cd electron && rmdir /s /q node_modules "
-                        "&& npm install"
+                    # 根因:electron 包目录已存在("残缺后补齐"场景)时,npm install 会
+                    # 【跳过 postinstall】,不会补下 dist/electron.exe 运行时二进制——
+                    # 光重跑 npm install 永远修不好,必须单独跑包自带的 install.js。
+                    from core.electron_launch_guard import (
+                        electron_binary_fix_hint, repair_electron_binary,
                     )
-                    return False
+                    if not repair_electron_binary(str(electron_dir.resolve())):
+                        logger.error(
+                            "npm install 后 electron 包仍不完整,已停止启动桌面壳。\n%s",
+                            electron_binary_fix_hint("electron"),
+                        )
+                        return False
             except Exception as exc:
                 logger.error("Electron npm install 异常: %s", exc)
                 return False
@@ -985,9 +996,16 @@ class GalaxyUnified:
             env.setdefault("PORT", str(self.config.web_ui_port))
             # GPU 自适应：默认让 Electron 走硬件加速（有独显的机器更流畅）。若 watch_processes
             # 检测到 GPU 模式反复崩溃，会置 _electron_force_software=True，这里注入
-            # GALAXY_ELECTRON_GPU=0 → main.js 据此 disableHardwareAcceleration（软件渲染兜底）。
+            # GALAXY_ELECTRON_GPU=0 → main.js 据此禁用硬件加速 + --disable-gpu
+            # + --disable-gpu-compositing（真正的纯软件渲染兜底）。
             if getattr(self, "_electron_force_software", False):
                 env["GALAXY_ELECTRON_GPU"] = "0"
+            # 第三级降级：软件渲染也反复崩溃(无独显 Windows 上透明分层窗口本身出问题)
+            # 时置 _electron_basic_window=True → main.js 改用【不透明 basic 小窗】承载
+            # 三态覆盖层——功能保留、只丢透明特效，而不是彻底放弃桌面壳。
+            if getattr(self, "_electron_basic_window", False):
+                env["GALAXY_ELECTRON_GPU"] = "0"
+                env["GALAXY_ELECTRON_BASIC"] = "1"
             # Prefer the locally-installed electron binary — robust and avoids the
             # `npm electron .` bug (invalid command) that hit when npx was absent.
             # CRITICAL: use ABSOLUTE paths for both the binary and the app dir.
@@ -1100,6 +1118,9 @@ class GalaxyUnified:
             env.setdefault("GALAXY_IPC_PORT", "9231")
             if getattr(self, "_electron_force_software", False):
                 env["GALAXY_ELECTRON_GPU"] = "0"
+            if getattr(self, "_electron_basic_window", False):
+                env["GALAXY_ELECTRON_GPU"] = "0"
+                env["GALAXY_ELECTRON_BASIC"] = "1"
             _log_dir = Path("logs")
             _log_dir.mkdir(exist_ok=True)
             # 复用同一份 logs/electron.log（托盘「三态动画日志」就打开它），便于一处看壳层日志。
@@ -1149,24 +1170,53 @@ class GalaxyUnified:
             logger.warning("系统托盘启动失败(非致命): %s", exc)
             return False
 
+    def _electron_log_excerpt(self, max_lines: int = 8) -> str:
+        """取 logs/electron.log 尾部的错误摘要，直接打进主日志。
+
+        真机排查痛点：每次降级/放弃都只说"详情见 logs/electron.log"，用户根本
+        不会去翻——而崩溃根因(gpu-process-gone 原因、Cannot find module、
+        Electron failed to install correctly…)其实就躺在那个文件尾部。这里把
+        尾部 8KB 里带错误特征的行摘出来，守护日志自己说清楚"为什么崩"。
+        """
+        try:
+            p = Path("logs") / "electron.log"
+            if not p.exists():
+                return "(logs/electron.log 不存在 —— Electron 可能根本没被拉起)"
+            with open(p, "rb") as f:
+                f.seek(max(0, p.stat().st_size - 8192))
+                tail = f.read().decode("utf-8", "replace")
+            keys = ("error", "Error", "ERROR", "FATAL", "gone", "Cannot find module",
+                    "GPU", "gpu", "crash", "Unable", "failed", "Failed", "退出", "失败")
+            lines = [ln.strip() for ln in tail.splitlines()
+                     if ln.strip() and any(k in ln for k in keys)]
+            picked = lines[-max_lines:] if lines else [ln for ln in tail.splitlines() if ln.strip()][-max_lines:]
+            return "\n    ".join(picked) if picked else "(electron.log 为空)"
+        except Exception as exc:  # noqa: BLE001 —— 摘要失败绝不能反过来搞挂守护循环
+            return f"(读取 electron.log 失败: {exc})"
+
     async def watch_processes(self):
-        """进程保活 + GPU 自适应：监控 Electron，崩溃时自动重启。
+        """进程保活 + 渲染模式三级自适应：监控 Electron，崩溃时自动重启。
 
         按机器实际情况自适应渲染模式（无需用户手动判断有没有 GPU）：
         - 默认 GPU（硬件加速）模式启动；
-        - 若 GPU 模式 60s 内崩溃 >= MAX_GPU 次（常见于笔记本双显卡/驱动不支持透明窗口
-          GPU 合成）→ 自动切换为软件渲染重试；
-        - 若软件渲染也 60s 内崩溃 >= MAX_SW 次 → 停止自动重启并给出指引。
-        Electron 的 stdout/stderr 写入 logs/electron.log（含 *-process-gone 崩溃原因）。
+        - 若 GPU 模式 60s 内崩溃 >= MAX_GPU 次（常见于无独显/驱动不支持透明窗口
+          GPU 合成）→ 自动切换为软件渲染（--disable-gpu + --disable-gpu-compositing）重试；
+        - 若软件渲染也 60s 内崩溃 >= MAX_SW 次 → 第三级降级：不透明 basic 窗口
+          （丢透明特效、保留覆盖层功能），而不是直接放弃；
+        - basic 窗口也 60s 内崩溃 >= MAX_BASIC 次 → 才停止自动重启并给出指引。
+        每次降级/放弃都把 logs/electron.log 尾部错误摘要打进主日志（见 _electron_log_excerpt）。
         """
         import asyncio
         import time
         restarts: list = []          # 最近 60s 窗口内的重启时间戳
         MAX_GPU = 3                  # GPU 模式连续崩溃达此数 → 切软件渲染
-        MAX_SW = 5                   # 软件渲染也崩到此数 → 放弃
+        MAX_SW = 5                   # 软件渲染也崩到此数 → 降级不透明 basic 窗口
+        MAX_BASIC = 5                # basic 窗口也崩到此数 → 放弃
         gave_up = False
         if not hasattr(self, "_electron_force_software"):
             self._electron_force_software = False
+        if not hasattr(self, "_electron_basic_window"):
+            self._electron_basic_window = False
         while True:
             await asyncio.sleep(5)
             proc = getattr(self, 'electron_proc', None)
@@ -1181,25 +1231,42 @@ class GalaxyUnified:
                 restarts = []
                 logger.warning(
                     "Electron GPU 模式 60s 内崩溃 %d 次，自动切换为软件渲染重试"
-                    "（你的显卡/驱动可能不支持透明窗口 GPU 合成；详情见 logs/electron.log）…",
-                    MAX_GPU,
+                    "（你的显卡/驱动可能不支持透明窗口 GPU 合成）。"
+                    "崩溃摘要(logs/electron.log 尾部)：\n    %s",
+                    MAX_GPU, self._electron_log_excerpt(),
                 )
                 await self.start_desktop_shell()
                 continue
 
-            # 软件渲染也反复崩溃 → 放弃
-            if self._electron_force_software and len(restarts) >= MAX_SW:
+            # 软件渲染也反复崩溃 → 第三级降级：不透明 basic 窗口（保功能、丢透明特效）。
+            # 根因：无独显 Windows 上透明分层窗口本身(而不只是 GPU 合成)可能就是崩溃点，
+            # 此前直接放弃 → 覆盖层整个没了；现在换不透明小窗再试，外壳尽量活着。
+            if (self._electron_force_software and not self._electron_basic_window
+                    and len(restarts) >= MAX_SW):
+                self._electron_basic_window = True
+                restarts = []
+                logger.warning(
+                    "Electron 软件渲染仍 60s 内崩溃 %d 次，降级为【不透明 basic 窗口】重试"
+                    "（覆盖层功能保留，仅无透明特效）。崩溃摘要(logs/electron.log 尾部)：\n    %s",
+                    MAX_SW, self._electron_log_excerpt(),
+                )
+                await self.start_desktop_shell()
+                continue
+
+            # basic 窗口也反复崩溃 → 放弃（此时多半不是渲染问题，摘要里通常能看出真因）
+            if self._electron_basic_window and len(restarts) >= MAX_BASIC:
                 gave_up = True
                 logger.error(
-                    "Electron 在 GPU 与软件渲染下均反复崩溃，已停止自动重启。"
-                    "崩溃详情见 logs/electron.log；后端与 API 仍在 "
-                    "http://localhost:%d 正常运行（Ctrl+Alt+Space 覆盖层暂不可用）。",
-                    self.config.web_ui_port,
+                    "Electron 在 GPU/软件渲染/不透明 basic 窗口下均反复崩溃，已停止自动重启。"
+                    "后端与 API 仍在 http://localhost:%d 正常运行（Ctrl+Alt+Space 覆盖层暂不可用）。"
+                    "崩溃摘要(logs/electron.log 尾部)：\n    %s",
+                    self.config.web_ui_port, self._electron_log_excerpt(),
                 )
                 continue
 
             restarts.append(now)
-            _mode = "软件渲染" if self._electron_force_software else "GPU"
+            _mode = ("basic 窗口" if self._electron_basic_window
+                     else "软件渲染" if self._electron_force_software else "GPU")
             logger.warning(
                 "Electron 已退出，重启中（%s 模式，60s 内第 %d 次；详情见 logs/electron.log）…",
                 _mode, len(restarts),
@@ -1210,17 +1277,43 @@ class GalaxyUnified:
         """加载配置并初始化服务管理器。"""
         self.service_manager.state = SystemState.LOADING_CONFIG
 
-    async def start_nats(self):
-        """启动 NATS 消息总线。"""
+    async def start_nats(self) -> dict:
+        """启动 NATS 消息总线。返回结构化真实结果(供启动横幅如实展示)。
+
+        诚实性修复(所有者 Windows 真机日志实证):此前 EmbeddedNATSServer.start()
+        返回 False(如 [WinError 4551] WDAC 拦截 nats-server.exe)被本函数静默吞掉;
+        接着 bus.connect() 按约定 C7【返回 {"success": False} 而非抛异常】,也被
+        无视返回值地 await 掉 —— 调用方的 try/except 永远走不到 except 分支,
+        启动横幅于是在 NATS 根本没起来时照打 "✓ 消息总线 nats://localhost:4222"。
+        现在:显式核验每一步结果,失败时带原因/修复指引返回,由横幅降级展示。
+
+        Returns:
+            {"ok": bool, "url": str, "error": str, "hint": str, "disabled": bool}
+        """
         from core.nats_server import EmbeddedNATSServer
         from core.nats_bus import get_nats_bus
+        # 显式关闭(install_windows.ps1 默认写入 GALAXY_NATS_ENABLED=false):
+        # 不再明知配置为关仍去拉起二进制,横幅如实标注"按配置未启用"。
+        if os.environ.get("GALAXY_NATS_ENABLED", "").strip().lower() in ("false", "0", "no", "off"):
+            return {"ok": False, "url": "", "error": "", "hint": "", "disabled": True}
         nats_url = os.environ.get("GALAXY_NATS_URL")
+        embedded_error = ""
+        embedded_hint = ""
         if not nats_url:
             server = EmbeddedNATSServer()
             if await server.start():
-                return
+                return {"ok": True, "url": os.environ.get("GALAXY_NATS_URL", "nats://localhost:4222"),
+                        "error": "", "hint": "", "disabled": False}
+            embedded_error = getattr(server, "last_error", "") or "内置 nats-server 启动失败"
+            embedded_hint = getattr(server, "last_error_hint", "")
         bus = get_nats_bus()
-        await bus.connect()
+        result = await bus.connect()
+        if isinstance(result, dict) and result.get("success") and bus.is_connected():
+            return {"ok": True, "url": os.environ.get("GALAXY_NATS_URL", nats_url or "nats://localhost:4222"),
+                    "error": "", "hint": "", "disabled": False}
+        _conn_err = (result.get("error", "") if isinstance(result, dict) else str(result)) or "NATS 连接失败"
+        return {"ok": False, "url": "", "error": embedded_error or _conn_err,
+                "hint": embedded_hint, "disabled": False}
 
     async def start_tailscale(self):
         """启动 Tailscale 网络。返回真实 Tailscale IP（供显示）。"""
@@ -1472,16 +1565,39 @@ class GalaxyUnified:
               hint="装 Docker/Podman 后重跑即恢复" if d_status != "ok" else None)
 
         # ── 消息总线 ──
+        # 诚实性修复(所有者 Windows 真机日志实证):旧代码"try: await start_nats()
+        # 不抛异常 == 成功"—— 但 NATSBus.connect() 按 C7 约定失败时返回
+        # {"success": False} 而非抛异常,EmbeddedNATSServer.start() 失败也只
+        # return False,于是 nats-server.exe 被 WDAC([WinError 4551])拦截、
+        # 根本没起来时,横幅仍打 "✓ 消息总线 nats://localhost:4222"(假绿)。
+        # 现在按 start_nats() 的结构化真实结果降级展示:原因 + 影响 + 专属修复指引。
         bus_details: List[Tuple[str, str, str]] = []
+        bus_hint: Optional[str] = None
         try:
-            await self.start_nats()
-            nats_host = os.environ.get("GALAXY_NATS_HOST", "localhost")
-            nats_port = os.environ.get("GALAXY_NATS_PORT", "4222")
-            bus_details.append(("NATS Bus", f"nats://{nats_host}:{nats_port}", "ok"))
-            nats_ok, bus_value = True, f"nats://{nats_host}:{nats_port}"
-        except Exception as exc:
-            bus_details.append(("NATS Bus", f"{exc}", "warn"))
-            nats_ok, bus_value = False, "NATS 未就绪"
+            _nats_res = await self.start_nats()
+        except Exception as exc:  # noqa: BLE001
+            _nats_res = {"ok": False, "url": "", "error": str(exc), "hint": "", "disabled": False}
+        if _nats_res.get("ok"):
+            nats_ok, bus_value = True, _nats_res.get("url") or "已连接"
+            bus_details.append(("NATS Bus", bus_value, "ok"))
+        elif _nats_res.get("disabled"):
+            # 按配置显式关闭 —— 是配置意图而非故障,但仍如实标注降级与影响。
+            nats_ok = False
+            bus_value = "未启用(GALAXY_NATS_ENABLED=false)· 降级:进程内总线,跨设备分发不可用"
+            bus_details.append(("NATS Bus", "按配置未启用(GALAXY_NATS_ENABLED=false)", "warn"))
+            bus_details.append(("影响", "跨设备任务分发/集群 mesh 不可用;单机进程内 Agent 总线不受影响", "info"))
+            bus_hint = "如需跨设备:设 GALAXY_NATS_ENABLED=true 并确保 nats-server 可运行"
+        else:
+            nats_ok = False
+            _err = _nats_res.get("error") or "未知原因"
+            bus_value = f"未启动 · {_err[:80]} · 降级:进程内总线(单机可用,跨设备分发不可用)"
+            bus_details.append(("NATS Bus", f"未启动:{_err}", "warn"))
+            bus_details.append(("影响", "跨设备任务分发/集群 mesh 不可用;单机进程内 Agent 总线不受影响", "info"))
+            bus_hint = _nats_res.get("hint") or (
+                "检查 nats-server 是否可运行(手动执行 nats-server -v 验证);"
+                "单机使用可设 GALAXY_NATS_ENABLED=false 明确关闭此项"
+            )
+            bus_details.append(("修复", bus_hint, "info"))
         try:
             ts_ip = await self.start_tailscale()
             bus_details.append(("Tailscale", ts_ip or "已连接", "ok"))
@@ -1500,7 +1616,9 @@ class GalaxyUnified:
                 pass
         except Exception:
             bus_details.append(("Tailscale", "未安装 (LAN 直连模式)", "warn"))
-        _emit("消息总线", bus_value, "ok" if nats_ok else "warn", details=bus_details)
+        # 降级时把该项【专属】修复指引挂到总结卡(hint),不再无提示地一笔带过。
+        _emit("消息总线", bus_value, "ok" if nats_ok else "warn", details=bus_details,
+              hint=bus_hint if not nats_ok else None)
 
         # ── AI 大脑（含主脑模型选择）──
         try:


### PR DESCRIPTION
## Summary
所有者 Windows 真机启动日志实证的四个问题,证据链闭环修复:

1. **Electron 覆盖层崩溃循环**:"软件渲染"未传真 flag(补 `--disable-gpu --disable-gpu-compositing`);主犯为 `dist/electron.exe` 缺失(postinstall 被跳过)且完整性检查不核二进制——现启动前核验+自动修复+失败给可照抄指令;新增第三级 basic 不透明小窗降级;electron.log 错误摘要进主日志。
2. **API Key 保存悬挂**:保存路由同步探测所有 provider(离线机 >8s 前端超时)→ 改后台去重调度立即返回;verify-provider 有界等待保证保存后立刻验证可见新 key。
3. **UVStream "Cannot call write() when closing" 刷屏**:即②的超时重试断开连锁;新增窄匹配断开判定 + 纯 ASGI 断开护栏(最外层),正常断开降级 debug,真实异常照抛。
4. **NATS 假成功**:WDAC 拦截(WinError 4551)后仍打 ✓——改结构化结果 + 如实降级横幅(原因/影响/修复指引);同族修复 API 网关 ImportError 假绿。

## Validation
- 全部改动文件 `py_compile` / `node --check` 通过;括号计数 vs HEAD 全平;
- 定向回归 137 个测试全绿(config parity / secret routing / verify-provider / rate-limit / SSE 等);
- 补 Electron 二进制完整性回归用例;断开判定/护栏/调度去重均有冒烟验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_