### PR TITLE
fix: 21 verified bugs from exhaustive multi-agent sweep (nodes + LLM router + command router + core leaks)

### DIFF
--- a/core/attached_runtime_session_registry.py
+++ b/core/attached_runtime_session_registry.py
@@ -1069,6 +1069,10 @@ class AttachedSessionRegistry:
         entry = self._get_by_entry_id(entry_id)
         if entry is None:
             return None
+        # 幽灵命中一致性校验(与 get_by_session_id 对齐):条目可能已被 reconnect
+        # 换成新的 attachment id,旧键指向的 entry_id 不应再以旧 attachment id 命中。
+        if entry.runtime_attachment_session_id != runtime_attachment_session_id:
+            return None
         if active_only and not entry.is_active():
             return None
         return entry

--- a/core/canonical_session_truth.py
+++ b/core/canonical_session_truth.py
@@ -615,8 +615,15 @@ class CanonicalSessionTruthRuntime:
         """
         self._snapshot_store = store
 
-    def record(self, rec: CanonicalSessionTruthRecord) -> CanonicalSessionTruthRecord:
+    def record(self, rec: CanonicalSessionTruthRecord, persist: bool = True) -> CanonicalSessionTruthRecord:
         """Add *rec* to the ring buffer and return it.
+
+        persist
+            When ``False``, the record is admitted to the in-memory ring buffer
+            but NOT written back to the durable audit/snapshot stores.  Used by
+            :func:`restore_session_truth_from_snapshot` — those records were
+            *loaded from* the snapshot, so re-appending them re-persists every
+            record on every restart (unbounded snapshot/audit growth + dupes).
 
         Ownership admission gate
         ------------------------
@@ -672,8 +679,9 @@ class CanonicalSessionTruthRuntime:
                 self._control_only_count += 1
             if rec.merge_success:
                 self._success_count += 1
-        # Write to durable store outside the lock to avoid potential deadlock
-        if self._audit_store is not None and _append_truth_audit_record is not None:
+        # Write to durable store outside the lock to avoid potential deadlock.
+        # persist=False(恢复回放)时跳过 —— 记录本就是从持久层读出来的。
+        if persist and self._audit_store is not None and _append_truth_audit_record is not None:
             try:
                 _append_truth_audit_record(
                     rec.to_dict(),
@@ -686,7 +694,7 @@ class CanonicalSessionTruthRuntime:
                     _exc,
                 )
         # Write to snapshot store for cross-restart recovery
-        if self._snapshot_store is not None:
+        if persist and self._snapshot_store is not None:
             try:
                 self._snapshot_store.append(rec.to_dict())
             except Exception as _exc:  # noqa: BLE001

--- a/core/cognitive/decay_controller.py
+++ b/core/cognitive/decay_controller.py
@@ -149,7 +149,17 @@ class DecayController:
         )
         try:
             loop = asyncio.get_running_loop()
+            # 单飞:trigger_decay 由【每个】任务完成事件触发,原来每次都新起一条
+            # 4 秒(8 步×0.5s)衰减序列且互不取消 —— 高吞吐下大量重叠序列并发改写
+            # 同一份认知状态,进程退出时留下一堆 "Task was destroyed but it is
+            # pending"(CI 实证)。_active_decay_task 字段本为单飞而设却从未接线。
+            # 新触发前取消上一条未完成的衰减(衰减本就是幂等的"从当前值继续衰减",
+            # 重启序列即可),全程只有一条在跑。
+            _prev = self._active_decay_task
+            if _prev is not None and not _prev.done():
+                _prev.cancel()
             _bt = loop.create_task(self._async_decay_sequence(task_id=task_id, trace_id=trace_id))
+            self._active_decay_task = _bt
             _BACKGROUND_TASKS.add(_bt)
             _bt.add_done_callback(_BACKGROUND_TASKS.discard)
         except RuntimeError:

--- a/core/command_router.py
+++ b/core/command_router.py
@@ -1317,21 +1317,46 @@ class CommandRouter:
         _tool_name_for_hitl = (envelope.tool_name or "").lower()
         if self._is_high_risk_command(_tool_name_for_hitl):
             _env_meta = envelope.metadata or {}
