### PR TITLE
fix(startup/tests): 修复 ServiceManager 分裂 + 消除启动期重复阻塞 + 堵住测试 PATH 污染

### DIFF
--- a/core/crash_log_aggregator.py
+++ b/core/crash_log_aggregator.py
@@ -26,7 +26,7 @@ import hashlib
 import re
 import time
 from pathlib import Path
-from typing import Iterable, Iterator, NamedTuple
+from typing import Iterator, NamedTuple
 
 from core.log_paths import crash_dir, crash_latest_path, log_root
 

--- a/main.py
+++ b/main.py
@@ -754,6 +754,20 @@ def phase2_ensure_deps(env_status: dict) -> bool:
     #     - 完整                        → 跳过
     #   npm install 本身是幂等的:该下的下、已在的跳过,既是"正常下载"也是"补齐"。
     npm_cmd = shutil.which("npm")
+    # env_status 是 Phase 0 拍的快照,而 Phase 1 的编排器 Phase 6(DESKTOP_SURFACE)
+    # 就在 Phase 0 和这里【中间】跑过一次 npm install。照着两个阶段前的旧快照判断,
+    # 依赖明明已经装好了也会再整装一遍(实测重复消耗 ~20s 纯等待,且这段是阻塞在
+    # 网关 bind 之前的)。完整性判定只是几次 os.path.isfile,重新取一次实时状态的
+    # 代价可忽略;失败路径完全不变——Phase 6 装失败/被跳过时这里照样判 False 并
+    # 跑下面那套三镜像重试(比 Phase 6 的更抗弱网),补齐能力一点没少。
+    if npm_cmd and not env_status.get("electron_deps_ok"):
+        try:
+            from core.electron_launch_guard import electron_package_intact
+            if electron_package_intact(str(ELECTRON_DIR)):
+                env_status["electron_deps_ok"] = True
+                print_item("Electron 依赖已就绪(启动早期阶段已装好)", "ok")
+        except Exception:  # noqa: BLE001
+            pass  # 复检本身出错 → 保持原判断,照常走安装
     if npm_cmd and not env_status.get("electron_deps_ok"):
         _node_modules_exists = (ELECTRON_DIR / "node_modules").exists()
         if _node_modules_exists:
@@ -824,28 +838,22 @@ def phase2_ensure_deps(env_status: dict) -> bool:
                 models = [line.split()[0] for line in rc.stdout.strip().split("\n")[1:] if line.strip()]
                 print_item(f"Ollama 模型: {len(models)} 个", "ok", ", ".join(models[:3]))
             else:
