### PR TITLE
fix(windows): 修复真机启动日志暴露的 8 处缺陷(桌面壳探活误杀是总根因)

### DIFF
--- a/core/crash_log_aggregator.py
+++ b/core/crash_log_aggregator.py
@@ -26,7 +26,7 @@ import hashlib
 import re
 import time
 from pathlib import Path
-from typing import Iterable, Iterator, NamedTuple
+from typing import Iterator, NamedTuple
 
 from core.log_paths import crash_dir, crash_latest_path, log_root
 
@@ -37,9 +37,14 @@ __all__ = [
     "CRASH_PATTERNS",
 ]
 
-#: 崩溃/致命特征(大小写不敏感)。命中即视为崩溃块的起点。
+#: 崩溃/致命特征总目录(大小写不敏感),供外部查阅本聚合器"认得哪些崩溃"。
 #: 覆盖:Python traceback、通用 fatal/crash、Electron/Chromium 崩溃、
 #: Windows 应用控制拦截(WinError 4551,真机出现过)、进程非零退出。
+#:
+#: 注意:命中本目录**不等于**就是崩溃锚点。真正的判定见 :func:`_is_crash_anchor`
+#: —— 结构性特征(traceback、WinError…)可以出现在行内任意位置就算数;而
+#: FATAL/CRITICAL/crash 这类普通英文词必须出现在日志的级别字段位置,
+#: 否则一句提到 "CRITICAL" 的建议文案就会被当成崩溃(真机踩过)。
 CRASH_PATTERNS: tuple[str, ...] = (
     r"Traceback \(most recent call last\)",
     r"\bFATAL\b",
@@ -55,10 +60,63 @@ CRASH_PATTERNS: tuple[str, ...] = (
     r"exited with code [1-9]",
 )
 
-_CRASH_RE = re.compile("|".join(CRASH_PATTERNS), re.IGNORECASE)
+#: 只要出现就足以判定崩溃的**结构性**特征——它们本身就是崩溃现场的形状,
+#: 不可能出现在正常叙述里。
+_STRUCTURAL_RE = re.compile(
+    "|".join(
+        (
+            r"Traceback \(most recent call last\)",
+            r"Unhandled (exception|rejection)",
+            r"未处理的异常",
+            r"GPU process (exited|crashed)",
+            r"renderer process (gone|crashed)",
+            r"did-fail-load",
+            r"WinError \d+",
+            r"Segmentation fault",
+            r"exited with code [1-9]",
+        )
+    ),
+    re.IGNORECASE,
+)
 
-#: 单个崩溃块最多保留的行数(含起始行)。
+#: FATAL/CRITICAL/crash 这类**普通英文词**只有出现在日志的"级别字段"位置才算数
+#: (``... | CRITICAL | ...``、``CRITICAL:``、行首)。
+#:
+#: 为什么必须加这道闸(真机实证):预检输出里有一句纯建议文案——
+#: "GALAXY_REQUIRE_API_TOKEN=true makes a missing token **CRITICAL** even with
+#: auth off" ——它被 ``\bCRITICAL\b`` 命中,于是聚合视图把一条建议当成崩溃锚点,
+#: 真正的崩溃反倒被当作它的"上下文"吞进块里;而同一个崩溃在另一个日志里锚在
+#: 正确的 ``| CRITICAL |`` 行上,两边指纹不同 → **同一个崩溃出现了两次**。
+_LEVEL_TOKEN_RE = re.compile(
+    r"(?:^|\||\[)\s*(?:FATAL|CRITICAL|CRASH(?:ED|ING)?)\b\s*(?:\||:|\])",
+    re.IGNORECASE,
+)
+
+#: 级别字段明确是 INFO/DEBUG/TRACE 的行,**永远不做崩溃锚点**。
+#:
+#: 真机实证:``| INFO | 注册安全规则: 高度限制检查 (critical)`` 和
+#: ``| INFO | Crash aggregation: 4 block(s) -> ...``(聚合器自己的记账行!)
+#: 都曾被判成崩溃。一条 INFO 按定义就不是崩溃记录,这条规则同时也用来判定
+#: "崩溃现场到哪儿结束"——日志回到正常流水,现场就结束了。
+_BENIGN_LEVEL_RE = re.compile(r"\|\s*(?:INFO|DEBUG|TRACE)\s*\|", re.IGNORECASE)
+
+
+def _is_crash_anchor(line: str) -> bool:
+    """该行是否可以作为崩溃块的起点。"""
+    if _BENIGN_LEVEL_RE.search(line):
+        return False
+    return bool(_STRUCTURAL_RE.search(line) or _LEVEL_TOKEN_RE.search(line))
+
+
+#: 单个崩溃块最多保留的行数(含起始行)。traceback 往往很长,给足。
 MAX_LINES_PER_BLOCK = 40
+
+#: 非 traceback 类(单行错误)崩溃块保留的后续上下文行数。
+#:
+#: 真机实证:此前不分类型一律取 40 行,结果一条 ``nats-server.zip 解压失败``
+#: 后面跟了 39 行毫不相干的 INFO 流水(节点启动、健康检查…),聚合视图里
+#: 真正有用的就头一行。单行错误给少量上下文即可。
+CONTEXT_LINES_SINGLE = 6
 
 #: 每个源日志最多提取的崩溃块数(取最近的)。
 MAX_BLOCKS_PER_SOURCE = 5
@@ -110,6 +168,25 @@ def _read_tail_lines(path: Path) -> list[str]:
         return fh.read().splitlines()
 
 
+def _collect_block(lines: list[str], idx: int) -> list[str]:
+    """从锚点行 ``idx`` 起,截出崩溃现场。
+
+    两条收尾规则,都是为了让块里**只有现场**、没有流水:
+
+    1. traceback 类给到 [MAX_LINES_PER_BLOCK] 行(调用栈本来就长);
+       单行错误类只给 [CONTEXT_LINES_SINGLE] 行上下文。
+    2. 一旦遇到级别为 INFO/DEBUG/TRACE 的行,说明日志已经回到正常流水,
+       崩溃现场就此结束——立即收尾,不再往下吞。
+    """
+    limit = MAX_LINES_PER_BLOCK if _STRUCTURAL_RE.search(lines[idx]) else 1 + CONTEXT_LINES_SINGLE
+    block = [lines[idx]]
+    for nxt in lines[idx + 1 : idx + limit]:
+        if _BENIGN_LEVEL_RE.search(nxt):
+            break
+        block.append(nxt)
+    return block
+
+
 def scan_source(path: Path, root: Path | None = None) -> list[CrashBlock]:
     """扫描单个日志文件,提取其中的崩溃块(最近 [MAX_BLOCKS_PER_SOURCE] 个)。"""
     root = root or log_root()
@@ -134,8 +211,8 @@ def scan_source(path: Path, root: Path | None = None) -> list[CrashBlock]:
     idx = 0
     total = len(lines)
     while idx < total:
-        if _CRASH_RE.search(lines[idx]):
-            block = lines[idx : idx + MAX_LINES_PER_BLOCK]
+        if _is_crash_anchor(lines[idx]):
+            block = _collect_block(lines, idx)
             blocks.append(
                 CrashBlock(
                     source=source,

--- a/core/electron_launch_guard.py
+++ b/core/electron_launch_guard.py
@@ -79,12 +79,92 @@ def resolve_gateway_port() -> int:
         return 9000
 
 
+_STILL_ACTIVE = 259  # Windows GetExitCodeProcess:进程仍在运行时的返回码
+
+
+def _pid_alive_windows(pid: int) -> bool:
+    """Windows 上【只读】判断 pid 是否仍在运行。
+
+    为什么不能用 ``os.kill(pid, 0)``(真机 16:12 那次启动的根因):
+    CPython 在 Windows 上的 ``os.kill`` 并不是发信号——除 CTRL_C_EVENT/
+    CTRL_BREAK_EVENT 外,它走的是 ``OpenProcess`` + **TerminateProcess(handle, sig)**。
+    也就是说 ``os.kill(pid, 0)`` 会把目标进程**以退出码 0 直接杀掉**,而不是探活。
+    这一个语义错误在所有者的 Windows 真机上同时炸出两种故障:
+
+    1. pid 已失效 → ``OpenProcess`` 报 ``[WinError 87] 参数错误``,该错误在
+       ``os.kill`` 里被包成 **SystemError**(<built-in function kill> returned a
+       result with an exception set),而 SystemError 不是 OSError 的子类,
+       原来的 ``except (OSError, ValueError)`` 接不住 → 异常一路上抛,
+       Phase 6 桌面壳阶段整个崩掉 → "Startup validation failed" CRITICAL、
+       系统降级启动。
+    2. pid 仍有效 → 刚刚拉起的 Electron 被 TerminateProcess 当场杀掉,
+       而函数还返回 True 说"它在跑"。
+
+    正解:``OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)`` 拿只读句柄,
+    再用 ``GetExitCodeProcess`` 看是否 STILL_ACTIVE。这条路径不会碰进程状态,
+    且能正确把"已退出但句柄尚未回收"的僵留 pid 判为**已死**——旧实现在这种
+    情况下 OpenProcess 是成功的,于是把死壳误报成活壳(见保活器空转的根因)。
+
+    已知边角:进程若恰好以退出码 259 结束,会与 STILL_ACTIVE 撞值而被判成活着。
+    这是 Win32 API 本身的固有歧义;对桌面壳(Electron/npm)而言实际不会发生,
+    且即便发生,后果也只是本轮少重启一次,不会像旧实现那样误杀进程。
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    process_query_limited_information = 0x1000
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    # 必须显式声明签名:ctypes 默认按 C int 处理返回值,而 64 位 Windows 上
+    # HANDLE 是 64 位——不声明会把句柄**截断**,后续 GetExitCodeProcess/
+    # CloseHandle 拿到的是坏句柄(既查不到状态,也漏掉句柄)。
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return False
+    try:
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return False
+        return code.value == _STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def _pid_alive(pid: int) -> bool:
+    """跨平台【只读】探活:活着返回 True。任何不确定一律当作已死(宁可多起一次壳,
+    也不要把死锁当活锁——后者会让保活重启彻底空转)。"""
+    if pid <= 0:
+        return False
+    try:
+        if os.name == "nt":
+            return _pid_alive_windows(pid)
+        os.kill(pid, 0)  # POSIX 分支:0 号信号确实是标准探活语义
+        return True
+    except Exception:  # noqa: BLE001
+        # 一律吞掉,原因见下。这里绝不能只接 OSError:
+        # - Windows: OpenProcess 的错误会被包成 SystemError(非 OSError);
+        # - POSIX:  锁文件里若是个超大数字,os.kill 抛的是 **OverflowError**
+        #           ("Python int too large to convert to C long")——同样不是
+        #           OSError,同样会一路上抛把启动预检判死。
+        # 探活失败一律按"已死"处理:大不了多起一次壳,总好过把死锁当活锁。
+        return False
+
+
 def already_running() -> bool:
     """检查是否已有另一条启动路径持有存活的桌面壳锁。
 
     调用方应在做任何"是否要启动"的判断(乃至 npm install 探测)之前先调用这个函数,
     是则直接跳过,避免重复起第二个 Electron/Tauri 子进程。
     死进程留下的陈旧锁会被自动清理。
+
+    本函数【绝不抛异常】:它被 Phase 6 等启动关键路径直接调用,一旦上抛就会把
+    整个启动预检判为失败(真机实证)。任何异常都按"没有存活的壳"处理。
     """
     path = lock_path()
     if not os.path.exists(path):
@@ -92,14 +172,28 @@ def already_running() -> bool:
     try:
         with open(path, encoding="utf-8") as f:
             existing_pid = int(f.read().strip())
-        os.kill(existing_pid, 0)  # 存活则不抛异常;POSIX/Windows 均可用
-        return True
     except (OSError, ValueError):
-        try:
-            os.remove(path)
-        except OSError:
-            pass
+        clear_lock()
         return False
+    if _pid_alive(existing_pid):
+        return True
+    clear_lock()
+    return False
+
+
+def clear_lock() -> None:
+    """删除桌面壳锁。
+
+    保活器在**观察到自己拉起的壳进程已退出**时必须调用它:否则陈旧锁会让
+    ``start_tauri()`` 的 ``already_running()`` 早退分支返回 True,
+    ``start_desktop_shell()` 随之短路,**根本不会再去拉 Electron**——真机上
+    13 条"Electron 已退出,重启中"对应的 electron.log 里只有一个启动标记,
+    GPU→软件渲染→basic 三级降级全程空转,就是这么来的。
+    """
+    try:
+        os.remove(lock_path())
+    except OSError:
+        pass
 
 
 def write_lock(pid: int) -> None:

--- a/core/nats_server.py
+++ b/core/nats_server.py
@@ -153,6 +153,18 @@ class EmbeddedNATSServer:
                 nats_dir = Path.home() / ".lumiv" / "bin"
                 nats_dir.mkdir(parents=True, exist_ok=True)
                 nats_exe = nats_dir / "nats-server.exe"
+
+                # 已经装过就直接复用,不要再下一遍。
+                # 真机实证:~/.lumiv/bin 在用户主目录里,重新克隆仓库也不会清掉,
+                # 于是 nats-server.exe 明明躺在那儿,每次启动仍照常走完整下载流程
+                # ——白等 30s("[PHASE-TIMING] 消息总线 30.44s" 基本全耗在这),
+                # 末了还因为目标文件已存在而抛 WinError 183 刷一条 ERROR。
+                # 入口处的 shutil.which("nats-server") 看不到它,只是因为
+                # ~/.lumiv/bin 本来就不在 PATH 上——那不代表"没装"。
+                if nats_exe.is_file() and nats_exe.stat().st_size > 0:
+                    os.environ["PATH"] = str(nats_dir) + os.pathsep + os.environ.get("PATH", "")
+                    logger.info("nats-server 已安装,复用 %s(跳过下载)", nats_exe)
+                    return True
                 # PR-NATS-CN: 使用国内镜像源加速下载，支持超时重试
                 tag = "v2.10.24"  # 固定已知可用版本，避免API调用
                 zip_name = f"nats-server-{tag}-windows-amd64.zip"
@@ -221,7 +233,18 @@ class EmbeddedNATSServer:
                                 if name.endswith("nats-server.exe"):
                                     z.extract(name, nats_dir)
                                     extracted = nats_dir / name
-                                    extracted.rename(nats_exe)
+                                    # os.replace 而不是 Path.rename:后者在 Windows 上
+                                    # 只要目标已存在就抛 [WinError 183] 当文件已存在时,
+                                    # 无法创建该文件(真机实证)——POSIX 的 rename 会静默
+                                    # 覆盖,这个差异让整段解压在 Windows 上必然失败。
+                                    # os.replace 两个平台都是"原子覆盖"。
+                                    os.replace(extracted, nats_exe)
+                                    # 顺手清掉解压出来的中间目录
+                                    # (nats-server-<tag>-windows-amd64/),
+                                    # 否则每次安装都往 ~/.lumiv/bin 里堆一层空壳目录。
+                                    parent = extracted.parent
+                                    if parent != nats_dir:
+                                        shutil.rmtree(parent, ignore_errors=True)
                                     break
                         zip_path.unlink(missing_ok=True)
                     except Exception as e:  # noqa: BLE001

--- a/core/system_orchestrator.py
+++ b/core/system_orchestrator.py
@@ -685,6 +685,19 @@ class SystemOrchestrator:
                     detail=electron_binary_fix_hint("electron"),
                 )
 
+        # 拉起用的必须是 shutil.which 解析出来的**绝对路径**,不能是裸 "npm"。
+        # 真机实证(同一次启动里自相矛盾的两行):Phase 0 打了 `✓ npm`,Phase 6 却报
+        # `DEGRADED — npm not found`。根因是 Windows 上 npm 实际叫 `npm.cmd`,
+        # 而 CreateProcess **不套用 PATHEXT** —— 裸 "npm" 必然 FileNotFoundError,
+        # 于是被下面的 except 判成"没装 Node.js",给出一个完全错误的诊断。
+        # 上面 npm install 那两处早就用的是 npm_path,只有这里漏了。
+        if not npm_path:
+            return PhaseResult(
+                phase=StartupPhase.DESKTOP_SURFACE,
+                status=PhaseStatus.DEGRADED,
+                detail="Electron GUI skipped (npm not in PATH — Node.js installed but npm missing)",
+            )
+
         # Launch Electron as detached subprocess
         try:
             env = os.environ.copy()
@@ -697,7 +710,7 @@ class SystemOrchestrator:
 
             # Use shell=False for security; npm start will run electron .
             process = subprocess.Popen(
-                ["npm", "start"],
+                [npm_path, "start"],
                 cwd=electron_dir,
                 env=env,
                 stdout=subprocess.PIPE,
@@ -728,11 +741,14 @@ class SystemOrchestrator:
                 data={"electron_pid": process.pid},
             )
 
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
+            # 走到这里说明 shutil.which 找到的那个 npm 路径**自己**起不来
+            # (被删/权限/损坏),而不是"没装 Node.js" —— 如实说出真正缺的东西,
+            # 别再给用户一个去装 Node.js 的错误指引(它明明装着)。
             return PhaseResult(
                 phase=StartupPhase.DESKTOP_SURFACE,
                 status=PhaseStatus.DEGRADED,
-                detail="npm not found -- install Node.js to enable GUI",
+                detail=f"无法执行 npm({npm_path}): {exc}",
             )
         except Exception as exc:
             return PhaseResult(

--- a/electron/main.js
+++ b/electron/main.js
@@ -111,7 +111,11 @@ function resolveGatewayPort() {
     return 9000;
 }
 const GATEWAY_PORT = resolveGatewayPort();
-const GATEWAY_BASE = `http://localhost:${GATEWAY_PORT}`;
+// 刻意用 127.0.0.1 而不是 localhost:网关(uvicorn)绑的是 `0.0.0.0`,那是
+// **仅 IPv4** 的监听。而 Windows 上 `localhost` 会先解析到 IPv6 的 ::1,
+// 走到那一侧只会 ECONNREFUSED。127.0.0.1 直指 IPv4 环回,不给解析顺序留活口。
+const GATEWAY_HOST = '127.0.0.1';
+const GATEWAY_BASE = `http://${GATEWAY_HOST}:${GATEWAY_PORT}`;
 let ipcHttpServer = null;
 
 // 桌面连续感知（摄像头/麦克风/屏幕）。
@@ -207,6 +211,36 @@ async function _gatewayHealthy(timeoutMs = BACKEND_HEALTH_TIMEOUT_MS) {
     }
 }
 
+// 端口上是否已经有人在监听(纯 TCP 连通性,不关心对方是不是我们的网关)。
+// 这是"该不该再拉一套后端"的唯一可靠判据:端口被占时再 spawn 一套必然抢不到,
+// 只会白白多跑一整套系统然后以 10048 崩掉。
+function _portOccupied(timeoutMs = 1200) {
+    return new Promise((resolve) => {
+        const net = require('net');
+        const sock = new net.Socket();
+        let settled = false;
+        const done = (v) => { if (!settled) { settled = true; sock.destroy(); resolve(v); } };
+        sock.setTimeout(timeoutMs);
+        sock.once('connect', () => done(true));
+        sock.once('timeout', () => done(false));
+        sock.once('error', () => done(false));
+        sock.connect(GATEWAY_PORT, GATEWAY_HOST);
+    });
+}
+
+// 端口有人监听时,耐心等它把 /health 服务起来。
+// 为什么需要"耐心":真机上后端起来后还会继续跑 Podman 拉镜像、下载 NATS、
+// 把本地大模型载进内存(无独显时纯 CPU 推理)——这些阶段会把机器压满,
+// 单次 2.5s 的探测超时根本不能证明"网关不存在"。
+async function _waitForGateway(budgetMs) {
+    const start = Date.now();
+    while (Date.now() - start < budgetMs) {
+        if (await _gatewayHealthy()) return true;
+        await new Promise((r) => setTimeout(r, BACKEND_POLL_INTERVAL_MS));
+    }
+    return false;
+}
+
 async function ensureGatewayOnline(autoStart = true) {
     const alreadyHealthy = await _gatewayHealthy();
     if (alreadyHealthy) {
@@ -221,6 +255,26 @@ async function ensureGatewayOnline(autoStart = true) {
     backendStartPromise = (async () => {
         const nowHealthy = await _gatewayHealthy();
         if (nowHealthy) return { ok: true, reused: true };
+
+        // ── 端口已被占用 → 绝不再拉第二套后端 ──
+        // 真机实证(所有者 Windows 日志):这里原本不做任何检查,单次 /health 探测
+        // 失败就 spawn `launch_desktop.py --backend`,而它会把 **整个 main.py**
+        // 再拉起一遍去抢同一个 9000 端口,结果必然是
+        // `[Errno 10048] ... 通常每个套接字地址只允许使用一次` —— 第二套系统白跑
+        // 一遍再自杀,而真正健康的第一套后端始终好好地在那儿。
+        // 端口上有人监听 = 已经有网关(或别的进程)拥有它,此时唯一正确的动作是等,
+        // 不是再造一个必然失败的竞争者。
+        if (await _portOccupied()) {
+            const ok = await _waitForGateway(BACKEND_START_TIMEOUT_MS);
+            if (ok) return { ok: true, reused: true };
+            backendLastError =
+                `端口 ${GATEWAY_PORT} 已被占用,但 ${GATEWAY_BASE}/health 在 ` +
+                `${Math.round(BACKEND_START_TIMEOUT_MS / 1000)}s 内始终未就绪。` +
+                '已【跳过】重复拉起后端(再起一套只会因端口冲突失败)。' +
+                '若该端口被其它程序占用,请换端口或结束占用进程后重试。';
+            return { ok: false, error: backendLastError, portBusy: true };
+        }
+
         const py = _pythonExec();
         const script = path.join(PROJECT_ROOT, 'launch_desktop.py');
         const args = [script, ...BACKEND_START_ARGS];
@@ -475,21 +529,25 @@ app.whenReady().then(async () => {
     }
 
     const gatewayReady = await ensureGatewayOnline(true);
+
+    // 先把窗口建起来,再提示 —— 顺序不能反。
+    // 原先是 `await dialog.showMessageBox(...)` 挡在 createWindow() 前面:
+    // 那个模态框要等用户点掉才 resolve,没人点(比如覆盖层还没显示、用户压根
+    // 没看见它)就永远卡在这儿,三态覆盖层一个窗口都建不出来。
+    // 网关没就绪是**可降级**状态,不该连壳都不给。
+    createWindow();
+
     if (!gatewayReady.ok) {
         console.error('[Main] 网关不可达:', gatewayReady.error || `${GATEWAY_BASE} not ready`);
-        try {
-            await dialog.showMessageBox({
-                type: 'warning',
-                title: 'Galaxy 网关未就绪',
-                message: '后端网关未成功连接',
-                detail:
-                    `${gatewayReady.error || `无法连接 ${GATEWAY_BASE}`}\n\n` +
-                    '你可以在设置页点击“重试启动网关”再次尝试，并检查 logs/gateway.log。',
-            });
-        } catch (_e) {}
+        dialog.showMessageBox({
+            type: 'warning',
+            title: 'Galaxy 网关未就绪',
+            message: '后端网关未成功连接',
+            detail:
+                `${gatewayReady.error || `无法连接 ${GATEWAY_BASE}`}\n\n` +
+                '你可以在设置页点击“重试启动网关”再次尝试，并检查 logs/gateway.log。',
+        }).catch(() => {});
     }
-
-    createWindow();
 
     // ── IPC HTTP 接收端 ──
     // Python 后端 POST /ipc/presence-state → 转发到前端 via ipcMain

--- a/launch_desktop.py
+++ b/launch_desktop.py
@@ -379,7 +379,15 @@ def phase1_ensure_dependencies(status: dict, args) -> bool:
     # 1.4 Electron 依赖
     if not status["electron_deps_ok"]:
         logger.info("  cd electron && npm install ...")
-        rc, out, err = run(["npm", "install"], cwd=ELECTRON_DIR, timeout=120, capture=True)
+        # 同 start_electron_frontend():必须用 which 解析出的绝对路径。
+        # Windows 上 npm 是 `npm.cmd`,CreateProcess 不套用 PATHEXT,裸 "npm"
+        # 会让 run() 返回 (-2, "command not found"),报成"依赖安装失败"——
+        # 而 npm 其实好端端装着。
+        _npm = shutil.which("npm")
+        if not _npm:
+            rc, out, err = -2, "", "npm 未安装或不在 PATH"
+        else:
+            rc, out, err = run([_npm, "install"], cwd=ELECTRON_DIR, timeout=120, capture=True)
         if rc == 0:
             ok("Electron 依赖安装完成 ✓")
             status["electron_deps_ok"] = True

--- a/main.py
+++ b/main.py
@@ -474,10 +474,15 @@ def phase0_env_check() -> dict:
     status["api_keys_configured"] = api_count
 
     # npm
-    npm_ok = shutil.which("npm") is not None
+    # 用 which 解析出的**绝对路径**去调用,不能传裸 "npm"。
+    # Windows 上 npm 实际是 `npm.cmd`,而 CreateProcess 不套用 PATHEXT ——
+    # 裸 "npm" 必抛 FileNotFoundError,被下面的 except 吞掉后打出一个
+    # 没有版本号的 "✓ npm"。真机日志里 Node.js 有版本、npm 没有,就是这个指纹。
+    npm_exe = shutil.which("npm")
+    npm_ok = npm_exe is not None
     if npm_ok:
         try:
-            rc = sp.run(["npm", "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5)
+            rc = sp.run([npm_exe, "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5)
             npm_ver = rc.stdout.strip() if rc.returncode == 0 else "?"
             print_item("npm", "ok", npm_ver)
         except Exception:

--- a/tests/test_windows_launch_recovery.py
+++ b/tests/test_windows_launch_recovery.py
@@ -144,6 +144,28 @@ def test_probe_port_bindable_detects_occupied_port():
     assert _probe_port_bindable("127.0.0.1", port) == ""
 
 
+def test_probe_port_does_not_invent_wildcard_bind():
+    """host 为空时不得凭空绑到全网卡(CodeQL:Binding a socket to all interfaces)。
+
+    探测的意义是"预测 uvicorn 那次 bind 会不会成功",所以应当绑调用方给的那个
+    地址;没给地址就退回环回口,而不是替调用方决定去监听 0.0.0.0。
+    """
+    import inspect
+
+    import unified_launcher
+
+    src = inspect.getsource(unified_launcher._probe_port_bindable)
+    code = "\n".join(ln for ln in src.splitlines() if not ln.strip().startswith("#"))
+    body = code.split('"""')[-1]  # 去掉 docstring,只看真正的代码
+    assert "0.0.0.0" not in body, "端口预检不应出现全网卡字面量"
+
+    # 空 host 仍要能正确识别环回口上的占用
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as busy:
+        busy.bind(("127.0.0.1", 0))
+        busy.listen(1)
+        assert unified_launcher._probe_port_bindable("", busy.getsockname()[1])
+
+
 # ── 3. Electron:端口被占时绝不再拉一套后端 ────────────────────────────
 
 

--- a/tests/test_windows_launch_recovery.py
+++ b/tests/test_windows_launch_recovery.py
@@ -137,33 +137,47 @@ def test_probe_port_bindable_detects_occupied_port():
         busy.bind(("127.0.0.1", 0))
         busy.listen(1)
         port = busy.getsockname()[1]
-        reason = _probe_port_bindable("127.0.0.1", port)
+        reason = _probe_port_bindable(port)
         assert reason, "端口已被占用时必须返回失败原因"
 
     # 占用者关闭后同一端口应重新可绑
-    assert _probe_port_bindable("127.0.0.1", port) == ""
+    assert _probe_port_bindable(port) == ""
 
 
-def test_probe_port_does_not_invent_wildcard_bind():
-    """host 为空时不得凭空绑到全网卡(CodeQL:Binding a socket to all interfaces)。
+def test_probe_port_detects_wildcard_holder_without_binding_wildcard():
+    """别人占着 0.0.0.0:P 时,只探环回口也必须能识别出来。
 
-    探测的意义是"预测 uvicorn 那次 bind 会不会成功",所以应当绑调用方给的那个
-    地址;没给地址就退回环回口,而不是替调用方决定去监听 0.0.0.0。
+    这条是"只探环回口"这个设计成立的前提:只要不开 SO_REUSEADDR,通配绑定
+    与具体地址绑定在同一端口上互斥,所以环回探测足以覆盖真机那个场景
+    (Electron 拉起第二套后端去抢已被占用的 9000)。
+    """
+    from unified_launcher import _probe_port_bindable
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as wildcard:
+        wildcard.bind(("0.0.0.0", 0))  # 模拟 uvicorn 的真实监听形态
+        wildcard.listen(1)
+        port = wildcard.getsockname()[1]
+        assert _probe_port_bindable(port), "通配监听占着的端口必须被判为不可绑"
+
+
+def test_probe_port_never_binds_all_interfaces():
+    """端口预检自身绝不绑通配地址(CodeQL:Binding a socket to all interfaces)。
+
+    真要防的是"本机已有一个 Galaxy 占着这个端口",环回探测就够;为此开一个
+    全网卡绑定既无必要也是真实的攻击面。
     """
     import inspect
 
     import unified_launcher
 
-    src = inspect.getsource(unified_launcher._probe_port_bindable)
-    code = "\n".join(ln for ln in src.splitlines() if not ln.strip().startswith("#"))
-    body = code.split('"""')[-1]  # 去掉 docstring,只看真正的代码
-    assert "0.0.0.0" not in body, "端口预检不应出现全网卡字面量"
+    body = inspect.getsource(unified_launcher._probe_port_bindable).split('"""')[-1]
+    assert "0.0.0.0" not in body, "端口预检代码体内不应出现通配监听地址"
 
-    # 空 host 仍要能正确识别环回口上的占用
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as busy:
-        busy.bind(("127.0.0.1", 0))
-        busy.listen(1)
-        assert unified_launcher._probe_port_bindable("", busy.getsockname()[1])
+    # bind 的地址必须来自那个写死为环回口的常量,而不是任何可能为空/通配的变量
+    bind_lines = [ln.strip() for ln in body.splitlines() if ".bind(" in ln]
+    assert len(bind_lines) == 1, f"预期恰好一处 bind,实际 {bind_lines}"
+    assert "_PORT_PROBE_HOST" in bind_lines[0], f"bind 地址应为 _PORT_PROBE_HOST:{bind_lines[0]}"
+    assert unified_launcher._PORT_PROBE_HOST == "127.0.0.1"
 
 
 # ── 3. Electron:端口被占时绝不再拉一套后端 ────────────────────────────

--- a/tests/test_windows_launch_recovery.py
+++ b/tests/test_windows_launch_recovery.py
@@ -1,0 +1,349 @@
+"""所有者 Windows 真机启动日志(2026-07-28 16:10~16:13)暴露问题的回归测试。
+
+那一次启动的因果链是:
+
+    os.kill(pid, 0) 在 Windows 上其实是 TerminateProcess
+      ├─ pid 已失效 → WinError 87 包成 SystemError 逃出 except(OSError, ValueError)
+      │                → Phase 6 崩 → "Startup validation failed" CRITICAL
+      └─ 陈旧锁被当成"壳还活着" → start_tauri() 早退 True → start_desktop_shell()
+                                 短路 → 13 次"重启中"一次都没真的重启
+
+    Electron 单次 /health 探测失败 → spawn 第二套完整后端去抢 9000
+      → [Errno 10048] → 网关不可达 → 覆盖层彻底放弃
+
+    崩溃聚合器把一句提到 "CRITICAL" 的**建议文案**当成崩溃锚点
+      → 指纹错位 → 同一个崩溃在聚合视图里出现两次
+
+本文件逐条钉死修复后的行为。
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+# ── 1. 桌面壳锁:只读探活,绝不误杀、绝不上抛 ──────────────────────────
+
+
+@pytest.fixture()
+def temp_lock(tmp_path, monkeypatch):
+    """把桌面壳锁指到临时文件,避免污染项目根的 .electron.pid。"""
+    import core.electron_launch_guard as guard
+
+    lock = tmp_path / ".electron.pid"
+    monkeypatch.setattr(guard, "lock_path", lambda: str(lock))
+    return lock
+
+
+def _dead_pid() -> int:
+    """拿一个确定已经退出且已被回收的 pid。"""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+def test_pid_alive_reports_self_alive():
+    import os as _os
+
+    from core.electron_launch_guard import _pid_alive
+
+    assert _pid_alive(_os.getpid()) is True
+
+
+def test_pid_alive_reports_dead_pid_dead():
+    from core.electron_launch_guard import _pid_alive
+
+    assert _pid_alive(_dead_pid()) is False
+
+
+def test_pid_alive_rejects_nonpositive_pid():
+    """pid<=0 在 POSIX 上是"整个进程组"的意思,绝不能当成普通探活放行。"""
+    from core.electron_launch_guard import _pid_alive
+
+    assert _pid_alive(0) is False
+    assert _pid_alive(-1) is False
+
+
+def test_already_running_never_raises_on_garbage_lock(temp_lock):
+    """锁文件内容损坏时必须安静返回 False。
+
+    它被 Phase 6 直接调用,一旦上抛就会把整个启动预检判为失败(真机实证:
+    SystemError 逃出 except 子句 → Startup validation failed CRITICAL)。
+    """
+    from core.electron_launch_guard import already_running
+
+    for garbage in ("", "   ", "not-a-pid", "12 34", "9999999999999999999999"):
+        temp_lock.write_text(garbage, encoding="utf-8")
+        assert already_running() is False
+
+
+def test_already_running_clears_stale_lock(temp_lock):
+    """死进程留下的锁必须被清掉 —— 否则保活重启会永远空转。"""
+    from core.electron_launch_guard import already_running
+
+    temp_lock.write_text(str(_dead_pid()), encoding="utf-8")
+    assert already_running() is False
+    assert not temp_lock.exists(), "陈旧锁必须被清理,否则 start_tauri 会一直早退"
+
+
+def test_already_running_true_for_live_pid_without_killing_it(temp_lock):
+    """活着的壳要被认出来,而且**探完还得活着**。
+
+    旧实现在 Windows 上会把它 TerminateProcess 掉再返回 True。这里用一个真实
+    的子进程验证探活是只读的。
+    """
+    from core.electron_launch_guard import already_running
+
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        temp_lock.write_text(str(proc.pid), encoding="utf-8")
+        assert already_running() is True
+        assert proc.poll() is None, "探活绝不允许杀掉被探测的进程"
+    finally:
+        proc.kill()
+        proc.wait()
+
+
+def test_guard_does_not_use_os_kill_as_windows_liveness_probe():
+    """生产代码里不得再出现 `os.kill(pid, 0)` 式的跨平台探活。
+
+    Windows 上它走的是 TerminateProcess —— 这是本次真机故障的总根因。
+    POSIX 分支里的 os.kill 是合法的,故只禁止"无平台判断"的用法:
+    要求 os.kill 出现处的上下文里有 POSIX 分支标记。
+    """
+    src = (REPO / "core" / "electron_launch_guard.py").read_text(encoding="utf-8")
+    # 只看真正的调用语句(行首就是 os.kill(),排除文档/注释里对它的讨论)
+    calls = [(lineno, line) for lineno, line in enumerate(src.splitlines(), 1) if line.strip().startswith("os.kill(")]
+    assert calls, "预期 POSIX 分支仍保留 os.kill 探活"
+    for lineno, line in calls:
+        assert "POSIX" in line, f"electron_launch_guard.py:{lineno} 的 os.kill 缺少 POSIX 限定"
+
+
+# ── 2. 端口预检 ────────────────────────────────────────────────────────
+
+
+def test_probe_port_bindable_detects_occupied_port():
+    from unified_launcher import _probe_port_bindable
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as busy:
+        busy.bind(("127.0.0.1", 0))
+        busy.listen(1)
+        port = busy.getsockname()[1]
+        reason = _probe_port_bindable("127.0.0.1", port)
+        assert reason, "端口已被占用时必须返回失败原因"
+
+    # 占用者关闭后同一端口应重新可绑
+    assert _probe_port_bindable("127.0.0.1", port) == ""
+
+
+# ── 3. Electron:端口被占时绝不再拉一套后端 ────────────────────────────
+
+
+def _main_js() -> str:
+    return (REPO / "electron" / "main.js").read_text(encoding="utf-8")
+
+
+def test_electron_probes_port_before_spawning_backend():
+    """spawn 后端之前必须先探端口占用 —— 否则就是真机那次的 10048。"""
+    src = _main_js()
+    assert "_portOccupied" in src, "缺少端口占用探测"
+    # 用真正的 spawn 语句定位,而不是注释里对它的引用
+    spawn_at = src.index("path.join(PROJECT_ROOT, 'launch_desktop.py')")
+    probe_at = src.index("await _portOccupied()")
+    assert probe_at < spawn_at, "端口占用探测必须排在拉起后端之前"
+
+
+def test_electron_gateway_base_pins_ipv4_loopback():
+    """网关绑的是 0.0.0.0(仅 IPv4);客户端用 localhost 可能先解析到 ::1。"""
+    src = _main_js()
+    assert "const GATEWAY_HOST = '127.0.0.1';" in src
+    assert "http://localhost:${GATEWAY_PORT}`;" not in src
+
+
+def test_electron_creates_window_before_warning_dialog():
+    """网关未就绪是可降级状态,不能因为一个没人点的模态框而连壳都不建。"""
+    src = _main_js()
+    create_at = src.index("createWindow();")
+    dialog_at = src.index("title: 'Galaxy 网关未就绪'")
+    assert create_at < dialog_at, "createWindow() 必须排在告警模态框之前"
+
+
+# ── 4. 崩溃聚合器:锚点必须是真的崩溃 ──────────────────────────────────
+
+
+@pytest.fixture()
+def temp_log_root(tmp_path, monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("GALAXY_LOG_DIR", str(tmp_path))
+    import core.log_paths as lp
+
+    importlib.reload(lp)
+    yield tmp_path
+    monkeypatch.delenv("GALAXY_LOG_DIR", raising=False)
+    importlib.reload(lp)
+
+
+def test_advice_text_mentioning_critical_is_not_a_crash(temp_log_root):
+    """真机原句:预检建议里提到 CRITICAL,被当成了崩溃锚点。"""
+    from core.crash_log_aggregator import aggregate_crashes
+
+    (temp_log_root / "gateway.log").write_text(
+        "GALAXY_REQUIRE_API_TOKEN=true makes a missing token CRITICAL even with auth off "
+        "(staging). Without it, any client can command the API when auth is off.\n"
+        "  ✓  All CRITICAL checks passed.\n",
+        encoding="utf-8",
+    )
+    _, count = aggregate_crashes()
+    assert count == 0, "建议/汇总文案里的 CRITICAL 不是崩溃"
+
+
+def test_info_level_lines_are_never_crash_anchors(temp_log_root):
+    """INFO 行按定义就不是崩溃记录 —— 含聚合器自己的记账行。"""
+    from core.crash_log_aggregator import aggregate_crashes
+
+    (temp_log_root / "lumiv.log").write_text(
+        "16:11:59 | INFO | 注册安全规则: 高度限制检查 (critical)\n"
+        "16:12:24 | INFO | Crash aggregation: 4 block(s) -> logs\\crashes\\latest.log\n",
+        encoding="utf-8",
+    )
+    _, count = aggregate_crashes()
+    assert count == 0
+
+
+def test_same_crash_in_two_logs_merges_despite_different_context(temp_log_root):
+    """同一崩溃分别落在两个日志、前后文不同,聚合视图里只能有一条。
+
+    真机复现:gateway.log 里它前面是一段建议文案、lumiv.log 里前面是别的 INFO,
+    旧实现在 gateway.log 那侧锚到了建议文案上,于是同一个崩溃出现了两次。
+    """
+    from core.crash_log_aggregator import aggregate_crashes
+
+    crash = "16:12:09 | CRITICAL | Startup validation failed: <built-in function kill> returned a result\n"
+    (temp_log_root / "gateway.log").write_text(
+        "GALAXY_REQUIRE_API_TOKEN=true makes a missing token CRITICAL even with auth off\n" + crash,
+        encoding="utf-8",
+    )
+    (temp_log_root / "lumiv.log").write_text("16:12:08 | WARNING | 别的上下文\n" + crash, encoding="utf-8")
+
+    path, count = aggregate_crashes()
+    assert count == 1, "同一崩溃跨来源必须合并为一条"
+    body = path.read_text(encoding="utf-8")
+    assert "gateway.log" in body and "lumiv.log" in body
+
+
+def test_single_line_error_block_stops_at_normal_flow(temp_log_root):
+    """单行错误不该把后面几十行正常流水一并吞进崩溃块。"""
+    from core.crash_log_aggregator import aggregate_crashes
+
+    noise = "".join(f"16:11:5{i % 10} | INFO | 服务已启动: Node_{i:02d}\n" for i in range(30))
+    (temp_log_root / "lumiv.log").write_text(
+        "16:11:44 | ERROR | nats-server.zip 解压失败: [WinError 183] 当文件已存在时\n" + noise,
+        encoding="utf-8",
+    )
+    path, count = aggregate_crashes()
+    assert count == 1
+    body = path.read_text(encoding="utf-8")
+    assert "WinError 183" in body
+    assert "服务已启动" not in body, "崩溃块不应吞入正常流水日志"
+
+
+def test_traceback_block_keeps_full_stack(temp_log_root):
+    """traceback 要完整保留 —— 收窄单行块的同时不能把调用栈砍掉。"""
+    from core.crash_log_aggregator import aggregate_crashes
+
+    tb = (
+        "Traceback (most recent call last):\n"
+        '  File "main.py", line 366, in _run_orchestrator_preflight\n'
+        "    summary = orch.run_startup_sequence()\n"
+        '  File "core/electron_launch_guard.py", line 95, in already_running\n'
+        "    os.kill(existing_pid, 0)\n"
+        "SystemError: <built-in function kill> returned a result with an exception set\n"
+    )
+    (temp_log_root / "gateway.log").write_text(tb, encoding="utf-8")
+    path, _ = aggregate_crashes()
+    body = path.read_text(encoding="utf-8")
+    assert "SystemError" in body, "traceback 末尾的异常类型必须保留"
+    assert "already_running" in body
+
+
+# ── 5. Windows 上 npm 是 npm.cmd:不许用裸 "npm" 起子进程 ────────────────
+
+
+def test_no_production_path_spawns_bare_npm():
+    """所有拉起 npm 的地方都必须先经 ``shutil.which`` 解析成绝对路径。
+
+    根因:Windows 上 npm 实际是 ``npm.cmd``,而 CreateProcess **不套用 PATHEXT**
+    —— 传裸 ``"npm"`` 必然 FileNotFoundError。真机上的两条后果:
+
+    - Phase 6 因此报 ``DEGRADED — npm not found``,与同一次启动 Phase 0 的
+      ``✓ npm`` 直接打架,给出完全错误的诊断(让用户去装明明装着的 Node.js);
+    - Phase 0 那条 ``✓ npm`` **不带版本号**(Node.js 那条有),正是裸调用已经
+      抛异常被 except 吞掉的指纹。
+
+    唯一豁免:显式 ``shell=True`` 的调用(shell 会自己套 PATHEXT)。
+    """
+    offenders: list[str] = []
+    for rel in ("main.py", "launch_desktop.py", "unified_launcher.py"):
+        _scan_bare_npm(REPO / rel, offenders)
+    for sub in ("core", "windows_service"):
+        for path in sorted((REPO / sub).rglob("*.py")):
+            _scan_bare_npm(path, offenders)
+    assert not offenders, "以下位置仍用裸 npm 起子进程:\n" + "\n".join(offenders)
+
+
+def _scan_bare_npm(path: Path, offenders: list[str]) -> None:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return
+    for lineno, line in enumerate(lines, 1):
+        # 只认"把 npm 当 argv 首元素"的写法(["npm", ...] / ['npm']);
+        # shutil.which("npm") 这类解析调用正是我们想要的,不能误判。
+        if not re.search(r"""\[\s*["']npm["']\s*[,\]]""", line) or line.strip().startswith("#"):
+            continue
+        # 取该调用前后若干行判断是否显式 shell=True
+        window = "\n".join(lines[max(0, lineno - 4) : lineno + 4])
+        if "shell=True" in window:
+            continue
+        offenders.append(f"{path.relative_to(REPO)}:{lineno}: {line.strip()[:90]}")
+
+
+def test_orchestrator_phase6_launches_npm_by_resolved_path():
+    src = (REPO / "core" / "system_orchestrator.py").read_text(encoding="utf-8")
+    assert '[npm_path, "start"]' in src
+    assert '["npm", "start"]' not in src
+
+
+# ── 6. nats-server 安装:已装即复用、覆盖用 os.replace ──────────────────
+
+
+def test_nats_install_reuses_existing_binary_and_replaces_atomically():
+    """真机:exe 已在 ~/.lumiv/bin,每次启动仍白下 30s,末了 WinError 183。"""
+    src = (REPO / "core" / "nats_server.py").read_text(encoding="utf-8")
+    assert "复用" in src and "跳过下载" in src, "缺少'已安装即复用'的短路"
+    assert "os.replace(extracted, nats_exe)" in src, "覆盖必须用 os.replace"
+    assert "extracted.rename(nats_exe)" not in src, "Path.rename 在 Windows 上目标已存在必抛 WinError 183"
+
+
+# ── 6. 就绪横幅指路与托盘实际条目一致 ─────────────────────────────────
+
+
+def test_ready_banner_points_at_existing_tray_entries():
+    launcher = (REPO / "unified_launcher.py").read_text(encoding="utf-8")
+    tray = (REPO / "windows_service" / "tray_icon.py").read_text(encoding="utf-8")
+
+    banner_rows = [ln for ln in launcher.splitlines() if '("日志"' in ln or '("崩溃"' in ln]
+    assert banner_rows, "就绪横幅应给出日志指路"
+    joined = "\n".join(banner_rows)
+    assert "三态动画日志" not in joined, "该托盘入口已在日志统一时移除,横幅不能再指向它"
+    assert "崩溃日志" in joined and "崩溃日志" in tray
+    assert "View Logs" in joined and "View Logs" in tray

--- a/tests/test_windows_launch_recovery.py
+++ b/tests/test_windows_launch_recovery.py
@@ -150,14 +150,20 @@ def test_probe_port_detects_wildcard_holder_without_binding_wildcard():
     这条是"只探环回口"这个设计成立的前提:只要不开 SO_REUSEADDR,通配绑定
     与具体地址绑定在同一端口上互斥,所以环回探测足以覆盖真机那个场景
     (Electron 拉起第二套后端去抢已被占用的 9000)。
+
+    这里的通配 bind 是**刻意**的,也是本用例的全部意义所在——不真的造一个
+    uvicorn 那种形态的占用者,就无从验证这个前提,只能靠"我认为"。
+    CodeQL 会就此报 py/bind-socket-all-network-interfaces:属实,但已把实际
+    暴露面压到零 —— 端口号取 0(临时端口)、**刻意不 listen**(端口占用在
+    bind() 时就已成立,不 listen 则永远不可能被任何人连上)、且随 with 立即
+    关闭。仅限测试进程内存活数毫秒。
     """
     from unified_launcher import _probe_port_bindable
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as wildcard:
-        wildcard.bind(("0.0.0.0", 0))  # 模拟 uvicorn 的真实监听形态
-        wildcard.listen(1)
+        wildcard.bind(("0.0.0.0", 0))  # 模拟 uvicorn 的真实占用形态(见上:不 listen)
         port = wildcard.getsockname()[1]
-        assert _probe_port_bindable(port), "通配监听占着的端口必须被判为不可绑"
+        assert _probe_port_bindable(port), "通配绑定占着的端口必须被判为不可绑"
 
 
 def test_probe_port_never_binds_all_interfaces():

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -287,6 +287,24 @@ def _get_lan_ip() -> str:
         return ""
 
 
+def _probe_port_bindable(host: str, port: int) -> str:
+    """试绑一次端口。可绑返回空串;不可绑返回人话原因。
+
+    只做一次真实的 bind/close,不留监听——这是判断"端口是不是已经被占了"
+    最直接也最可靠的办法(比连一下看通不通准确:后者对只绑了 IPv4 或正在
+    启动中的服务会误判)。
+
+    刻意**不设** SO_REUSEADDR:在 Windows 上它的语义是"允许强抢已被占用的
+    端口",打开反而会让探测通过、真正 bind 时才炸,与本函数的目的正好相反。
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((host or "0.0.0.0", int(port)))
+        return ""
+    except OSError as exc:
+        return f"{exc.__class__.__name__}: {exc}"
+
+
 _CLOUD_LLM_KEY_ENV_VARS = (
     "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", "GEMINI_API_KEY",
     "GOOGLE_API_KEY", "GROQ_API_KEY", "OPENROUTER_API_KEY", "ZHIPU_API_KEY",
@@ -638,6 +656,22 @@ class UnifiedWebUI:
                 log_level="warning"
             )
             server = uvicorn.Server(_uvi_config)
+
+            # ── 绑定前先自检端口 ──
+            # 端口被占时,uvicorn 是在后台任务里 `sys.exit(1)`,真机上的表现是:
+            # 一条无上下文的 `ERROR: [Errno 10048] ...`,加一段横跨 winloop/asyncio
+            # 的双层 traceback,末尾还挂一条 `Task exception was never retrieved`
+            # —— 用户完全看不出"这只是端口被另一个 Galaxy 占着"。
+            # 提前用一次普通 bind 探明,把它变成一句能直接照做的话。
+            _bind_err = _probe_port_bindable(self.config.host, self.config.web_ui_port)
+            if _bind_err:
+                raise RuntimeError(
+                    f"API 网关端口 {self.config.web_ui_port} 无法绑定({_bind_err})。"
+                    "最常见原因是**已经有一个 Galaxy 在运行**(请勿重复启动),"
+                    "或该端口被其它程序占用。"
+                    f"可用 `python main.py --port <其它端口>` 换端口启动。"
+                )
+
             logger.info(
                 "Galaxy API 服务启动: http://%s:%d",
                 self.config.host, self.config.web_ui_port
@@ -654,6 +688,12 @@ class UnifiedWebUI:
             # banner) instead of blocking here.
             self._server = server
             self._serve_task = asyncio.create_task(server.serve())
+            # serve() 若在我们取回结果前就异常收场(端口竞态、ASGI 启动失败…),
+            # asyncio 会在任务被回收时打印 "Task exception was never retrieved"
+            # 加一段裸 traceback —— 真机日志里那条噪声就是这么来的。
+            # 挂一个吞掉未取回异常的回调:真正的失败下面 result() 会照常抛出,
+            # 这里只负责保证"没人取"这件事不会再变成刷屏。
+            self._serve_task.add_done_callback(lambda t: t.cancelled() or t.exception())
             for _ in range(300):  # up to ~30s for bind + ASGI startup
                 if server.started or self._serve_task.done():
                     break
@@ -661,7 +701,17 @@ class UnifiedWebUI:
             if self._serve_task.done():
                 # serve() exited during startup — re-raise the real error so the
                 # caller logs an accurate "API 网关启动失败" cause.
-                self._serve_task.result()
+                try:
+                    self._serve_task.result()
+                except SystemExit as exc:
+                    # uvicorn 在启动失败时走的是 `sys.exit(1)`,抛出的 SystemExit
+                    # 继承自 BaseException —— 下面所有 `except Exception` 都接不住,
+                    # 它会一路穿透启动器把整个进程带走(真机上就是那段裸 traceback)。
+                    # 转成普通异常,交给既有的失败分支如实汇报。
+                    raise RuntimeError(
+                        f"API 网关启动失败:uvicorn 以退出码 {exc.code} 中止"
+                        f"(端口 {self.config.web_ui_port},详见上方日志)。"
+                    ) from exc
             logger.debug("启动后健康检查")
             await run_startup_health_check(self.config.web_ui_port)
 
@@ -1137,7 +1187,7 @@ class GalaxyUnified:
                 env["GALAXY_ELECTRON_BASIC"] = "1"
             _log_dir = Path("logs")
             _log_dir.mkdir(exist_ok=True)
-            # 复用同一份 logs/electron.log（托盘「三态动画日志」就打开它），便于一处看壳层日志。
+            # 复用同一份 logs/electron.log（托盘「View Logs」目录下），便于一处看壳层日志。
             _tlog = open(_log_dir / "electron.log", "ab")
             _tlog.write(
                 f"\n===== tauri start {__import__('datetime').datetime.now().isoformat()} "
@@ -1236,6 +1286,19 @@ class GalaxyUnified:
             proc = getattr(self, 'electron_proc', None)
             if not proc or proc.poll() is None or gave_up:
                 continue              # 未启动 / 仍在运行 / 已放弃
+            # 我们【亲眼看到】自己拉起的壳进程已经退出 —— 立刻把锁清掉。
+            # 不清会怎样(真机实证):锁里那个 pid 已死,但 Windows 上 pid 会被系统
+            # 回收给无关进程,already_running() 就把陌生进程当成"壳还活着",
+            # start_tauri() 早退返回 True → start_desktop_shell() 短路 →
+            # 下面的 start_desktop_shell() 根本不会去拉 Electron。真机上 13 条
+            # "Electron 已退出,重启中"对应的 electron.log 里只有一个启动标记,
+            # GPU→软件渲染→basic 三级降级全程空转,正是这么来的。
+            # 自己的孩子自己收尸,是这里唯一能 100% 确定锁已失效的时刻。
+            try:
+                from core.electron_launch_guard import clear_lock
+                clear_lock()
+            except Exception as exc:  # noqa: BLE001 —— 清锁失败不该挡住重启
+                logger.debug("清理桌面壳锁失败(不影响重启): %s", exc)
             now = time.time()
             restarts = [t for t in restarts if now - t < 60]
 
@@ -1872,7 +1935,8 @@ class GalaxyUnified:
                 ("面板", f"http://localhost:{port}"),
                 ("文档", f"http://localhost:{port}/docs"),
                 ("唤醒", "Ctrl+Alt+Space    隐藏 Ctrl+Alt+H"),
-                ("日志", "托盘 →「三态动画日志」"),
+                ("崩溃", "托盘 →「💥 崩溃日志」(全仓崩溃已合并去重)"),
+                ("日志", "托盘 →「View Logs(统一日志目录)」"),
             ],
             degraded=degraded_items or None,
             hints=[("停止", "Ctrl+C"), ("详细", "python main.py -v")],

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -287,7 +287,12 @@ def _get_lan_ip() -> str:
         return ""
 
 
-def _probe_port_bindable(host: str, port: int) -> str:
+#: 端口预检专用的探测地址。刻意只探环回口,绝不绑通配地址,详见
+#: :func:`_probe_port_bindable`。
+_PORT_PROBE_HOST = "127.0.0.1"
+
+
+def _probe_port_bindable(port: int) -> str:
     """试绑一次端口。可绑返回空串;不可绑返回人话原因。
 
     只做一次真实的 bind/close,不留监听——这是判断"端口是不是已经被占了"
@@ -297,15 +302,20 @@ def _probe_port_bindable(host: str, port: int) -> str:
     刻意**不设** SO_REUSEADDR:在 Windows 上它的语义是"允许强抢已被占用的
     端口",打开反而会让探测通过、真正 bind 时才炸,与本函数的目的正好相反。
 
-    ``host`` 应当就是随后交给 uvicorn 的那个监听地址——只有绑同一个地址,
-    探测结果才真的能预测 uvicorn 会不会成功。故这里**不**替调用方臆造默认
-    监听地址:``host`` 为空时退回只探环回口,足以覆盖本函数唯一要防的场景
-    (本机已经有一个 Galaxy 占着这个端口),也不会凭空开出一个全网卡绑定。
+    **只探环回口,不绑通配地址。** 这既不是妥协也不是为了绕过静态扫描:
+    只要不开 SO_REUSEADDR,别的进程占着 ``0.0.0.0:P`` 时,再去绑
+    ``127.0.0.1:P`` 同样会 EADDRINUSE(Windows/POSIX 皆然)。所以环回探测
+    足以覆盖本函数唯一要防的场景——**本机已经有一个 Galaxy 占着这个端口**
+    (真机上 Electron 拉起第二套后端抢 9000 就是这个形态)。
+
+    已知不覆盖的残余情形:某个服务只绑在**某块具体的非环回网卡**上
+    (如 ``192.168.1.5:P``)。此时本探测会放行,而 uvicorn 绑 ``0.0.0.0:P``
+    仍会失败——那条路径由调用方对 uvicorn 启动失败的处理如实兜底,不会再
+    退化成一段无上下文的 traceback。
     """
-    bind_host = (host or "").strip() or "127.0.0.1"
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind((bind_host, int(port)))
+            s.bind((_PORT_PROBE_HOST, int(port)))
         return ""
     except OSError as exc:
         return f"{exc.__class__.__name__}: {exc}"
@@ -669,7 +679,7 @@ class UnifiedWebUI:
             # 的双层 traceback,末尾还挂一条 `Task exception was never retrieved`
             # —— 用户完全看不出"这只是端口被另一个 Galaxy 占着"。
             # 提前用一次普通 bind 探明,把它变成一句能直接照做的话。
-            _bind_err = _probe_port_bindable(self.config.host, self.config.web_ui_port)
+            _bind_err = _probe_port_bindable(self.config.web_ui_port)
             if _bind_err:
                 raise RuntimeError(
                     f"API 网关端口 {self.config.web_ui_port} 无法绑定({_bind_err})。"

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -296,10 +296,16 @@ def _probe_port_bindable(host: str, port: int) -> str:
 
     刻意**不设** SO_REUSEADDR:在 Windows 上它的语义是"允许强抢已被占用的
     端口",打开反而会让探测通过、真正 bind 时才炸,与本函数的目的正好相反。
+
+    ``host`` 应当就是随后交给 uvicorn 的那个监听地址——只有绑同一个地址,
+    探测结果才真的能预测 uvicorn 会不会成功。故这里**不**替调用方臆造默认
+    监听地址:``host`` 为空时退回只探环回口,足以覆盖本函数唯一要防的场景
+    (本机已经有一个 Galaxy 占着这个端口),也不会凭空开出一个全网卡绑定。
     """
+    bind_host = (host or "").strip() or "127.0.0.1"
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind((host or "0.0.0.0", int(port)))
+            s.bind((bind_host, int(port)))
         return ""
     except OSError as exc:
         return f"{exc.__class__.__name__}: {exc}"

--- a/windows_service/galaxy_service.py
+++ b/windows_service/galaxy_service.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import threading
@@ -59,10 +60,10 @@ def _unified_log_root() -> str:
 _HAVE_PYWIN32 = False
 if sys.platform == "win32":
     try:
+        import servicemanager
         import win32event
         import win32service
         import win32serviceutil
-        import servicemanager
 
         _HAVE_PYWIN32 = True
     except ImportError:
@@ -279,9 +280,17 @@ if _HAVE_PYWIN32:
                     logger.info("Electron node_modules not found -- run 'npm install' in electron/")
                     return
 
+            # 必须用 which 解析出的绝对路径:Windows 上 npm 是 `npm.cmd`,
+            # 而 CreateProcess 不套用 PATHEXT —— 裸 "npm" 在这条(纯 Windows 的)
+            # 服务路径上必然 FileNotFoundError,Electron 永远拉不起来。
+            npm_exe = shutil.which("npm")
+            if not npm_exe:
+                logger.info("npm not in PATH -- skip Electron spawn")
+                return
+
             try:
                 self._electron_process = subprocess.Popen(
-                    ["npm", "start"],
+                    [npm_exe, "start"],
                     cwd=electron_dir,
                     env=env,
                     stdout=subprocess.PIPE,
@@ -356,8 +365,9 @@ if _HAVE_PYWIN32:
 
         def _monitor(self) -> None:
             """后台监控 —— 检测子进程崩溃并自动重启。"""
-            import psutil
             import gc
+
+            import psutil
 
             process = psutil.Process(self._process.pid) if self._process else None
 


### PR DESCRIPTION
## Summary

按所有者 2026-07-28 16:10~16:13 的 Windows 真机日志逐条排查。表面现象是「Electron 崩了 13 次最终放弃」,实际因果链**完全不是渲染问题**。

### 总根因:`os.kill(pid, 0)` 在 Windows 上不是探活,是 `TerminateProcess`

CPython 在 Windows 上的 `os.kill` 除 `CTRL_C_EVENT`/`CTRL_BREAK_EVENT` 外走的是 `OpenProcess` + **`TerminateProcess(handle, sig)`**。`core/electron_launch_guard.already_running()` 用它做跨平台探活,一个语义错误同时炸出两种故障:

1. **pid 已失效** → `[WinError 87]` 被包成 **`SystemError`**,而它不是 `OSError` 子类,原 `except (OSError, ValueError)` 接不住 → 异常上抛 → Phase 6 崩 → `Startup validation failed` **CRITICAL**、系统降级启动。
2. **pid 仍有效** → 刚拉起的 Electron 被当场 `TerminateProcess` 掉,函数还返回 `True` 说「它在跑」。

现改为 `ctypes` `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess` **只读**探活(显式声明 `argtypes`/`restype`,否则 64 位上 `HANDLE` 会被截断),异常一律按「已死」处理,并新增 `clear_lock()`。

### 由此暴露:那 13 次「重启中」一次都没真的重启过

陈旧锁让 `start_tauri()` 的 `already_running()` 早退返回 `True` → `start_desktop_shell()` 短路 → `start_electron()` **从不执行**。证据是 `electron.log` 全程只有一个 `===== electron start 16:11:59 =====` 标记 —— GPU→软件渲染→basic **三级降级全程空转**。保活器现在察觉自己的子进程退出即清锁。

### 其余 6 处

| # | 位置 | 问题 |
|---|---|---|
| ③ | `electron/main.js` | 单次 2.5s `/health` 探测失败即 spawn `launch_desktop.py --backend`,把整个 `main.py` 再拉一遍去抢 9000 → `[Errno 10048]`。现在 spawn 前先 TCP 探端口占用,占用则**绝不 spawn**、只耐心轮询;`GATEWAY_BASE` 钉到 `127.0.0.1`(网关绑 `0.0.0.0` 是仅 IPv4,`localhost` 在 Windows 上先解析 `::1`);告警模态框不再挡在 `createWindow()` 前面 |
| ④ | `unified_launcher.py` | 绑定前预检端口 → 一句可直接照做的话,取代裸 `[Errno 10048]` 双层 traceback;uvicorn 的 `SystemExit`(BaseException,会穿透所有 `except Exception`)转为普通异常;serve 任务异常始终被取回,消除 `Task exception was never retrieved` |
| ⑤ | `core/nats_server.py` | `~/.lumiv/bin/nats-server.exe` 明明已在,仍走完整下载流程(「消息总线 30.44s」基本全耗在这),末了 `Path.rename` 因目标已存在抛 `WinError 183`。改为已装即复用、`os.replace` 原子覆盖、清理解压残留 |
| ⑥ | `core/crash_log_aggregator.py` | `\bCRITICAL\b` 命中了预检**建议文案**「makes a missing token CRITICAL even with auth off」→ 锚点落在无关行 → 指纹错位 → 同一个崩溃在聚合视图里成了 `[1]` 和 `[5]` **两条**;`\bcrash\b` 还把聚合器自己的 INFO 记账行当成崩溃。现在这类普通英文词必须出现在日志**级别字段**位置,INFO/DEBUG/TRACE 行永不做锚点;块体按类型收窄并在日志回到正常流水时立即收尾 |
| ⑦ | `unified_launcher.py` | 就绪横幅仍指向已删除的托盘入口「三态动画日志」,改为与托盘实际条目对齐 |
| ⑧ | 4 处调用点 | Windows 上 npm 实际是 `npm.cmd` 而 `CreateProcess` **不套用 PATHEXT**,裸 `"npm"` 必 `FileNotFoundError`。后果是同一次启动里 Phase 0 打 `✓ npm`、Phase 6 却报 `DEGRADED — npm not found`,让用户去装明明装着的 Node.js。Phase 0 那条 `✓ npm` **不带版本号**(Node.js 那条有)正是裸调用已抛异常被 `except` 吞掉的指纹 |

## Validation

**零新增失败 —— 全量口径实测,不是推断。** 在独立 git worktree 上跑 `origin/main` 全量作对照:

| | 通过 | 失败 |
|---|---|---|
| `origin/main` 基线 | 42242 | **53** |
| 本 PR | 42262 (+20 = 新增测试) | **53** |

两边失败集 `diff` **逐条完全一致,零新增零消失**。那 53 条是该套件既有的跨文件测试污染(把它们所在的 16 个文件单独跑,两边同为 3 failed / 905 passed)。

其余:

- 新增 `tests/test_windows_launch_recovery.py` **22 项契约测试全绿**:只读探活不误杀真实子进程、陈旧锁被清、探活永不上抛、端口预检、spawn 前必先探端口、聚合器锚点与跨来源去重、全仓无裸 npm 守卫。
- **该测试在编写过程中抓到一处新的真 bug**:POSIX 分支 `os.kill` 遇超大 pid 抛 `OverflowError`(同样非 `OSError`,同样会逃出去),已一并修掉。
- CI 同款 lint 全绿:`flake8 core/ --max-line-length=120` 从 1 条 F401 降到 **0**;`black --check core/ tests/` 通过。

## 已知红门与 CodeQL 处置

- **`File Complexity Budget`(红,与本 PR 无关)**:门禁脚本只扫 `core`/`galaxy_gateway`/`enhancements`/`dashboard`;违规条数 `origin/main` 基线 **133** = 本 PR **133**,我改的文件没有一个在清单里。这是主干存量大文件欠账(`command_router.py` 5435 行、`openclawd.py` 9655 行等),属于已被所有者取消的大文件拆分专项,本 PR 不捡回。
- **CodeQL `py/bind-socket-all-network-interfaces`(生产代码,已修)**:端口预检原先有 `host or "0.0.0.0"` 兜底,凭空开一次全网卡绑定。顺着这条提示想清楚了更根本的一点:**这个探测根本不需要绑通配地址** —— 只要不开 `SO_REUSEADDR`,通配绑定与具体地址绑定在同一端口上互斥,环回探测就足以覆盖唯一要防的场景(本机已有一个 Galaxy 占着该端口)。现固定探 `127.0.0.1`,并用一个真实的 `0.0.0.0` 占用者写测试验证了这个前提。
- **CodeQL 同一条(测试代码,刻意保留)**:上述验证用例必须真的造一个通配占用者,否则设计前提只能靠「我认为」。已把实际暴露面压到零 —— 临时端口、**刻意不 `listen()`**(占用在 `bind()` 时就成立,不 listen 则永不可被连接)、随 `with` 立即关闭。理由写进 docstring,防止后人当疏漏「补上 listen」。

## 仍需真机验证

本轮修复集中在 **Windows 专属路径**(`ctypes` 探活、`npm.cmd`、端口竞争),CI 与沙盒都是 Linux,覆盖不到。建议在真机重跑一次 `python main.py` 确认:覆盖层能正常起来、不再出现 `Startup validation failed`、不再有第二套后端抢 9000、消息总线阶段不再白等 30s。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b