-            if not _env_meta.get("_hitl_approved"):
-                logger.debug(
-                    "route_envelope: high-risk tool_name=%r detected; "
-                    "_hitl_required will be stamped if not pre-approved",
+            _env_args = getattr(envelope, "args", None) or {}
+            _hitl_ok = bool(_env_meta.get("_hitl_approved")) or bool(_env_args.get("_hitl_approved"))
+            if not _hitl_ok:
+                # 安全修复(fail-open):此前这里只把 _hitl_required 盖进 metadata、
+                # 并不阻断,真正的阻断门在 _execute_command(仅本地路径)。而高危
+                # 命令若走 executor_target_type=android_device/node_service/go_worker,
+                # route_envelope 会在下方 2431/2448 直接分叉到 _route_cross_device_
+                # envelope / _route_worker_envelope,【绕过】那道阻断门 → 跨设备/worker
+                # 上的高危命令无需批准即执行。改为在【分叉前】统一阻断:高危且未
+                # 携带 _hitl_approved 时立即返回 HITL_APPROVAL_REQUIRED。
+                logger.warning(
+                    "route_envelope: high-risk tool_name=%r without _hitl_approved — blocked (HITL required)",
                     envelope.tool_name,
                 )
-                # stamp _hitl_required into metadata so downstream can detect it
-                envelope = envelope.model_copy(
-                    update={
-                        "metadata": {
-                            **_env_meta,
-                            "_hitl_required": True,
-                        }
-                    }
-                )
+                try:
+                    self._emit_audit(
+                        "HITL_REQUIRED",
+                        trace_id=getattr(envelope, "trace_id", "") or "",
+                        task_id=getattr(envelope, "task_id", "") or "",
+                        device_id=(envelope.targets[0] if getattr(envelope, "targets", None) else ""),
+                        message=(
+                            f"HITL approval required for high-risk tool "
+                            f"'{envelope.tool_name}' (pre-dispatch, all paths)"
+                        ),
+                        payload={"tool_name": envelope.tool_name},
+                    )
+                except Exception as _audit_exc:  # noqa: BLE001
+                    logger.debug("route_envelope HITL audit emit skipped: %s", _audit_exc)
+                return {
+                    "success": False,
+                    "result": None,
+                    "task_id": getattr(envelope, "task_id", "") or "",
+                    "trace_id": getattr(envelope, "trace_id", "") or "",
+                    "error_code": "HITL_APPROVAL_REQUIRED",
+                    "error_message": (
+                        f"High-risk command '{envelope.tool_name}' requires HITL approval. "
+                        "Include _hitl_approved=True in payload/metadata after obtaining approval."
+                    ),
+                    "requires_hitl": True,
+                }
         try:
             from core.task_memory import get_task_memory
 
@@ -1360,7 +1385,15 @@ class CommandRouter:
             # empty targets — device selection is performed by the DeviceRouter
             # substrate inside _route_cross_device_envelope().
             _early_meta = envelope.metadata or {}
-            if _early_meta.get("cross_device") == "true":
+            # 跨设备信号有两种:metadata.cross_device=="true",或一等公民字段
+            # executor_target_type ∈ {android_device, node_service}(其目标由
+            # DeviceRouter substrate 在 _route_cross_device_envelope 内选择,故允许
+            # 空 targets)。此前只认前者,导致【仅】用 executor_target_type 表达
+            # 跨设备意图、且未显式列 targets 的信封被误判为无目标而走进本地
+            # 池选择/报错分支。用 .value 判定(str(enum) 带类名前缀会漏判)。
+            _ett_early = getattr(envelope, "executor_target_type", None)
+            _ett_early_val = getattr(_ett_early, "value", "") if _ett_early is not None else ""
+            if _early_meta.get("cross_device") == "true" or _ett_early_val in ("android_device", "node_service"):
                 pass  # targets resolved by substrate; skip pool/error check
             else:
                 # PR-3: When required_capabilities are present but no explicit target is
@@ -1509,7 +1542,8 @@ class CommandRouter:
                     _meta_pf = envelope.metadata or {}
                     _is_cross_device_hint = _meta_pf.get("cross_device") == "true" or (
                         envelope.executor_target_type is not None
-                        and str(envelope.executor_target_type) in ("android_device", "node_service")
+                        # .value:(str,Enum) 的 str() 带类名前缀,in 检查恒 False。
+                        and getattr(envelope.executor_target_type, "value", "") in ("android_device", "node_service")
                     )
                     if not _is_cross_device_hint:
                         logger.debug(
@@ -2059,7 +2093,18 @@ class CommandRouter:
                 elif _v3_meta.get("cross_device") == "true":
                     _v3_exec_mode = "cross_device"
                 elif envelope.executor_target_type is not None:
-                    _v3_exec_mode = str(envelope.executor_target_type)
+                    # (str, Enum) 上 str(member) 返回 'ExecutorTargetType.android_device'
+                    # (类名前缀),不是 'android_device' —— 用 .value。且 android_device/
+                    # node_service 都是跨设备派发,必须映射为 'cross_device' 才能命中
+                    # 下游 slot-authority 的 require_cd 集(cross_device/handoff/takeover/
+                    # wake_routed);否则跨设备就绪门被静默绕过。go_worker 保留其值
+                    # (走 worker 域,本就不应触发 cross-device 就绪校验)。
+                    _ett = envelope.executor_target_type
+                    _ett_val = getattr(_ett, "value", str(_ett))
+                    if _ett_val in ("android_device", "node_service"):
+                        _v3_exec_mode = "cross_device"
+                    else:
+                        _v3_exec_mode = _ett_val
                 else:
                     _v3_exec_mode = "cross_device"
                 _v3_required_caps: Optional[List[str]] = (

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -404,17 +404,19 @@ PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
         TaskType.GENERAL: "gemini-3.5-flash",
     },
     "meta": {
-        # Muse Spark 1.1(2026-07-09,Meta Superintelligence Labs):Llama 后继,
-        # Meta Model API 首发唯一模型。多模态推理+agentic(工具/电脑使用/编码),
-        # 1M ctx,OpenAI SDK 兼容(api.meta.ai/v1),$1.25/$4.25 每 M tokens。
-        TaskType.REASONING: "muse-spark-1.1",
-        TaskType.FAST_RESPONSE: "muse-spark-1.1",
-        TaskType.CODING: "muse-spark-1.1",
-        TaskType.CREATIVE: "muse-spark-1.1",
-        TaskType.ANALYSIS: "muse-spark-1.1",
-        TaskType.PLANNING: "muse-spark-1.1",
-        TaskType.AGENT_CONTROL: "muse-spark-1.1",
-        TaskType.GENERAL: "muse-spark-1.1",
+        # 对齐 PROVIDER_REGISTRY['meta'] 的真实模型名(api.llama.com/compat/v1)。
+        # 此前全部映射到 "muse-spark-1.1" —— registry 注释已明确它【并非真实模型】,
+        # 而 map 对每个 TaskType 都有值、消费方永远取 map 值(不落到 default_model),
+        # 于是每个走 meta 的请求都拿假模型名去请求 → 400/404、provider 被判 DOWN。
+        # 重档用 Maverick(旗舰),快档用 Scout(轻量)。
+        TaskType.REASONING: "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        TaskType.FAST_RESPONSE: "Llama-4-Scout-17B-16E-Instruct-FP8",
+        TaskType.CODING: "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        TaskType.CREATIVE: "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        TaskType.ANALYSIS: "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        TaskType.PLANNING: "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        TaskType.AGENT_CONTROL: "Llama-4-Maverick-17B-128E-Instruct-FP8",
+        TaskType.GENERAL: "Llama-4-Scout-17B-16E-Instruct-FP8",
     },
     "xai": {
         TaskType.REASONING: "grok-4.5",
@@ -465,14 +467,17 @@ PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
         TaskType.PLANNING: "glm-5.1",
     },
     "minimax": {
-        TaskType.REASONING: "minimax-m2.7",
-        TaskType.FAST_RESPONSE: "minimax-m2.7",
-        TaskType.CODING: "minimax-m2.7",
-        TaskType.CREATIVE: "minimax-m2.7",
-        TaskType.ANALYSIS: "minimax-m2.7",
-        TaskType.PLANNING: "minimax-m2.7",
-        TaskType.AGENT_CONTROL: "minimax-m2.7",
-        TaskType.GENERAL: "minimax-m2.7",
+        # 对齐 PROVIDER_REGISTRY['minimax'].models(大小写敏感的官方 id):
+        # 此前用小写 "minimax-m2.7"(registry 里根本没有此拼写)→ 请求即 404。
+        # 重档 MiniMax-M3(default),快档 MiniMax-M2.7。
+        TaskType.REASONING: "MiniMax-M3",
+        TaskType.FAST_RESPONSE: "MiniMax-M2.7",
+        TaskType.CODING: "MiniMax-M3",
+        TaskType.CREATIVE: "MiniMax-M3",
+        TaskType.ANALYSIS: "MiniMax-M3",
+        TaskType.PLANNING: "MiniMax-M3",
+        TaskType.AGENT_CONTROL: "MiniMax-M3",
+        TaskType.GENERAL: "MiniMax-M2.7",
     },
     "step": {
         TaskType.REASONING: "step-3.7-flash",
@@ -2238,7 +2243,17 @@ class MultiLLMRouter:
         last_user_msg = ""
         for m in reversed(messages):
             if m.get("role") == "user":
-                last_user_msg = m.get("content", "").lower()
+                # content 可能是 str,也可能是 OpenAI-vision 的分段 list
+                # ([{type:text,...},{type:image_url,...}])——本 router 明确支持后者。
+                # 直接 .lower() 会在 list 上 AttributeError,把整个 chat() 在路由前
+                # 就打断(多模态 ambient 决策因此每次静默丢失画面输入)。先归一化。
+                _content = m.get("content", "")
+                if isinstance(_content, str):
+                    last_user_msg = _content.lower()
+                elif isinstance(_content, list):
+                    last_user_msg = " ".join(
+                        p.get("text", "") for p in _content if isinstance(p, dict) and p.get("type") == "text"
+                    ).lower()
                 break
 
         # 加权关键词 → 任务类型 (keyword, weight)

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -8048,6 +8048,12 @@ class OpenClawd:
         tool_records: List[ToolCallRecord] = []
         last_response = None
         total_tokens = 0
+        # 是否因触顶 max_iterations 而终止(区别于"无工具调用自然完成"或限频/
+        # 重复检测提前中止)。此前 _react_loop 从不返回该键,handle_chat 的
+        # result.get("hit_max_iterations", False) 恒 False —— 观测面永远看不到
+        # "agent 卡在迭代上限没跑完"这一真实终止原因。for-else 精确捕获:
+        # 循环跑满 max_iterations 且【无任何 break】即触顶。
+        hit_max_iterations = False
 
         # Phase 9: 频率限制计数器
         _total_tool_calls = 0
@@ -8068,6 +8074,7 @@ class OpenClawd:
         async def _inner_loop():
             nonlocal last_response, total_tokens
             nonlocal _total_tool_calls, _last_tool_name
+            nonlocal hit_max_iterations
 
             for iteration in range(max_iterations):
                 # 任务成本账本:记一轮 ReAct(账本故障绝不反噬)
@@ -8250,6 +8257,10 @@ class OpenClawd:
                             "content": _clipped,
                         }
                     )
+            else:
+                # for 循环跑满 max_iterations 且无任何 break(自然完成/限频/重复
+                # 都是 break)→ 触顶迭代上限。
+                hit_max_iterations = True
 
         try:
             await _asyncio.wait_for(_inner_loop(), timeout=timeout)
@@ -8269,6 +8280,7 @@ class OpenClawd:
             "model": last_response.model if last_response else "",
             "total_tokens": total_tokens,
             "timeout": timed_out,
+            "hit_max_iterations": hit_max_iterations,
         }
 
     # ========================================================================