-                # 按【实际硬件】挑推荐模型再拉，而不是写死 12B：无独显的笔记本只会拉轻量的
-                # gemma4:e2b（不会白下 8GB 的大模型）。仅探测、不持久化，Phase 5 仍可改选。
-                try:
-                    from core import model_selection as _ms
-                    rec_model = _ms.recommend()
-                except Exception:
-                    rec_model = "gemma4:e2b"
-                print_item("未检测到本地模型，正在下载推荐模型...", "ok", rec_model)
-                # 弱网加固:①流式输出让 ollama 自带进度条可见(此前 capture
-                # 导致几 GB 的下载全程无声,"看着像卡死");②超时放宽到 1h——
-                # 600s 在弱网下必然误杀大模型下载(ollama pull 本身断点续传,
-                # 超时后重跑会从断点继续,但不该让正常慢速下载被误判失败)。
-                try:
-                    rc2 = sp.run(["ollama", "pull", rec_model], timeout=3600).returncode
-                except sp.TimeoutExpired:
-                    rc2 = -1
-                    print_item("模型下载超 1h 未完成", "warn",
-                               f"ollama pull {rec_model} 支持断点续传,重跑即从断点继续")
-                if rc2 == 0:
-                    print_item(f"模型 {rec_model} 下载完成", "ok")
-                elif rc2 != -1:
-                    print_item("模型下载失败", "warn", f"ollama pull {rec_model} 手动重试")
+                # 这里【只报告、不下载】。模型拉取由 Phase 5「AI 大脑」统一负责
+                # (unified_launcher._phase5 → core.model_selection.background_pull),
+                # 那条路径在每个维度上都严格更优,曾经放在这里的阻塞式 ollama pull
+                # 属于纯粹重复且更差的一份:
+                #   · 拉的模型不对——这里拉 recommend() 的硬件推荐值,而 Phase 5 拉
+                #     resolve_main_brain() 的【用户实际选定】值;两者不同时,用户要
+                #     先等一个自己根本不用的模型下完。
+                #   · 阻塞网关——timeout=3600 且位于 bind 之前,首启机器上网关最长
+                #     一小时不监听,用户连「保存 API Key」都做不了(真机反馈过的
+                #     "后端未启动"就是这一类)。Phase 5 走后台线程,不挡启动。
+                #   · 时序更早、更容易空放一枪——Phase 5 特意把 start_local_brain()
+                #     排在拉取之前以确保 Ollama 真已就绪(见其 docstring 记录的竞态),
+                #     而这里比它还早,ollama serve 往往尚未绑定端口。
+                #   · 缺少 Phase 5 已有的 /api/show 残缺 manifest 核实、HuggingFace
+                #     回退、版本不兼容诊断。
+                print_item("未检测到本地模型", "warn", "将由 Phase 5「AI 大脑」按所选主脑后台拉取(不阻塞启动)")
         except Exception as exc:
             print_item(f"Ollama 模型检查失败: {exc}", "warn")
 

--- a/tests/test_electron_launch_guard.py
+++ b/tests/test_electron_launch_guard.py
@@ -205,6 +205,23 @@ class _FakeSub:
 class TestVcvarsBuildEnv:
     """vcvars64 完整构建环境加载:PATH+LIB+INCLUDE 一并灌进 os.environ(修 LNK1181)。"""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_os_environ(self):
+        """把整个 os.environ 快照/还原。
+
+        被测函数 _windows_setup_msvc_build_env 的职责就是把 vcvars dump 灌进
+        os.environ,所以它会把假 dump 里的 ``PATH=C:\\vc\\bin`` 写成进程真实
+        PATH。不还原的话,同一 pytest 进程里后续所有 shutil.which()/子进程查找
+        全部失效(实测会连锁打挂几十个用例)。monkeypatch 只能保护它显式改过的
+        键,这里改的键由假 dump 决定,故必须整体快照。
+        """
+        saved = dict(os.environ)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
+
     def test_applies_full_env_and_confirms_cl(self, monkeypatch):
         import shutil
 

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -1516,7 +1516,18 @@ class GalaxyUnified:
     async def start(self):
         """启动 Galaxy 后端 — 板块式输出。"""
         await self.setup()
-        self.service_manager = ServiceManager(self.config)
+        # 这里【不能】再 new 一个 ServiceManager。__init__ 已经建好一个,并且把
+        # core_launcher / node_launcher / l4_launcher / web_ui 全部绑在【那一个】
+        # 上了;在这里替换 self.service_manager 只会换掉自己这一份引用,web_ui
+        # 仍指向旧实例 —— 而 /api/status、/api/services 这两个端点正是 web_ui
+        # 里的闭包(见 UnifiedWebUI 步骤 6)。于是启动过程中 CoreServiceLauncher
+        # (launcher/core_services.py:28/43/61)和 NodeSystemLauncher
+        # (launcher/node_startup.py:586)注册进去的服务全落在新实例上,而两个查询
+        # 端点读的是那个再也收不到任何注册的旧实例:services 恒为空、state 也永远
+        # 停在 setup() 写的 LOADING_CONFIG。config 在 __init__(第 711 行)之后不
+        # 会被换对象(main.py 只是改它的 host/port 字段),所以这次 new 的入参与
+        # __init__ 那次完全相同 —— 纯粹是一份多余且有害的副本,删掉即让全系统
+        # 收敛到同一个 ServiceManager。
 
         # ── 启动阶段渲染（clig.dev：默认每阶段折叠一行，-v 展开逐项明细）──
         from core import cli_render as r