--- a/core/performance.py
+++ b/core/performance.py
@@ -225,16 +225,26 @@ class RateLimiter:
             current_count = len(self._windows[key])
             remaining = self.max_requests - current_count
 
+            # 逻辑修复:此前窗口硬顶(max_requests)只在【同时】1 秒内突发数
+            # ≥ burst 时才拒绝 —— 稳定发送(如 100 条均摊到 60s、每秒远不到 burst)
+            # 永远落到下面的 append+return True,窗口上限形同虚设,限流实际不生效。
+            # 正确语义:窗口顶与突发顶【各自独立】,任一超限即拒。
             if current_count >= self.max_requests:
-                # 检查突发容量
-                recent_burst = sum(1 for t in self._windows[key] if t > now - 1)
-                if recent_burst >= self.burst:
-                    return False, {
-                        "remaining": 0,
-                        "limit": self.max_requests,
-                        "reset_at": window_start + self.window_seconds,
-                        "retry_after": int(self.window_seconds - (now - self._windows[key][0])) + 1,
-                    }
+                return False, {
+                    "remaining": 0,
+                    "limit": self.max_requests,
+                    "reset_at": window_start + self.window_seconds,
+                    "retry_after": int(self.window_seconds - (now - self._windows[key][0])) + 1,
+                }
+
+            recent_burst = sum(1 for t in self._windows[key] if t > now - 1)
+            if recent_burst >= self.burst:
+                return False, {
+                    "remaining": max(0, remaining),
+                    "limit": self.max_requests,
+                    "reset_at": now + 1.0,
+                    "retry_after": 1,
+                }
 
             self._windows[key].append(now)
             return True, {

--- a/core/security_middleware.py
+++ b/core/security_middleware.py
@@ -74,12 +74,25 @@ class AuditLogger:
         self._error_count = 0
         self._total_count = 0
 
+    # 聚合字典基数上限:by_path/by_ip 的 key 是请求 path 和 client_ip,面对
+    # 404 探测(随机路径)或大量/伪造源 IP 会无界增长(内存泄漏)。get_stats
+    # 只展示 top-10,故只需保留高频项:超过上限时丢弃当前最低频的一批。
+    _MAX_AGG_KEYS = 10000
+
+    @staticmethod
+    def _bump_bounded(counter: Dict, key, cap: int) -> None:
+        counter[key] += 1
+        if len(counter) > cap:
+            # 丢弃最低频的 ~10%,摊销清理成本(top-N 统计不受影响)。
+            for k, _ in sorted(counter.items(), key=lambda kv: kv[1])[: max(1, cap // 10)]:
+                counter.pop(k, None)
+
     def record(self, entry: AuditEntry):
         """记录审计日志"""
         self._entries.append(entry)
-        self._by_path[entry.path] += 1
-        self._by_status[entry.status_code] += 1
-        self._by_ip[entry.client_ip] += 1
+        self._bump_bounded(self._by_path, entry.path, self._MAX_AGG_KEYS)
+        self._by_status[entry.status_code] += 1  # 状态码基数天然有限,不设上限
+        self._bump_bounded(self._by_ip, entry.client_ip, self._MAX_AGG_KEYS)
         self._total_count += 1
 
         if entry.status_code >= 400:

--- a/core/session_truth_snapshot.py
+++ b/core/session_truth_snapshot.py
@@ -290,7 +290,9 @@ def restore_session_truth_from_snapshot(
             from core.canonical_session_truth import CanonicalSessionTruthRecord
 
             rec = CanonicalSessionTruthRecord.from_dict(rd)
-            runtime.record(rec)
+            # persist=False:这些记录就是从快照里读出来的,再经默认 record() 回写
+            # 会把整份快照(和审计流)在每次重启时重复追加一遍 → 无界膨胀 + 重复。
+            runtime.record(rec, persist=False)
             restored += 1
         except Exception as exc:
             logger.debug(

--- a/core/tts/edge_tts_engine.py
+++ b/core/tts/edge_tts_engine.py
@@ -195,6 +195,7 @@ class EdgeTTSEngine:
         """
         system = platform.system()
         play_cmd: List[str] = []
+        _cleanup_temp: Optional[str] = None  # 播放结束后需删除的临时转码文件
 
         if system == "Windows":
             # Windows: 使用 PowerShell 播放
@@ -237,10 +238,11 @@ class EdgeTTSEngine:
                         check=True,
                     )
                     play_cmd = ["aplay", "-q", wav_path]
-                    try:
-                        os.remove(wav_path)
-                    except OSError:
-                        pass
+                    # 关键:此前在这里就 os.remove(wav_path) —— 但真正的播放在下方
+                    # `if play_cmd:` 才发生,文件已被删,aplay 播的是不存在的文件、
+                    # Linux(仅 aplay 可用)上 TTS 静默失败。改为记下临时文件,播放
+                    # 结束后再删。
+                    _cleanup_temp = wav_path
                 else:
                     logger.warning("No audio player found. Install mpg123 or ffmpeg.")
                     return
@@ -275,6 +277,13 @@ class EdgeTTSEngine:
                         stderr.decode("utf-8", errors="replace")[:200],
                     )
                 self._stopped = False
+
+        # 播放完成后清理临时转码文件(此前在播放【前】误删,导致 aplay 静默失败)。
+        if _cleanup_temp:
+            try:
+                os.remove(_cleanup_temp)
+            except OSError:
+                pass
 
     async def stop(self) -> None:
         """掐断【当前正在播放】的音频（barge-in）。无播放时是安全空操作。"""

--- a/nodes/Node_09_Sandbox/main.py
+++ b/nodes/Node_09_Sandbox/main.py
@@ -438,8 +438,11 @@ async def run_tests(code: str, tests: List[Dict[str, Any]], language: str = "pyt
     """运行测试用例"""
     results = []
     for i, test in enumerate(tests):
-        stdin = test.get("input", "")
-        expected_output = test.get("expected", "")
+        # present-but-None 防护:test.get(k, default) 的默认值只在键【缺失】时生效,
+        # 键存在但值为 null 时返回 None,后面 .strip() 直接 AttributeError → 整个
+        # /test 500。强制转字符串。
+        stdin = str(test.get("input") or "")
+        expected_output = str(test.get("expected") or "")
 
         exec_result = await execute_code(ExecuteRequest(code=code, language=language, stdin=stdin, timeout=10))
 

--- a/nodes/Node_55_MultiModal/main.py
+++ b/nodes/Node_55_MultiModal/main.py
@@ -9,6 +9,7 @@ import os
 import base64
 import io
 import statistics
+from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 from fastapi import FastAPI, HTTPException
@@ -51,8 +52,25 @@ app.add_middleware(CORSMiddleware, allow_origins=get_cors_origins(), allow_crede
 
 _ERR_NO_TRANSFORMERS = "transformers not installed. Run: pip install transformers torch"
 
-# Cached pipelines
-_pipelines: Dict[str, Any] = {}
+# Cached pipelines —— 有界 LRU。cache_key=f"{task}:{model}",task/model 都来自
+# 请求体,不设上限时每个不同组合都会常驻一整个 HF 模型(数百 MB~GB 显存/内存),
+# 面对多样请求会 OOM。超过上限时驱逐最久未用,并主动释放显存。
+_PIPELINE_CACHE_MAX = int(os.getenv("NODE55_PIPELINE_CACHE_MAX", "4"))
+_pipelines: "OrderedDict[str, Any]" = OrderedDict()
+
+
+def _evict_pipeline_if_needed() -> None:
+    while len(_pipelines) > _PIPELINE_CACHE_MAX:
+        _old_key, _old_pipe = _pipelines.popitem(last=False)
+        try:
+            del _old_pipe
+            import gc as _gc
+
+            _gc.collect()
+            if TORCH_AVAILABLE and torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001 — 释放失败不影响主流程
+            pass
 
 AVAILABLE_MODELS = [
     {"name": "text-generation", "type": "text", "description": "Generate text from prompt", "requires": ["transformers"]},
@@ -134,7 +152,7 @@ async def process(request: ProcessRequest):
         task = request.task
         params = request.params or {}
 
-        # Build or retrieve pipeline
+        # Build or retrieve pipeline（有界 LRU）
         cache_key = f"{task}:{request.model or 'default'}"
         if cache_key not in _pipelines:
             kwargs = {"task": task}
@@ -142,7 +160,11 @@ async def process(request: ProcessRequest):
                 kwargs["model"] = request.model
             if TORCH_AVAILABLE:
                 kwargs["device"] = 0 if torch.cuda.is_available() else -1
+            # 先构建(可能抛错,失败则不进缓存),成功再登记并按需驱逐。
             _pipelines[cache_key] = hf_pipeline(**kwargs)
+            _evict_pipeline_if_needed()
+        else:
+            _pipelines.move_to_end(cache_key)  # 命中即刷新 LRU 位置
 
         pipe = _pipelines[cache_key]
 
@@ -171,6 +193,9 @@ async def embed(request: EmbedRequest):
         cache_key = f"embed:{model_name}"
         if cache_key not in _pipelines:
             _pipelines[cache_key] = hf_pipeline("feature-extraction", model=model_name)
+            _evict_pipeline_if_needed()
+        else:
+            _pipelines.move_to_end(cache_key)
 
         pipe = _pipelines[cache_key]
 

--- a/nodes/Node_60_ReinforcementLearning/main.py
+++ b/nodes/Node_60_ReinforcementLearning/main.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 import os
 import math
 import random
+import collections
 import asyncio
 import logging
 from datetime import datetime
@@ -56,7 +57,9 @@ class RLAgent:
         self.episodes_completed = 0
         self.total_steps = 0
         self.total_reward = 0.0
-        self.episode_rewards: List[float] = []
+        # 有界:只有最近 ~100 条被读(get_stats 切 [-100:]),deque(maxlen) 防每次
+        # /episode 无界增长(长期运行 OOM)。切片/append/clear 语义不变。
+        self.episode_rewards: collections.deque = collections.deque(maxlen=200)
         self.policy_weights: Dict[str, float] = {}
 
     def _state_key(self, state: Any) -> str:
@@ -109,10 +112,9 @@ class RLAgent:
         return policy
 
     def get_stats(self) -> Dict[str, Any]:
-        avg_reward = (
-            sum(self.episode_rewards[-100:]) / len(self.episode_rewards[-100:])
-            if self.episode_rewards else 0.0
-        )
+        # deque 不支持切片([-100:] 会 TypeError),先物化为 list 再取尾窗。
+        _recent = list(self.episode_rewards)[-100:]
+        avg_reward = (sum(_recent) / len(_recent)) if _recent else 0.0
         return {
             "episodes_completed": self.episodes_completed,
             "total_steps": self.total_steps,

--- a/nodes/Node_62_ProbabilisticProgramming/main.py
+++ b/nodes/Node_62_ProbabilisticProgramming/main.py
@@ -51,14 +51,22 @@ async def sample_distribution(request: SampleRequest):
     samples = []
     dist = request.distribution.lower()
     params = request.params
-    
+
+    # n_samples<1 → 空 samples → 后面 sum/len 除零 500;先校验。
+    if request.n_samples < 1:
+        raise HTTPException(status_code=400, detail="n_samples must be >= 1")
+
     for _ in range(request.n_samples):
         if dist == "normal" or dist == "gaussian":
             s = random.gauss(params.get("mean", 0), params.get("std", 1))
         elif dist == "uniform":
             s = random.uniform(params.get("low", 0), params.get("high", 1))
         elif dist == "exponential":
-            s = random.expovariate(1 / params.get("scale", 1))
+            # scale=0 → 1/0 ZeroDivisionError;scale<0 → expovariate 报错。
+            _scale = params.get("scale", 1)
+            if _scale <= 0:
+                raise HTTPException(status_code=400, detail="exponential scale must be > 0")
+            s = random.expovariate(1 / _scale)
         elif dist == "poisson":
             lam = params.get("lambda", 1)
             s = sum(1 for _ in range(int(lam * 10)) if random.random() < lam / (lam * 10))
@@ -83,17 +91,25 @@ async def metropolis_hastings(request: MCMCRequest):
     samples = []
     current = 0
     
-    def target_pdf(x):
-        return math.exp(-0.5 * ((x - request.target_mean) / request.target_std)**2)
-    
+    if request.n_samples < 1 or request.burn_in < 0:
+        raise HTTPException(status_code=400, detail="n_samples must be >= 1 and burn_in >= 0")
+    if request.target_std <= 0:
+        raise HTTPException(status_code=400, detail="target_std must be > 0")
+
+    # 在【对数空间】算接受比,避免链条长期远离均值时 target_pdf(x) 下溢到 0.0、
+    # 导致 target_pdf(proposal)/target_pdf(current) 触发 ZeroDivisionError(整个
+    # /mcmc 500)。log p(x) = -0.5*((x-mean)/std)^2;acceptance = exp(min(0, Δlogp))。
+    def log_target_pdf(x):
+        return -0.5 * ((x - request.target_mean) / request.target_std) ** 2
+
     for i in range(request.n_samples + request.burn_in):
         proposal = current + random.gauss(0, 1)
-        acceptance = min(1, target_pdf(proposal) / target_pdf(current))
+        acceptance = math.exp(min(0.0, log_target_pdf(proposal) - log_target_pdf(current)))
         if random.random() < acceptance:
             current = proposal
         if i >= request.burn_in:
             samples.append(current)
-    
+
     mean = sum(samples) / len(samples)
     variance = sum((x - mean)**2 for x in samples) / len(samples)
     

--- a/nodes/Node_71_MultiDeviceCoordination/core/task_scheduler.py
+++ b/nodes/Node_71_MultiDeviceCoordination/core/task_scheduler.py
@@ -707,21 +707,33 @@ class TaskScheduler:
         """重试任务"""
         task.retry_count += 1
         task.state = TaskState.RETRYING
-        
+
         # 更新统计
         self._stats["retries"] += 1
-        
+
+        # 竞态修复:重试要 await sleep(delay),期间任务若仍留在 _running 且带着
+        # 上一轮的旧 started_at,_monitor_loop 的 _check_timeouts 会把它【误判超时】、
+        # 走 _handle_timeout 清理并置 TIMEOUT;sleep 结束后这里又 _assign_task 重新
+        # 加回 —— 状态错乱、双重处理。在等待前把任务移出 _running、清理设备占用、
+        # 清空 started_at,让它在重试窗口内不被超时检查看到。
+        self._running.pop(task.task_id, None)
+        device.current_task = None
+        if task.task_id in device.assigned_tasks:
+            device.assigned_tasks.remove(task.task_id)
+        device.state = DeviceState.IDLE
+        task.started_at = None
+
         self._emit_event(SchedulerEvent(
             event_type=SchedulerEventType.TASK_RETRY,
             task=task,
             device=device,
             message=f"Task {task.task_id} retrying ({task.retry_count}/{task.retry_policy.max_retries})"
         ))
-        
+
         # 等待重试延迟
         delay = task.get_next_retry_delay()
         await asyncio.sleep(delay)
-        
+
         # 重新执行
         task.state = TaskState.PENDING
         await self._assign_task(task, device)
@@ -778,6 +790,10 @@ class TaskScheduler:
         timed_out = []
         
         for task_id, task in self._running.items():
+            # 只对【真正在跑】的任务判超时。RETRYING/PENDING/ASSIGNED 等中间态
+            # 的 started_at 可能是旧值,不应据此误判超时(见 _retry_task 竞态修复)。
+            if task.state != TaskState.RUNNING:
+                continue
             if task.started_at:
                 elapsed = current_time - task.started_at
                 if elapsed > (task.timeout or self.config.task_timeout):

--- a/nodes/Node_89_APIGateway/main.py
+++ b/nodes/Node_89_APIGateway/main.py
@@ -17,7 +17,7 @@ import time
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 from contextlib import asynccontextmanager
-from collections import defaultdict, deque
+from collections import OrderedDict, defaultdict, deque
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request, Response
@@ -88,26 +88,57 @@ class MCPCallRequest(BaseModel):
 # =============================================================================
 
 class RateLimiter:
-    """Simple sliding-window in-memory rate limiter."""
+    """Simple sliding-window in-memory rate limiter.
+
+    内存有界:每个见过的 client_ip 都会在字典里留一条窗口,而客户端一去不返
+    (或伪造大量源 IP)时,其 key 永不再被访问、窗口从不被清理 → 无界增长。
+    两道防线:(1) 每次 is_allowed 惰性清扫一批过期(空窗)key;(2) key 总数
+    硬上限,超出时按最久未活动优先驱逐(全空、否则最旧)。
+    """
+
+    _MAX_CLIENTS = 50000
+    _SWEEP_EVERY = 256  # 每 N 次调用做一轮过期清扫(摊销成本)
 
     def __init__(self):
-        # client_key -> deque of request timestamps
-        self._windows: Dict[str, deque] = defaultdict(deque)
+        # client_key -> deque of request timestamps(有序:近似 LRU,新 key 追加在尾)
+        self._windows: "OrderedDict[str, deque]" = OrderedDict()
+        self._calls = 0
+
+    def _sweep_expired(self, cutoff: float) -> None:
+        stale = [k for k, w in self._windows.items() if not w or w[-1] < cutoff]
+        for k in stale:
+            self._windows.pop(k, None)
+
+    def _enforce_cap(self) -> None:
+        while len(self._windows) > self._MAX_CLIENTS:
+            self._windows.popitem(last=False)  # 驱逐最久未活动的
 
     def is_allowed(self, client_key: str, limit: int) -> bool:
         now = time.monotonic()
-        window = self._windows[client_key]
         cutoff = now - 60.0
+        self._calls += 1
+        if self._calls % self._SWEEP_EVERY == 0:
+            self._sweep_expired(cutoff)
+        window = self._windows.get(client_key)
+        if window is None:
+            window = deque()
+            self._windows[client_key] = window
+        else:
+            self._windows.move_to_end(client_key)  # 触达即刷新 LRU 位置
         while window and window[0] < cutoff:
             window.popleft()
         if len(window) >= limit:
             return False
         window.append(now)
+        self._enforce_cap()
         return True
 
     def remaining(self, client_key: str, limit: int) -> int:
         now = time.monotonic()
-        window = self._windows[client_key]
+        # get 而非 defaultdict 索引,避免只读查询凭空建 key。
+        window = self._windows.get(client_key)
+        if not window:
+            return limit
         cutoff = now - 60.0
         count = sum(1 for t in window if t >= cutoff)
         return max(0, limit - count)

--- a/nodes/Node_96_SmartTransportRouter/main.py
+++ b/nodes/Node_96_SmartTransportRouter/main.py
@@ -387,8 +387,10 @@ async def route_new_message(message: Dict[str, Any]):
     if not router:
         raise HTTPException(status_code=503, detail="Router not initialized.")
 
-    # 将字符串优先级转换为枚举成员
-    priority_str = message.get("priority", "LOW").upper()
+    # 将字符串优先级转换为枚举成员。message 是裸 dict(无 pydantic 校验),
+    # priority 若给成非字符串(如 int 3)或 null,.upper() 直接 AttributeError → 500。
+    # 强制转字符串后再规整。
+    priority_str = str(message.get("priority") or "LOW").upper()
     try:
         message["priority"] = MessagePriority[priority_str]
     except KeyError:


### PR DESCRIPTION
Exhaustive full-repo bug sweep of subsystems not covered by the earlier sweeps. An 8-finder multi-agent workflow scanned distinct subsystems for real defects; each candidate was adversarially verified against the actual producer/consumer code before fixing. 21 confirmed bugs fixed across 3 commits; 2 unverified candidates deliberately deferred.

## Node runtimes (8) — `8d4293d`

- **Node_09_Sandbox** `/test`: `test.get('expected','')` returns `None` on a present-but-null key → `.strip()` crashes the endpoint. Coerce.
- **Node_60_ReinforcementLearning**: `episode_rewards` unbounded list appended per `/episode` (long-run OOM) → `deque(maxlen=200)` (get_stats materializes before slicing).
- **Node_62_ProbabilisticProgramming** `/mcmc`: `target_pdf(proposal)/target_pdf(current)` → **ZeroDivisionError** when the chain drifts far from the mean (both pdfs underflow to 0.0). Computed in log space. `/sample`: n_samples=0 and exponential scale=0 divide-by-zero — validated.
- **Node_96_SmartTransportRouter** `/route`: `message['priority'].upper()` crashes (500) on non-string/null priority. Coerce.
- **Node_55_MultiModal**: `_pipelines` cached unbounded HF pipelines by request task+model (each a multi-hundred-MB/GB model) → OOM. Bounded LRU with GPU-cache release.
- **Node_89_APIGateway** RateLimiter: per-client windows in a defaultdict never evicted (silent clients / spoofed IPs leak keys). OrderedDict LRU + client cap + amortized sweep.
- **Node_71 TaskScheduler** retry race: `_retry_task` await-sleeps while the task stays in `_running` with a stale `started_at`, so `_check_timeouts` force-times it out mid-retry and double-handles it. Evict + reset before the delay; skip non-RUNNING in `_check_timeouts`.

## LLM router + command router + session truth (7) — `18bdea2`

- **command_router HITL fail-open** (security): the blocking high-risk gate lived only in `_execute_command` (local path); `route_envelope` merely stamped `_hitl_required` then branched to cross-device/worker dispatch — high-risk commands to an android_device/node_service/go_worker executed with **no approval**. Now blocks before path branching.
- **command_router executor_target_type gating bypass**: `str(ExecutorTargetType.android_device)` yields `'ExecutorTargetType.android_device'` (class-prefixed) on Python 3.11, not the value — so `_v3_exec_mode` never matched the slot-authority `require_cd` set and cross-device readiness gating was silently skipped. Use `.value` + map android_device/node_service → `cross_device`. Same `str()`-vs-`.value` bug in the posture-gate hint and the empty-targets guard.
- **multi_llm_router.classify_task**: `content.lower()` crashed on OpenAI-vision list content, aborting `chat()` before routing; the ambient loop then silently retried text-only, dropping the image. Normalize str|list.
- **PROVIDER_MODEL_MAP['meta']**: every task mapped to `'muse-spark-1.1'` (the registry's own comment says it is not a real model) → every meta request 400/404. Aligned to real Llama-4 ids.
- **PROVIDER_MODEL_MAP['minimax']**: lowercase `'minimax-m2.7'` absent from the case-sensitive registry → 404. Aligned to `MiniMax-M3/M2.7`.
- **session-truth restore re-persist**: `restore_session_truth_from_snapshot` re-`record()`ed snapshot-loaded records back into the snapshot + audit stores every restart (unbounded growth + dupes). Added `record(rec, persist=False)`.

## Core leaks & logic (6) — `08f1e97`

- **performance.RateLimiter** (live on every request via RateLimitMiddleware): the per-window cap was only enforced when the 1-second burst ALSO exceeded `burst` — a steady sub-burst stream was never limited. Enforce window and burst caps independently.
- **security_middleware.AuditLogger**: `_by_path`/`_by_ip` defaultdicts grew unbounded (404-probing / IP churn). Bounded cardinality with least-frequent eviction (top-N stats preserved).
- **cognitive.DecayController**: `trigger_decay` spawned a fresh 4s decay sequence per task-completion event with no cancellation — overlapping sequences mutating one state (the "Task was destroyed but it is pending" CI warnings). Wired the long-declared `_active_decay_task` single-flight (cancel prior in-flight).
- **openclawd._react_loop**: never returned `hit_max_iterations`, so the observability surface always saw False. Added a `for-else` flag + the return key.
- **tts.edge_tts_engine**: the aplay branch `os.remove`d the transcoded WAV **before** playback ran — silent TTS on Linux hosts that only have aplay. Deferred cleanup to after playback.
- **attached_runtime_session_registry.get_by_runtime_attachment_session_id**: missing the ghost-hit consistency guard that `get_by_session_id` has — a stale attachment-id index key could resolve to a reassigned entry. Added the matching guard.

## Deferred (found, plausible, NOT adversarially verified)

Two `live_mesh_runtime_engine` barrier findings (posture open/wait_primary/soft treated as hard; barrier waiting on offline/heartbeat-timed-out participants) whose verifiers hit the session limit. Speculative edits to barrier-release semantics risk a distributed-correctness regression, so they need a dedicated design pass against the `MeshBarrierPosture` contract rather than a blind fix.

## Verification

Every fix was verified against the real producer/consumer code before committing; `py_compile` + `flake8`/`black`/`isort` clean on all touched core files; standalone smokes for each algorithmic/leak fix (rate-limiter caps, MCMC log-space stability, bounded caches, decay single-flight, executor-target mapping, multimodal classify); 619 attached-registry + 340 cross-device/HITL/restart tests pass. The handful of `-k`-run failures are pre-existing or order-dependent mock pollution that pass in isolation and don't touch this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_