### PR DESCRIPTION
## 背景

本轮目标：在不动方向 A(拆分大文件)与方向 C(裁剪路由/`/gateway`)的前提下，把启动路径上的重复与错误彻底解决，并顺带再排一遍错；对任何"删掉的东西"给出它确实不必要的硬证据。

---

## 1. `unified_launcher`：删掉 `start()` 里第二次 `new ServiceManager`（真实缺陷）

`__init__`(711–716 行)建好一个 `ServiceManager`，并把 `core_launcher` / `node_launcher` / `l4_launcher` / `web_ui` **全部绑在那一个实例上**。而 `start()` 开头又 `new` 了一个，只覆盖 `self.service_manager` 这一份引用——系统就此分裂成两个实例：

- 启动期真正的服务注册走**新**实例：`launcher/core_services.py:28/43/61`(`device_agent_manager`、`microsoft_ufo_integration`)与 `launcher/node_startup.py:586`(逐节点注册)，因为 1591/1749/1764 行的三个 launcher 是用新实例重建的；
- 而 `/api/status` 与 `/api/services` 是 `UnifiedWebUI` 里的闭包(624/625/631 行)，读的是 `__init__` 那个**旧**实例。

**后果**：两个端点的 `services` 恒为空，`state` 也永远停在 `setup()` 写的 `LOADING_CONFIG`，所有实际起来的核心服务与节点全部查不到。

`self.config` 在 `__init__` 之后不会被换对象(`main.py` 只改它的 `host`/`port` 字段)，故这次 `new` 的入参与 `__init__` 那次完全相同——纯属多余且有害的副本。

**实测验证**（修复前后）：

```
修复前： web_ui 指向 __init__ 实例；start() 替换后 web_ui 变为 stale = True
修复后： web_ui sees same SM : True
        web_ui sees service : True     # 注册后立即可见
        launchers see same  : True True True
```

## 2. `main.py` Phase 2.4：依赖判定改为实时复检

`env_status` 是 Phase 0 拍的快照，而 Phase 1 编排器的 Phase 6(`DESKTOP_SURFACE`)就在 Phase 0 与 Phase 2.4 **中间**跑过一次 `npm install`。照旧快照判断，会在依赖其实已装好时再整装一遍——实测重复消耗约 20s，且这段阻塞在网关 bind 之前。

完整性判定(`electron_package_intact`)只是几次 `os.path.isfile`，复检代价可忽略。**失败路径完全不变**：Phase 6 装失败或被跳过时这里照样判 `False`，并跑原有那套三镜像重试(比 Phase 6 的更抗弱网)，补齐能力一点没少。

## 3. `main.py` Phase 2.5：去掉阻塞式 `ollama pull`，交回 Phase 5 统一负责

模型拉取本就由 Phase 5「AI 大脑」的 `core.model_selection.background_pull` 负责(`unified_launcher.py:1503`)。这里那份是纯重复且**每个维度都更差**的一份：

| | main.py 2.5(已删) | Phase 5 `background_pull` |
|---|---|---|
| 拉哪个模型 | `recommend()` 硬件推荐值 | `resolve_main_brain()` 用户实际选定值 |
| 是否阻塞 bind | 是，`timeout=3600` | 否，后台线程 |
| 等 Ollama 就绪 | 否 | 是，先 `start_local_brain()`(约 40s 重试) |
| 残缺 manifest 核实 | 无 | 有，`/api/show` |
| HuggingFace 回退 | 无 | 有 |

其中"阻塞 bind"一项正是此前反馈过的「保存 API 密钥 → 后端未启动」那一类症状：首启机器上网关最长一小时不监听。且 Phase 5 的 docstring 明确记录了"必须先 `start_local_brain()` 再拉取"的竞态，而这里比 Phase 5 还早，更容易空放一枪。

仅保留「未检测到本地模型」的如实报告，并指明将由 Phase 5 后台拉取。相关既有测试(`test_background_pull_verifies_loadable`、`test_brain_startup_ordering`、`test_hf_ollama_import_fallback`、`test_summary_card_per_item_hints`，共 23 项)全部通过。

## 4. `tests/test_electron_launch_guard.py`：`TestVcvarsBuildEnv` 加 `os.environ` 快照还原

被测的 `_windows_setup_msvc_build_env` 的职责**就是**把 vcvars dump 灌进 `os.environ`，而测试喂的假 dump 含 `PATH=C:\vc\bin`，于是进程真实 `PATH` 被改成一个不存在的 Windows 路径，同一 pytest 进程内后续所有 `shutil.which()` 与子进程查找全部失效。

实测污染证据：

```
PATH_CHANGED: True
PATH_AFTER:   C:\vc\bin
which(python3) after: None
```

`monkeypatch` 只能保护它显式改过的键，而这里改哪些键**由假 dump 决定**，故必须整体快照 `os.environ`。

**生产侧代码没有问题**(灌环境正是它该做的事)，缺陷纯在测试侧，故只改测试。

---

## 关于"确保删的东西真的不必要"——两个原计划的删除已撤销

原计划要删两个"死编排器"。逐一核实后证明**前提是错的，两个都不能删**：

**`galaxy_gateway/orchestrator/galaxy_orchestrator.py` 根本不是死代码。** 它是 `fusion/unified_orchestrator.py` 废弃声明里指定的「唯一的顶层编排器」，也是 `core/compat_surface_retirement.py` 里登记的 `canonical_replacement`。更关键的是 `tests/test_constellation_entry_default.py` 证明它是 **ConstellationRuntime 的默认入口路径**(PR-6 Goal 1)：`GalaxyOrchestrator.process_request()` 默认 `use_constellation=True`(见 `galaxy_orchestrator.py:824-860`)。实测移除后 **12 个用例失败 + 7 个静默转为 skip**，其中包含行为测试而非仅治理哨兵测试。

**`fusion/unified_orchestrator.py` 是仓库明文保留的废弃门面。** 它在 `core/legacy_dispatch_registry.py:420` 注册为 `FACADE_ONLY`，携带 4 个被约 12 个测试文件断言的治理哨兵常量。仓库自己的退休记录写明了移除条件，而该条件**尚未满足**：

> "Remove when `fusion/start_fusion.py` and `fusion/demo_e2e.py` are updated to import from `galaxy_gateway.orchestrator` and the only remaining callers are the deprecation tests."

实测移除后 3 个用例硬失败，另有 **7 个用例从通过静默降级为 skip**——它们用 `pytest.skip` 兜 ImportError，所以删除不会响亮地失败，而是悄悄把治理覆盖掏空。这比硬失败更危险。

因此本 PR **不删除任何模块**，只删除了上面第 1 条那处被证明有害的重复对象构造。

---

## 验证

- `py_compile` / `flake8` / `black` / `isort`：CI 门禁范围(`core/`、`tests/`)全部干净；`main.py` 与 `unified_launcher.py` 不在门禁范围内，且本 diff 未引入任何**新增**告警(已用 stash 前后对比确认，两侧输出完全一致)。
- `tests/test_electron_launch_guard.py`：19 项通过，并用探针用例确认 `PATH` 在其后完好、`which(python3)` 正常。
- `GalaxyUnified` / `ServiceManager` 相关：`test_brain_startup_ordering`、`test_pr9_integration_validation`、`test_clone_to_use_startup_hardening`、`test_launcher_refactor` 共 127 通过 / 1 skip。
- 编排器引用面：`unified_orchestrator` 相关 553 项、`galaxy_orchestrator` 相关 649 项，均全数通过。
- 全量套件正在跑，完成后会把失败数变化补充到本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_