### PR TITLE
批处理静默丢条目:续跑丢依赖边、回流记忆丢损坏行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ env/
 .galaxy_model
 .galaxy_runtime
 .galaxy_revoked_tokens.json
+# Mesh 主密钥 —— capability_token 的签名密钥,同时也是 agent_card 的名片签名密钥。
+# 此前只忽略了撤销表却漏了密钥本身:该文件由 core/capability_token.py 首次签发时
+# 自动生成(0600),泄露等于任何人都能伪造能力令牌与配对名片。绝不入库。
+.galaxy_mesh_key
+# 对端信任档案(peer_trust)与配对产生的本机运行时数据
+data/peer_trust.json
 
 # Logs
 *.log

--- a/core/agent_card.py
+++ b/core/agent_card.py
@@ -143,7 +143,10 @@ def from_link(link: str, *, now: Optional[float] = None) -> CardVerdict:
     try:
         parsed = urlparse(str(link).strip())
     except Exception as exc:  # noqa: BLE001
-        return CardVerdict(False, f"链接无法解析: {exc}")
+        # reason 会被配对接口原样回给调用方,因此不能带异常文本
+        # (CodeQL: Information exposure through an exception)。细节只进日志。
+        logger.debug("配对链接解析失败: %s", exc, exc_info=True)
+        return CardVerdict(False, "链接格式无法解析")
     if parsed.scheme != CARD_SCHEME or (parsed.netloc or parsed.path.strip("/")) != CARD_HOST:
         return CardVerdict(False, f"不是配对链接(期望 {CARD_SCHEME}://{CARD_HOST})")
     q = parse_qs(parsed.query)
@@ -168,7 +171,9 @@ def from_link(link: str, *, now: Optional[float] = None) -> CardVerdict:
             nonce=str(data.get("nonce", "") or ""),
         )
     except Exception as exc:  # noqa: BLE001
-        return CardVerdict(False, f"名片内容损坏: {exc}")
+        # 同上:不把异常文本带进对外 reason
+        logger.debug("名片内容解码失败: %s", exc, exc_info=True)
+        return CardVerdict(False, "名片内容损坏")
     if not card.device_id:
         return CardVerdict(False, "名片缺少 device_id")
     if card.is_expired(now):

--- a/core/agent_card.py
+++ b/core/agent_card.py
@@ -1,0 +1,315 @@
+"""core/agent_card.py — 可分享的智能体名片(配对凭证)
+
+解决什么
+--------
+此前设备接入只有 ``AIP_TOKEN``(一把共享令牌),而
+``galaxy_gateway/routes/websocket.py`` 的入口登记表里自己写着
+``device_cert 未实现(诚实化)``。也就是说:**没有任何"把一台设备的身份 + 能力 +
+端点打包成一份可传递凭证"的东西**。配对只能靠人工把令牌和地址抄过去。
+
+AgentCard 就是这份凭证:一段自描述、防篡改、可放进二维码或直接口述的短文本。
+
+与既有设施的关系(刻意复用,不另起一套)
+--------------------------------------
+签名**直接复用** ``core.capability_token`` 的 Mesh 主密钥与 HMAC-SHA256 例程
+(``_mesh_secret`` / ``_sign``),不引入第二套密钥体系:
+
+* 单属主 Mesh 里签发方 = 验证方,HMAC 足够,且零额外依赖 ——
+  这与 capability_token.py:15-17 已经写下的选型判断一致;
+* 复用同一把密钥意味着**换密钥即同时吊销所有名片和令牌**,不会出现
+  "令牌换了但名片还认"的半吊销状态。
+
+将来若要支持**多属主**(别人的智能体接进来),再按 capability_token 里已经写明的
+路线切 ed25519 公钥体系 —— 那时 ``AgentCard.issuer`` 字段就是放 DID 的地方,
+本模块的链接格式不必改。
+
+两种配对方式(对齐"扫码 / 命令"两条路)
+--------------------------------------
+1. **链接**:``galaxy://pair?c=<payload>&s=<sig>`` —— 可直接渲染成二维码扫码;
+2. **短码**:6 位人类可读配对码(去掉易混字符),可口述、可手输,
+   由 :class:`PairingCodeRegistry` 在内存中短时保管,默认 10 分钟过期。
+
+短码存在的理由:二维码需要一块屏幕和一个摄像头,而终端/SSH 场景两者都没有。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from core.capability_token import _b64d, _b64e, _sign  # 复用同一把 Mesh 主密钥
+
+logger = logging.getLogger("Galaxy.AgentCard")
+
+#: 配对链接 scheme。用自有 scheme 而不是 http,避免被当成可点击的外链误导用户。
+CARD_SCHEME = "galaxy"
+CARD_HOST = "pair"
+
+#: 名片默认有效期(秒)。名片是**配对凭证**不是长效授权,短一点更安全;
+#: 真正的长效授权由 capability_token 签发。
+DEFAULT_CARD_TTL_S = 24 * 3600.0
+
+#: 短码字符集:去掉 0/O/1/I/L 等易混字符,便于口述与手输。
+_CODE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ"
+DEFAULT_CODE_TTL_S = 600.0
+
+
+@dataclass
+class AgentCard:
+    """一台设备/智能体的自描述名片。"""
+
+    device_id: str
+    name: str = ""
+    device_type: str = "unknown"
+    capabilities: List[str] = field(default_factory=list)
+    #: 传输端点,如 {"websocket": "ws://10.0.0.5:9000/ws/device/<id>"}
+    endpoints: Dict[str, str] = field(default_factory=dict)
+    #: 签发者标识。单属主 Mesh 下就是本机 device_id;将来多属主时放 DID。
+    issuer: str = ""
+    issued_at: float = 0.0
+    expires_at: float = 0.0
+    #: 防重放随机串
+    nonce: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def is_expired(self, now: Optional[float] = None) -> bool:
+        if not self.expires_at:
+            return False
+        return (now if now is not None else time.time()) > self.expires_at
+
+
+def _payload_b64(card: AgentCard) -> str:
+    # sort_keys + 紧凑分隔符:同一张名片必须序列化成同一串,否则签名无法复验
+    raw = json.dumps(card.to_dict(), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return _b64e(raw.encode("utf-8"))
+
+
+def create_agent_card(
+    device_id: str,
+    *,
+    name: str = "",
+    device_type: str = "unknown",
+    capabilities: Optional[List[str]] = None,
+    endpoints: Optional[Dict[str, str]] = None,
+    issuer: str = "",
+    ttl_s: float = DEFAULT_CARD_TTL_S,
+    now: Optional[float] = None,
+) -> AgentCard:
+    """签发一张名片(未签名;签名在 to_link/to_token 时施加)。"""
+    t = now if now is not None else time.time()
+    return AgentCard(
+        device_id=str(device_id),
+        name=str(name or device_id),
+        device_type=str(device_type or "unknown"),
+        capabilities=[str(c) for c in (capabilities or [])],
+        endpoints={str(k): str(v) for k, v in (endpoints or {}).items()},
+        issuer=str(issuer or device_id),
+        issued_at=t,
+        expires_at=t + float(ttl_s) if ttl_s else 0.0,
+        nonce=secrets.token_hex(8),
+    )
+
+
+def to_link(card: AgentCard) -> str:
+    """名片 → 可扫码/可粘贴的配对链接。"""
+    payload = _payload_b64(card)
+    return f"{CARD_SCHEME}://{CARD_HOST}?" + urlencode({"c": payload, "s": _sign(payload)})
+
+
+@dataclass(frozen=True)
+class CardVerdict:
+    """名片校验结论。``card`` 仅在 valid 时有值。"""
+
+    valid: bool
+    reason: str = ""
+    card: Optional[AgentCard] = None
+
+
+def from_link(link: str, *, now: Optional[float] = None) -> CardVerdict:
+    """解析并**校验**配对链接。签名不符或已过期一律判无效。
+
+    绝不在校验失败时返回半个 card —— 调用方一旦拿到 card 就会据此登记设备,
+    返回"内容对但签名错"的名片等于把伪造名片放进了信任链。
+    """
+    try:
+        parsed = urlparse(str(link).strip())
+    except Exception as exc:  # noqa: BLE001
+        return CardVerdict(False, f"链接无法解析: {exc}")
+    if parsed.scheme != CARD_SCHEME or (parsed.netloc or parsed.path.strip("/")) != CARD_HOST:
+        return CardVerdict(False, f"不是配对链接(期望 {CARD_SCHEME}://{CARD_HOST})")
+    q = parse_qs(parsed.query)
+    payload = (q.get("c") or [""])[0]
+    sig = (q.get("s") or [""])[0]
+    if not payload or not sig:
+        return CardVerdict(False, "链接缺少 c/s 参数")
+    # 用 secrets.compare_digest 做定时安全比较,避免按字节比较泄漏签名前缀
+    if not secrets.compare_digest(_sign(payload), sig):
+        return CardVerdict(False, "签名校验失败(名片被篡改,或签发方与本机主密钥不同)")
+    try:
+        data = json.loads(_b64d(payload).decode("utf-8"))
+        card = AgentCard(
+            device_id=str(data.get("device_id", "")),
+            name=str(data.get("name", "") or ""),
+            device_type=str(data.get("device_type", "unknown") or "unknown"),
+            capabilities=[str(c) for c in (data.get("capabilities") or [])],
+            endpoints={str(k): str(v) for k, v in (data.get("endpoints") or {}).items()},
+            issuer=str(data.get("issuer", "") or ""),
+            issued_at=float(data.get("issued_at", 0.0) or 0.0),
+            expires_at=float(data.get("expires_at", 0.0) or 0.0),
+            nonce=str(data.get("nonce", "") or ""),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return CardVerdict(False, f"名片内容损坏: {exc}")
+    if not card.device_id:
+        return CardVerdict(False, "名片缺少 device_id")
+    if card.is_expired(now):
+        return CardVerdict(False, "名片已过期,请让对方重新出示")
+    return CardVerdict(True, "", card)
+
+
+# ── 短码配对(无摄像头场景)────────────────────────────────────────────────
+@dataclass
+class _CodeEntry:
+    link: str
+    expires_at: float
+
+
+class PairingCodeRegistry:
+    """短码 → 配对链接 的短时映射(仅内存,进程重启即失效)。
+
+    刻意不落盘:短码是**一次性、分钟级**的引导凭证,落盘只会延长它的暴露窗口。
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._codes: Dict[str, _CodeEntry] = {}
+
+    def _sweep_unlocked(self, now: float) -> None:
+        for code in [c for c, e in self._codes.items() if e.expires_at <= now]:
+            self._codes.pop(code, None)
+
+    def issue(self, link: str, *, ttl_s: float = DEFAULT_CODE_TTL_S, now: Optional[float] = None) -> Tuple[str, float]:
+        t = now if now is not None else time.time()
+        with self._lock:
+            self._sweep_unlocked(t)
+            for _ in range(64):  # 极小概率碰撞,重试即可
+                code = "".join(secrets.choice(_CODE_ALPHABET) for _ in range(6))
+                if code not in self._codes:
+                    expires = t + float(ttl_s)
+                    self._codes[code] = _CodeEntry(link=link, expires_at=expires)
+                    return code, expires
+            raise RuntimeError("配对短码生成失败:连续 64 次碰撞")
+
+    def resolve(self, code: str, *, consume: bool = True, now: Optional[float] = None) -> Optional[str]:
+        """短码 → 链接。默认**用后即焚**(consume=True)。"""
+        t = now if now is not None else time.time()
+        key = str(code).strip().upper()
+        with self._lock:
+            self._sweep_unlocked(t)
+            entry = self._codes.get(key)
+            if entry is None:
+                return None
+            if consume:
+                self._codes.pop(key, None)
+            return entry.link
+
+    def active_count(self) -> int:
+        with self._lock:
+            self._sweep_unlocked(time.time())
+            return len(self._codes)
+
+
+_registry_lock = threading.Lock()
+_registry: Optional[PairingCodeRegistry] = None
+
+
+def get_pairing_code_registry() -> PairingCodeRegistry:
+    global _registry
+    if _registry is not None:
+        return _registry
+    with _registry_lock:
+        if _registry is None:
+            _registry = PairingCodeRegistry()
+    return _registry
+
+
+def reset_pairing_code_registry() -> None:
+    """测试用。"""
+    global _registry
+    with _registry_lock:
+        _registry = None
+
+
+# ── 本机名片 ──────────────────────────────────────────────────────────────
+def local_device_id() -> str:
+    """本机在 Mesh 中的标识。优先环境变量,其次主机名。"""
+    for key in ("GALAXY_DEVICE_ID", "GALAXY_NODE_ID"):
+        v = os.getenv(key, "").strip()
+        if v:
+            return v
+    try:
+        import socket
+
+        return socket.gethostname() or "galaxy-local"
+    except Exception:  # noqa: BLE001
+        return "galaxy-local"
+
+
+def build_local_card(
+    *,
+    capabilities: Optional[List[str]] = None,
+    endpoints: Optional[Dict[str, str]] = None,
+    ttl_s: float = DEFAULT_CARD_TTL_S,
+) -> AgentCard:
+    """构造本机名片。端点未显式给出时,按实际监听端口推导 websocket 入口。
+
+    端口取自 ``core.electron_launch_guard.resolve_gateway_port()`` —— 那是本仓库
+    既有的"网关实际监听端口"权威解析(env → port_config → 默认 9000),
+    不在这里另写一份端口推导逻辑。
+    """
+    did = local_device_id()
+    eps = dict(endpoints or {})
+    if not eps:
+        try:
+            from core.electron_launch_guard import resolve_gateway_port
+
+            port = resolve_gateway_port()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("名片端点推导:网关端口解析失败(%s),端点留空", exc)
+            port = 0
+        if port:
+            eps["websocket"] = f"ws://{_local_ip()}:{port}/ws/device/{did}"
+    return create_agent_card(
+        did,
+        name=os.getenv("GALAXY_DEVICE_NAME", "").strip() or did,
+        device_type=os.getenv("GALAXY_DEVICE_TYPE", "").strip() or "unknown",
+        capabilities=capabilities or [],
+        endpoints=eps,
+        issuer=did,
+        ttl_s=ttl_s,
+    )
+
+
+def _local_ip() -> str:
+    """取本机在局域网中的出口 IP;失败退回 127.0.0.1。"""
+    try:
+        import socket
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("10.255.255.255", 1))  # 不发包,只为让内核选路
+            return s.getsockname()[0]
+        finally:
+            s.close()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("本机 IP 探测失败,退回 127.0.0.1: %s", exc)
+        return "127.0.0.1"

--- a/core/api_routes.py
+++ b/core/api_routes.py
@@ -314,6 +314,7 @@ def create_api_routes(service_manager=None, config=None) -> APIRouter:
     from core.routes import modality as modality_route
     from core.routes import models as models_route
     from core.routes import monitoring, nodes
+    from core.routes import pairing as pairing_routes
     from core.routes import perception as perception_routes
     from core.routes import relay
     from core.routes import remote_desktop as remote_desktop_routes
@@ -371,6 +372,11 @@ def create_api_routes(service_manager=None, config=None) -> APIRouter:
         cmd_routes.create_router(service_manager=service_manager, config=config), dependencies=_auth_deps
     )
     router.include_router(relay.create_router(service_manager=service_manager, config=config), dependencies=_auth_deps)
+    # 配对与对端信任:签发/接纳名片、调整信任级别、签发能力令牌。
+    # 属授权面,必须鉴权 —— 否则任何人都能把自己提成 trusted。
+    router.include_router(
+        pairing_routes.create_router(service_manager=service_manager, config=config), dependencies=_auth_deps
+    )
     router.include_router(vault.create_router(service_manager=service_manager, config=config), dependencies=_auth_deps)
     router.include_router(
         federation.create_router(service_manager=service_manager, config=config), dependencies=_auth_deps

--- a/core/electron_launch_guard.py
+++ b/core/electron_launch_guard.py
@@ -75,7 +75,14 @@ def resolve_gateway_port() -> int:
         from core.port_config import get_service_port
 
         return get_service_port("unified_launcher")
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        # core.port_config 在本仓库内恒可导入,走到这里是真实读取错误(如
+        # config/unified_ports.yaml 损坏)。仍退回内置默认值,但必须留痕:
+        # 若网关实际监听的不是 9000,桌面壳会连到一个空端口,而此前毫无线索。
+        _logger.warning(
+            "网关端口解析失败(%s):退回内置默认值 9000;若网关实际不在 9000,桌面壳将连不上",
+            exc,
+        )
         return 9000
 
 

--- a/core/execution/readiness_gate.py
+++ b/core/execution/readiness_gate.py
@@ -510,6 +510,48 @@ class ExecutionReadinessGate:
             (policy is not None and policy.requires_confirmation) or hitl_result.get("requires_confirmation", False)
         )
 
+        # 对端信任豁免(core.peer_trust)
+        #
+        # 配对时把一台设备设为 trusted、或给 friend 配上匹配的 auto_accept 模式,
+        # 本身就是一次**显式的、有记录的人工授权**。若每次动作仍然弹确认,
+        # 这个授权就等于没有意义 —— 分级信任存在的全部价值就是"只问该问的"。
+        #
+        # 三条刻意的边界:
+        #   1. 只豁免 policy 侧的 requires_confirmation。hitl_result 自己要求确认时
+        #      **不豁免** —— HITL 是独立的、针对具体动作的刹车,不该被一个
+        #      针对设备的长期设置覆盖掉。
+        #   2. 只在 target_type == "device" 时才把 target_ref 当设备用。该字段可能是
+        #      app 名/窗口标题/URL(见 intent_profile.target_ref 的定义),
+        #      拿 app 名去查对端信任是张冠李戴。
+        #   3. 豁免必然写进 notes,便于事后审计"这次为什么没问我"。
+        trust_waived = False
+        if requires_confirmation and not hitl_result.get("requires_confirmation", False):
+            _target_type = str(getattr(intent_profile, "target_type", "") or "").strip().lower()
+            if _target_type == "device" and eff_target_ref:
+                try:
+                    from core.peer_trust import PermissionResult, check_peer
+
+                    _intent_key = eff_intent_id or eff_action_level or ""
+                    if check_peer(eff_target_ref, _intent_key) is PermissionResult.ALLOWED:
+                        trust_waived = True
+                        requires_confirmation = False
+                        extra_notes.append(
+                            f"peer_trust waived confirmation for device={eff_target_ref!r} intent={_intent_key!r}"
+                        )
+                        logger.info(
+                            "对端信任豁免人工确认:device=%s intent=%s(配对时已显式授权)",
+                            eff_target_ref,
+                            _intent_key,
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    # 信任层故障时**保持要确认**(fail-closed):这里的失败方向与
+                    # 派发门相反 —— 派发门失败放行是为了不让整个 Mesh 停摆,
+                    # 而这里失败放行等于绕过人工确认,必须保守。
+                    logger.warning(
+                        "对端信任豁免检查失败(%s):保持要求人工确认(fail-closed)",
+                        exc,
+                    )
+
         if requires_confirmation:
             confirm_notes = list(extra_notes)
             if policy is not None and policy.requires_confirmation:
@@ -536,7 +578,11 @@ class ExecutionReadinessGate:
         return ReadinessResult(
             ready=True,
             status=ReadinessStatus.READY.value,
-            reason="execution is ready; all readiness gates passed",
+            reason=(
+                "execution is ready; confirmation waived by peer trust"
+                if trust_waived
+                else "execution is ready; all readiness gates passed"
+            ),
             requires_confirmation=False,
             policy_band=policy_band_str,
             blocked_by=BlockedBy.NONE.value,

--- a/core/local_brain_manager.py
+++ b/core/local_brain_manager.py
@@ -133,9 +133,18 @@ class LocalBrainManager:
             from core.ollama_endpoint import normalize_ollama_url
 
             return normalize_ollama_url(raw)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             if raw.startswith(("http://", "https://")):
                 return raw.rstrip("/")
+            # 到这里说明 raw 既不带协议头、规范化又失败了 —— 会被悄悄改指本机。
+            # 如果用户配的是一台远程 Ollama(比如写成 "10.0.0.5:11434" 少了协议头),
+            # 之前会静默查本机、报"模型没装",线索为零。
+            logger.warning(
+                "Ollama URL 规范化失败(raw=%r, %s):退回 http://localhost:11434;"
+                "若你配的是远程 Ollama,请补上 http:// 前缀",
+                raw,
+                exc,
+            )
             return "http://localhost:11434"
 
     @ollama_url.setter

--- a/core/memory/android_backflow.py
+++ b/core/memory/android_backflow.py
@@ -53,6 +53,7 @@ class AndroidMemoryBackflow:
 
     # ── 持久化 ──────────────────────────────────────────────────────────
     def _load(self) -> None:
+        n_bad = 0
         try:
             if not os.path.exists(self._path):
                 return
@@ -67,7 +68,18 @@ class AndroidMemoryBackflow:
                         if tid:
                             self._index[tid] = e  # 后写覆盖
                     except Exception:
+                        # 此前是裸 continue:损坏行被静默丢弃,而下面那句只报
+                        # 载入成功的条数 —— 一个半数损坏的文件看起来和完整文件
+                        # 一模一样,调用方无从知道记忆缺了一块。
+                        n_bad += 1
                         continue
+            if n_bad:
+                logger.warning(
+                    "Android 回流记忆:%d 行损坏已跳过(成功载入 %d 条): %s",
+                    n_bad,
+                    len(self._index),
+                    self._path,
+                )
             logger.info("Android 回流记忆载入 %d 条: %s", len(self._index), self._path)
         except Exception as exc:  # noqa: BLE001
             logger.debug("android backflow load skipped: %s", exc)

--- a/core/model_selection.py
+++ b/core/model_selection.py
@@ -101,7 +101,10 @@ def _default_tag() -> str:
         from core.model_catalog import default_model
 
         return default_model()
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
+        # 这个字面量是唯一真相源 default_model() 的副本,只在真相源读不到时兜底。
+        # 副本迟早会和真相源漂移(改了目录却忘了改这里),静默退回等于悄悄换了主脑。
+        logger.warning("读取默认主脑失败(%s):退回内置副本 gemma4:12b,可能与模型目录不一致", exc)
         return "gemma4:12b"
 
 

--- a/core/peer_trust.py
+++ b/core/peer_trust.py
@@ -1,0 +1,318 @@
+"""core/peer_trust.py — 对端分级信任(blocked / unknown / ask / friend / trusted)
+
+为什么需要这一层
+----------------
+本仓库此前有两种"信任",但都不是**对端信任**:
+
+* ``trust_level`` 在 ``execution_governance_audit_authority`` 等处出现,含义是
+  **数据源可信度**(high/medium/low),回答的是"这条真相该不该采信";
+* ``core/governance/tool_governor.py`` 的风险分级,回答的是"这个**动作**危不危险"。
+
+缺的是第三个问题:**"这台设备/这个智能体,我信到什么程度"**。没有它,HITL 只能在
+"每次都问"和"全都不问"之间二选一 —— 一台刚扫码进来的陌生设备和自己的主力机
+被一视同仁。
+
+本模块补上这一层,并刻意与既有两层**正交**:
+    风险分级(动作多危险) × 对端信任(这台设备多可信) → 放行 / 拒绝 / 要人确认
+
+设计要点
+--------
+* 五级:``blocked`` < ``unknown`` < ``ask`` < ``friend`` < ``trusted``。
+* ``friend`` 支持 ``auto_accept`` 通配模式(fnmatch,如 ``"messaging.*"``),
+  只对匹配上的意图免确认,其余仍要人确认 —— 这是"只问该问的"的关键。
+* ``blocked`` 是**硬拒绝**:不看意图、不看模式,直接 DENIED。
+* 未登记的对端按 ``default_trust`` 处理(默认 ``ask``,即保守要人确认)。
+  可用 ``GALAXY_PEER_DEFAULT_TRUST`` 覆盖。
+* 落盘用"写临时文件 → flush → fsync → os.replace → fsync 目录"的原子序列;
+  ``os.replace`` 的原子性只覆盖目录项,不覆盖数据块,所以 fsync 不能省。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from fnmatch import fnmatch
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.PeerTrust")
+
+
+class TrustLevel(str, Enum):
+    """对端信任级别(由低到高)。"""
+
+    BLOCKED = "blocked"
+    UNKNOWN = "unknown"
+    ASK = "ask"
+    FRIEND = "friend"
+    TRUSTED = "trusted"
+
+
+#: 由低到高的次序,用于比较(不要依赖 Enum 定义顺序做大小比较)。
+_ORDER: Dict[str, int] = {
+    TrustLevel.BLOCKED.value: 0,
+    TrustLevel.UNKNOWN.value: 1,
+    TrustLevel.ASK.value: 2,
+    TrustLevel.FRIEND.value: 3,
+    TrustLevel.TRUSTED.value: 4,
+}
+
+
+class PermissionResult(str, Enum):
+    """一次意图检查的结论。"""
+
+    ALLOWED = "allowed"
+    DENIED = "denied"
+    REQUIRE_APPROVAL = "require_approval"
+
+
+def trust_rank(level: Any) -> int:
+    """把任意信任级别表示折算成可比较的序数;不认识的按 UNKNOWN。"""
+    raw = getattr(level, "value", level)
+    return _ORDER.get(str(raw).strip().lower(), _ORDER[TrustLevel.UNKNOWN.value])
+
+
+def coerce_trust(level: Any, default: TrustLevel = TrustLevel.UNKNOWN) -> TrustLevel:
+    """把任意输入折算成 TrustLevel;不认识的返回 *default*。
+
+    注意 TrustLevel 是 (str, Enum),``str(member)`` 得到的是 ``'TrustLevel.ASK'``
+    而不是 ``'ask'`` —— 因此这里一律走 ``.value``。
+    """
+    raw = getattr(level, "value", level)
+    key = str(raw).strip().lower()
+    for member in TrustLevel:
+        if member.value == key:
+            return member
+    return default
+
+
+@dataclass
+class PeerRecord:
+    """一个已登记对端的信任档案。"""
+
+    device_id: str
+    name: str = ""
+    trust: str = TrustLevel.UNKNOWN.value
+    #: fnmatch 模式列表;仅在 trust >= friend 时参与自动放行
+    auto_accept: List[str] = field(default_factory=list)
+    #: 配对时对方名片声明的能力(仅作展示/审计,不作为授权依据)
+    capabilities: List[str] = field(default_factory=list)
+    paired_at: float = 0.0
+    last_seen: float = 0.0
+    note: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _default_trust() -> TrustLevel:
+    return coerce_trust(os.getenv("GALAXY_PEER_DEFAULT_TRUST", "").strip(), TrustLevel.ASK)
+
+
+def _store_path() -> str:
+    explicit = os.getenv("GALAXY_PEER_TRUST_PATH", "").strip()
+    if explicit:
+        return explicit
+    base = os.getenv("GALAXY_DATA_DIR", "").strip() or os.path.join(os.getcwd(), "data")
+    return os.path.join(base, "peer_trust.json")
+
+
+class PeerTrustBook:
+    """对端信任档案簿(进程内单例,见 get_peer_trust_book)。"""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self._lock = threading.RLock()
+        self._path = path or _store_path()
+        self._peers: Dict[str, PeerRecord] = {}
+        self._load()
+
+    # ── 持久化 ────────────────────────────────────────────────────────────
+    def _load(self) -> None:
+        n_bad = 0
+        try:
+            if not os.path.exists(self._path):
+                return
+            with open(self._path, encoding="utf-8") as fh:
+                raw = json.load(fh)
+            for did, rec in (raw.get("peers") or {}).items():
+                try:
+                    self._peers[str(did)] = PeerRecord(
+                        device_id=str(did),
+                        name=str(rec.get("name", "") or ""),
+                        trust=coerce_trust(rec.get("trust")).value,
+                        auto_accept=[str(p) for p in (rec.get("auto_accept") or [])],
+                        capabilities=[str(c) for c in (rec.get("capabilities") or [])],
+                        paired_at=float(rec.get("paired_at", 0.0) or 0.0),
+                        last_seen=float(rec.get("last_seen", 0.0) or 0.0),
+                        note=str(rec.get("note", "") or ""),
+                    )
+                except Exception:  # noqa: BLE001 — 单条损坏不该拖垮整簿
+                    n_bad += 1
+            if n_bad:
+                # 静默跳过会让"信任档案缺了一块"完全不可见 —— 而缺失的档案会让
+                # 原本 trusted 的设备悄悄降级成 default_trust(多问几次尚可接受),
+                # 或让原本 blocked 的设备**不再被拦**(不可接受)。必须告警。
+                logger.warning(
+                    "对端信任档案有 %d 条损坏已跳过(成功载入 %d 条):%s;" "被跳过的 blocked 条目将不再生效,请检查该文件",
+                    n_bad,
+                    len(self._peers),
+                    self._path,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("对端信任档案载入失败(按空档案继续):%s: %s", self._path, exc)
+
+    def _save_unlocked(self) -> None:
+        payload = {
+            "version": 1,
+            "updated_at": time.time(),
+            "peers": {did: rec.to_dict() for did, rec in self._peers.items()},
+        }
+        d = os.path.dirname(os.path.abspath(self._path))
+        try:
+            os.makedirs(d, exist_ok=True)
+            tmp = f"{self._path}.tmp"
+            with open(tmp, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, ensure_ascii=False, indent=2)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, self._path)
+            # os.replace 只保证目录项原子替换,不保证数据块已落盘;
+            # 目录本身也要 fsync,否则崩溃后可能看不到这次改名。
+            try:
+                dfd = os.open(d, os.O_RDONLY)
+                try:
+                    os.fsync(dfd)
+                finally:
+                    os.close(dfd)
+            except OSError:
+                pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("对端信任档案落盘失败(内存内仍生效,重启后丢失):%s", exc)
+
+    # ── 读 ────────────────────────────────────────────────────────────────
+    def get(self, device_id: str) -> Optional[PeerRecord]:
+        with self._lock:
+            rec = self._peers.get(str(device_id))
+            return PeerRecord(**rec.to_dict()) if rec else None
+
+    def list_peers(self) -> List[PeerRecord]:
+        with self._lock:
+            return [PeerRecord(**r.to_dict()) for r in self._peers.values()]
+
+    def trust_of(self, device_id: str) -> TrustLevel:
+        """未登记对端返回 default_trust。"""
+        with self._lock:
+            rec = self._peers.get(str(device_id))
+        return coerce_trust(rec.trust) if rec else _default_trust()
+
+    # ── 写 ────────────────────────────────────────────────────────────────
+    def upsert(
+        self,
+        device_id: str,
+        *,
+        name: Optional[str] = None,
+        trust: Optional[Any] = None,
+        auto_accept: Optional[List[str]] = None,
+        capabilities: Optional[List[str]] = None,
+        note: Optional[str] = None,
+    ) -> PeerRecord:
+        did = str(device_id)
+        with self._lock:
+            rec = self._peers.get(did) or PeerRecord(device_id=did, paired_at=time.time())
+            if name is not None:
+                rec.name = str(name)
+            if trust is not None:
+                rec.trust = coerce_trust(trust).value
+            if auto_accept is not None:
+                rec.auto_accept = [str(p) for p in auto_accept]
+            if capabilities is not None:
+                rec.capabilities = [str(c) for c in capabilities]
+            if note is not None:
+                rec.note = str(note)
+            self._peers[did] = rec
+            self._save_unlocked()
+            out = PeerRecord(**rec.to_dict())
+        logger.info("对端信任已更新:device_id=%s trust=%s auto_accept=%s", did, out.trust, out.auto_accept)
+        return out
+
+    def set_trust(self, device_id: str, trust: Any) -> PeerRecord:
+        return self.upsert(device_id, trust=trust)
+
+    def touch(self, device_id: str) -> None:
+        """记录一次活动时间(不存在则不创建,避免陌生设备被隐式登记)。"""
+        with self._lock:
+            rec = self._peers.get(str(device_id))
+            if rec is None:
+                return
+            rec.last_seen = time.time()
+            self._save_unlocked()
+
+    def remove(self, device_id: str) -> bool:
+        with self._lock:
+            existed = self._peers.pop(str(device_id), None) is not None
+            if existed:
+                self._save_unlocked()
+        if existed:
+            logger.info("对端已从信任档案移除:device_id=%s", device_id)
+        return existed
+
+    # ── 判定 ──────────────────────────────────────────────────────────────
+    def check(self, device_id: str, intent: str = "") -> PermissionResult:
+        """对 *device_id* 执行 *intent* 的放行判定。
+
+        规则(自上而下,先命中先返回):
+          1. blocked            → DENIED(硬拒绝,不看意图)
+          2. trusted            → ALLOWED
+          3. friend + 模式命中  → ALLOWED
+          4. 其余(unknown/ask/friend 未命中) → REQUIRE_APPROVAL
+        """
+        level = self.trust_of(device_id)
+        if level is TrustLevel.BLOCKED:
+            return PermissionResult.DENIED
+        if level is TrustLevel.TRUSTED:
+            return PermissionResult.ALLOWED
+        if level is TrustLevel.FRIEND and intent:
+            rec = self.get(device_id)
+            for pattern in (rec.auto_accept if rec else []):
+                if fnmatch(intent, pattern):
+                    return PermissionResult.ALLOWED
+        return PermissionResult.REQUIRE_APPROVAL
+
+
+# ── 进程级单例 ────────────────────────────────────────────────────────────
+_book_lock = threading.Lock()
+_book: Optional[PeerTrustBook] = None
+
+
+def get_peer_trust_book() -> PeerTrustBook:
+    global _book
+    if _book is not None:
+        return _book
+    with _book_lock:
+        if _book is None:
+            _book = PeerTrustBook()
+    return _book
+
+
+def reset_peer_trust_book() -> None:
+    """测试用:丢弃单例,下次重新从盘上载入。"""
+    global _book
+    with _book_lock:
+        _book = None
+
+
+# ── 便捷函数(供调用方少写两行)────────────────────────────────────────────
+def trust_of(device_id: str) -> TrustLevel:
+    return get_peer_trust_book().trust_of(device_id)
+
+
+def is_blocked(device_id: str) -> bool:
+    return get_peer_trust_book().trust_of(device_id) is TrustLevel.BLOCKED
+
+
+def check_peer(device_id: str, intent: str = "") -> PermissionResult:
+    return get_peer_trust_book().check(device_id, intent)

--- a/core/routes/pairing.py
+++ b/core/routes/pairing.py
@@ -48,6 +48,30 @@ def _scopes_for_trust(trust: str) -> List[str]:
     return list(_TRUST_SCOPES.get(str(trust).lower(), _TRUST_SCOPES["unknown"]))
 
 
+def _server_error(where: str, exc: Exception) -> JSONResponse:
+    """把内部异常转成脱敏响应:完整异常只进服务端日志。
+
+    起因是 CodeQL 的 "Information exposure through an exception":原先这里
+    直接 ``str(exc)`` 回给调用方,而异常文本可能带出文件路径、内部模块名、
+    密钥文件位置等。配对接口尤其敏感 —— 它就是信任链的入口。
+
+    与仓库既有做法一致(见 core/routes/models.py::verify_provider:
+    "分类成用户能行动的脱敏文案;完整异常只进服务端日志")。
+
+    仍返回一个稳定的 ``error_code``,让调用方能据此分支处理、并凭它去
+    服务端日志里定位对应那条 ERROR —— 脱敏不等于让人无从排查。
+    """
+    logger.error("配对接口内部错误 [%s]: %s", where, exc, exc_info=True)
+    return JSONResponse(
+        {
+            "success": False,
+            "error": "内部错误,请查看服务端日志",
+            "error_code": where,
+        },
+        status_code=500,
+    )
+
+
 class ClaimRequest(BaseModel):
     #: 二选一:配对链接(galaxy://pair?...)或 6 位短码
     link: Optional[str] = None
@@ -105,8 +129,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                 }
             )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("出示本机名片失败: %s", exc)
-            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+            return _server_error("pair_card", exc)
 
     @router.post("/api/v1/pair/claim")
     async def claim_peer(req: ClaimRequest):
@@ -178,8 +201,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                 }
             )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("配对失败: %s", exc)
-            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+            return _server_error("pair_claim", exc)
 
     @router.get("/api/v1/pair/peers")
     async def list_peers():
@@ -189,7 +211,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             peers = [p.to_dict() for p in get_peer_trust_book().list_peers()]
             return JSONResponse({"success": True, "count": len(peers), "peers": peers})
         except Exception as exc:  # noqa: BLE001
-            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+            return _server_error("pair_list_peers", exc)
 
     @router.get("/api/v1/pair/peers/{device_id}")
     async def get_peer(device_id: str):
@@ -212,7 +234,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                 )
             return JSONResponse({"success": True, "registered": True, "peer": rec.to_dict()})
         except Exception as exc:  # noqa: BLE001
-            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+            return _server_error("pair_get_peer", exc)
 
     @router.post("/api/v1/pair/trust")
     async def set_trust(req: TrustRequest):
@@ -235,7 +257,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                 }
             )
         except Exception as exc:  # noqa: BLE001
-            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+            return _server_error("pair_set_trust", exc)
 
     @router.delete("/api/v1/pair/peers/{device_id}")
     async def remove_peer(device_id: str):
@@ -245,7 +267,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             removed = get_peer_trust_book().remove(device_id)
             return JSONResponse({"success": True, "removed": removed, "device_id": device_id})
         except Exception as exc:  # noqa: BLE001
-            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+            return _server_error("pair_remove_peer", exc)
 
     @router.post("/api/v1/pair/check")
     async def check_intent(req: CheckRequest):
@@ -268,6 +290,6 @@ def create_router(service_manager=None, config=None) -> APIRouter:
                 }
             )
         except Exception as exc:  # noqa: BLE001
-            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+            return _server_error("pair_check", exc)
 
     return router

--- a/core/routes/pairing.py
+++ b/core/routes/pairing.py
@@ -1,0 +1,273 @@
+"""core/routes/pairing.py — 配对与对端信任的对外接口
+
+端点
+----
+  GET    /api/v1/pair/card              本机名片(链接 + 短码,可扫码或口述)
+  POST   /api/v1/pair/claim             凭链接或短码接纳一台对端,并签发能力令牌
+  GET    /api/v1/pair/peers             已登记对端列表
+  GET    /api/v1/pair/peers/{device_id} 单个对端档案
+  POST   /api/v1/pair/trust             调整对端信任级别 / 自动放行模式
+  DELETE /api/v1/pair/peers/{device_id} 移除对端
+  POST   /api/v1/pair/check             试算一次意图判定(排障用,不产生副作用)
+
+为什么把"签发能力令牌"放在配对里
+--------------------------------
+``core/capability_token.py`` 此前**全仓只有测试在调用** —— 签发/校验能力令牌的
+基础设施造好了却没有任何生产路径使用它。配对是它天然的入口:
+接纳一台设备的那一刻,正是该决定"它能干什么、到什么时候"的时刻。
+
+令牌作用域由信任级别推导(见 :func:`_scopes_for_trust`),因此
+"提升信任" 与 "扩大授权" 是同一个动作,不会出现两套彼此漂移的权限来源。
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger("Galaxy.API.Pairing")
+
+#: 各信任级别对应的能力令牌作用域。
+#: 刻意保守:blocked 无令牌;ask/unknown 只给只读;friend 给常规操作;
+#: trusted 才给通配。改这里等于改整个 Mesh 的授权面,故集中在一处。
+_TRUST_SCOPES: Dict[str, List[str]] = {
+    "blocked": [],
+    "unknown": ["device:status"],
+    "ask": ["device:status"],
+    "friend": ["device:status", "device:tap", "device:input", "messaging:*"],
+    "trusted": ["*"],
+}
+
+
+def _scopes_for_trust(trust: str) -> List[str]:
+    return list(_TRUST_SCOPES.get(str(trust).lower(), _TRUST_SCOPES["unknown"]))
+
+
+class ClaimRequest(BaseModel):
+    #: 二选一:配对链接(galaxy://pair?...)或 6 位短码
+    link: Optional[str] = None
+    code: Optional[str] = None
+    #: 接纳时赋予的信任级别,默认 ask(保守:先接进来,动作仍要人确认)
+    trust: str = "ask"
+    auto_accept: Optional[List[str]] = None
+    note: str = ""
+    #: 能力令牌有效期
+    token_ttl_s: float = 24 * 3600.0
+
+
+class TrustRequest(BaseModel):
+    device_id: str
+    trust: Optional[str] = None
+    auto_accept: Optional[List[str]] = None
+    note: Optional[str] = None
+
+
+class CheckRequest(BaseModel):
+    device_id: str
+    intent: str = ""
+
+
+def create_router(service_manager=None, config=None) -> APIRouter:
+    """配对与对端信任路由。"""
+    router = APIRouter()
+
+    @router.get("/api/v1/pair/card")
+    async def get_local_card(ttl_s: float = 0.0, code_ttl_s: float = 0.0):
+        """出示本机名片:同时给出可扫码的链接与可口述的短码。
+
+        两种形态覆盖两类现场:有屏幕有摄像头的扫码,和只有终端的手输。
+        """
+        try:
+            from core.agent_card import (
+                DEFAULT_CARD_TTL_S,
+                DEFAULT_CODE_TTL_S,
+                build_local_card,
+                get_pairing_code_registry,
+                to_link,
+            )
+
+            card = build_local_card(ttl_s=ttl_s or DEFAULT_CARD_TTL_S)
+            link = to_link(card)
+            code, code_exp = get_pairing_code_registry().issue(link, ttl_s=code_ttl_s or DEFAULT_CODE_TTL_S)
+            return JSONResponse(
+                {
+                    "success": True,
+                    "card": card.to_dict(),
+                    "link": link,
+                    "code": code,
+                    "code_expires_at": code_exp,
+                    "hint": "对方可扫码/粘贴 link,或在无摄像头场景直接输入 code(一次性,默认 10 分钟内有效)",
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("出示本机名片失败: %s", exc)
+            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+    @router.post("/api/v1/pair/claim")
+    async def claim_peer(req: ClaimRequest):
+        """凭链接或短码接纳一台对端。
+
+        名片签名校验不通过一律拒绝 —— 这是信任链的入口,不能"内容看着对"就放行。
+        """
+        try:
+            from core.agent_card import from_link, get_pairing_code_registry
+            from core.peer_trust import TrustLevel, coerce_trust, get_peer_trust_book
+
+            link = (req.link or "").strip()
+            if not link:
+                code = (req.code or "").strip()
+                if not code:
+                    return JSONResponse({"success": False, "error": "需要提供 link 或 code"}, status_code=400)
+                link = get_pairing_code_registry().resolve(code) or ""
+                if not link:
+                    return JSONResponse(
+                        {"success": False, "error": "配对码无效或已过期/已被使用"},
+                        status_code=400,
+                    )
+
+            verdict = from_link(link)
+            if not verdict.valid or verdict.card is None:
+                logger.warning("配对被拒:名片校验失败 —— %s", verdict.reason)
+                return JSONResponse({"success": False, "error": verdict.reason}, status_code=400)
+
+            card = verdict.card
+            trust = coerce_trust(req.trust, TrustLevel.ASK)
+            book = get_peer_trust_book()
+            rec = book.upsert(
+                card.device_id,
+                name=card.name,
+                trust=trust,
+                auto_accept=req.auto_accept if req.auto_accept is not None else [],
+                capabilities=card.capabilities,
+                note=req.note,
+            )
+
+            # 能力令牌:作用域由信任级别推导,与信任同源,不另立一套权限。
+            token: Optional[str] = None
+            scopes = _scopes_for_trust(rec.trust)
+            if scopes:
+                try:
+                    from core.capability_token import issue_token
+
+                    token = issue_token(card.device_id, scopes, ttl_s=req.token_ttl_s)
+                except Exception as exc:  # noqa: BLE001
+                    # 令牌签发失败不该让配对整体回滚(对端已登记、信任已生效),
+                    # 但必须让调用方知道它没拿到令牌,否则会以为拿到了。
+                    logger.warning("配对成功但能力令牌签发失败:device_id=%s: %s", card.device_id, exc)
+
+            logger.info(
+                "配对成功:device_id=%s name=%s trust=%s scopes=%s",
+                card.device_id,
+                card.name,
+                rec.trust,
+                scopes,
+            )
+            return JSONResponse(
+                {
+                    "success": True,
+                    "peer": rec.to_dict(),
+                    "capability_token": token,
+                    "token_scopes": scopes,
+                    "token_issued": token is not None,
+                    "endpoints": card.endpoints,
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("配对失败: %s", exc)
+            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+    @router.get("/api/v1/pair/peers")
+    async def list_peers():
+        try:
+            from core.peer_trust import get_peer_trust_book
+
+            peers = [p.to_dict() for p in get_peer_trust_book().list_peers()]
+            return JSONResponse({"success": True, "count": len(peers), "peers": peers})
+        except Exception as exc:  # noqa: BLE001
+            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+    @router.get("/api/v1/pair/peers/{device_id}")
+    async def get_peer(device_id: str):
+        try:
+            from core.peer_trust import get_peer_trust_book
+
+            book = get_peer_trust_book()
+            rec = book.get(device_id)
+            if rec is None:
+                # 未登记不是错误:如实告知它当前按默认信任处理,而不是 404 让调用方
+                # 以为"这台设备不存在"。
+                return JSONResponse(
+                    {
+                        "success": True,
+                        "registered": False,
+                        "device_id": device_id,
+                        "effective_trust": book.trust_of(device_id).value,
+                        "hint": "该对端尚未配对,按默认信任级别处理",
+                    }
+                )
+            return JSONResponse({"success": True, "registered": True, "peer": rec.to_dict()})
+        except Exception as exc:  # noqa: BLE001
+            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+    @router.post("/api/v1/pair/trust")
+    async def set_trust(req: TrustRequest):
+        """调整信任级别 / 自动放行模式。提升信任会同步扩大令牌作用域(下次签发生效)。"""
+        try:
+            from core.peer_trust import get_peer_trust_book
+
+            book = get_peer_trust_book()
+            rec = book.upsert(
+                req.device_id,
+                trust=req.trust,
+                auto_accept=req.auto_accept,
+                note=req.note,
+            )
+            return JSONResponse(
+                {
+                    "success": True,
+                    "peer": rec.to_dict(),
+                    "token_scopes_next_issue": _scopes_for_trust(rec.trust),
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+    @router.delete("/api/v1/pair/peers/{device_id}")
+    async def remove_peer(device_id: str):
+        try:
+            from core.peer_trust import get_peer_trust_book
+
+            removed = get_peer_trust_book().remove(device_id)
+            return JSONResponse({"success": True, "removed": removed, "device_id": device_id})
+        except Exception as exc:  # noqa: BLE001
+            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+    @router.post("/api/v1/pair/check")
+    async def check_intent(req: CheckRequest):
+        """试算判定,便于排障:为什么这台设备的这个动作被拦/被放行。"""
+        try:
+            from core.peer_trust import get_peer_trust_book
+
+            book = get_peer_trust_book()
+            result = book.check(req.device_id, req.intent)
+            rec = book.get(req.device_id)
+            return JSONResponse(
+                {
+                    "success": True,
+                    "device_id": req.device_id,
+                    "intent": req.intent,
+                    "trust": book.trust_of(req.device_id).value,
+                    "auto_accept": rec.auto_accept if rec else [],
+                    "result": result.value,
+                    "checked_at": time.time(),
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            return JSONResponse({"success": False, "error": str(exc)}, status_code=500)
+
+    return router

--- a/core/task_graph_runtime.py
+++ b/core/task_graph_runtime.py
@@ -914,12 +914,10 @@ class TaskGraphRuntime:
                 n_loaded += 1
             except Exception as exc:  # noqa: BLE001
                 logger.debug("task_graph_runtime: 跳过损坏节点记录: %s", exc)
-        # 边的处理此前与节点【不对称】:节点损坏会记 debug 并计数,边损坏则是
-        # 裸 except: pass —— 一个字都不留,末尾那句汇总也只报节点数。于是一次
-        # 丢了依赖边的续跑看上去完全成功,而重建出来的 DAG 少了 depends_on,
-        # 任务会以错误的顺序执行(或在前置根本没跑完时就启动)。这里补齐计数与告警。
-        n_edges = 0
-        n_edges_bad = 0
+        # 边此前是裸 except: pass(节点则有 debug + 计数)。丢边不报错,只是让
+        # 重建的 DAG 少了 depends_on —— 任务会以错误顺序执行,比丢节点更隐蔽,
+        # 故用 warning 而非 debug。
+        n_edges = n_edges_bad = 0
         for ed in data.get("edges", []) or []:
             try:
                 edge = GraphEdge.from_dict(ed) if hasattr(GraphEdge, "from_dict") else None
@@ -932,7 +930,6 @@ class TaskGraphRuntime:
                 n_edges_bad += 1
                 logger.debug("task_graph_runtime: 跳过损坏边记录: %s", exc)
         if n_edges_bad:
-            # 丢边会改变执行顺序,比丢节点更隐蔽 —— 必须是 warning 而不是 debug。
             logger.warning(
                 "task_graph_runtime: 检查点中有 %d 条边无法重建(已重建 %d 条);续跑的 DAG 依赖关系可能不完整 ← %s",
                 n_edges_bad,

--- a/core/task_graph_runtime.py
+++ b/core/task_graph_runtime.py
@@ -914,15 +914,38 @@ class TaskGraphRuntime:
                 n_loaded += 1
             except Exception as exc:  # noqa: BLE001
                 logger.debug("task_graph_runtime: 跳过损坏节点记录: %s", exc)
+        # 边的处理此前与节点【不对称】:节点损坏会记 debug 并计数,边损坏则是
+        # 裸 except: pass —— 一个字都不留,末尾那句汇总也只报节点数。于是一次
+        # 丢了依赖边的续跑看上去完全成功,而重建出来的 DAG 少了 depends_on,
+        # 任务会以错误的顺序执行(或在前置根本没跑完时就启动)。这里补齐计数与告警。
+        n_edges = 0
+        n_edges_bad = 0
         for ed in data.get("edges", []) or []:
             try:
                 edge = GraphEdge.from_dict(ed) if hasattr(GraphEdge, "from_dict") else None
                 if edge is not None and edge.edge_id:
                     self._edges[edge.edge_id] = edge
-            except Exception:  # noqa: BLE001
-                pass
+                    n_edges += 1
+                else:
+                    n_edges_bad += 1
+            except Exception as exc:  # noqa: BLE001
+                n_edges_bad += 1
+                logger.debug("task_graph_runtime: 跳过损坏边记录: %s", exc)
+        if n_edges_bad:
+            # 丢边会改变执行顺序,比丢节点更隐蔽 —— 必须是 warning 而不是 debug。
+            logger.warning(
+                "task_graph_runtime: 检查点中有 %d 条边无法重建(已重建 %d 条);续跑的 DAG 依赖关系可能不完整 ← %s",
+                n_edges_bad,
+                n_edges,
+                self._state_path,
+            )
         if n_loaded:
-            logger.info("task_graph_runtime: 从检查点重建 %d 个节点(续跑基础) ← %s", n_loaded, self._state_path)
+            logger.info(
+                "task_graph_runtime: 从检查点重建 %d 个节点 / %d 条边(续跑基础) ← %s",
+                n_loaded,
+                n_edges,
+                self._state_path,
+            )
 
     def completed_task_ids(self) -> List[str]:
         """已到终态且成功(COMPLETED)的 task_id —— 续跑时应跳过。"""

--- a/core/unified_dispatch_readiness_gate.py
+++ b/core/unified_dispatch_readiness_gate.py
@@ -172,6 +172,10 @@ class DispatchReadinessStatus(str, Enum):
     BLOCKED_CAPABILITY
         Device does not satisfy the required capability / action constraints
         for this dispatch request.
+    BLOCKED_PEER_TRUST
+        The peer is explicitly ``blocked`` in ``core.peer_trust``.  Dispatch is
+        refused before any other check — a blacklisted peer must not receive
+        work regardless of how healthy its registration or transport looks.
     BLOCKED_SESSION_VALIDITY
         Session identity is invalid, stale, or conflicts with an active
         session for this device.
@@ -212,6 +216,7 @@ class DispatchReadinessStatus(str, Enum):
     BLOCKED_STALE_ATTACHMENT = "blocked_stale_attachment"
     BLOCKED_TRANSPORT = "blocked_transport"
     BLOCKED_CAPABILITY = "blocked_capability"
+    BLOCKED_PEER_TRUST = "blocked_peer_trust"
     BLOCKED_SESSION_VALIDITY = "blocked_session_validity"
     BLOCKED_CROSS_DEVICE_ELIGIBILITY = "blocked_cross_device_eligibility"
     BLOCKED_OPERATIONAL_SUPPORT = "blocked_operational_support"
@@ -279,6 +284,10 @@ class DispatchReadinessResult:
     device_type: Optional[str] = None
     operational_support_status: Optional[str] = None
     operational_support_reason: str = ""
+    #: 该对端在 core.peer_trust 中的信任级别(blocked/unknown/ask/friend/trusted)。
+    #: 即使未拦截也一并带出,让调用方(尤其是要不要人确认的执行策略层)拿到判据,
+    #: 不必再查一次。信任层不可用时保持 "unknown"。
+    peer_trust: str = "unknown"
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -296,6 +305,7 @@ class DispatchReadinessResult:
             "device_type": self.device_type,
             "operational_support_status": self.operational_support_status,
             "operational_support_reason": self.operational_support_reason,
+            "peer_trust": self.peer_trust,
             "authority": UNIFIED_DISPATCH_READINESS_GATE_AUTHORITY,
         }
 
@@ -391,6 +401,52 @@ def _evaluate_impl(
         notes.append(f"execution_mode={execution_mode!r}")
 
     # ----------------------------------------------------------------
+    # Gate 0: Peer trust check (core.peer_trust)
+    #
+    # 必须排在所有检查之前:一台被显式 blocked 的设备,不论它注册得多完整、
+    # 传输多健康,都不该收到任何派发。放在后面等于"先验证一台已经被拉黑的
+    # 设备是否健康",既浪费也容易在某条早退分支里被绕过。
+    #
+    # 这里只拦 blocked(硬拒绝)。ask / friend / unknown 属于"要不要人确认"的
+    # 范畴,那是执行策略层(requires_confirmation)的职责,不是派发就绪的职责 ——
+    # 在这里把 ask 也拦掉会让所有未登记设备直接不可派发,属于越权。
+    # ----------------------------------------------------------------
+    trust_value = "unknown"
+    try:
+        from core.peer_trust import TrustLevel, get_peer_trust_book
+
+        _book = get_peer_trust_book()
+        _level = _book.trust_of(device_id)
+        trust_value = _level.value
+        if _level is TrustLevel.BLOCKED:
+            logger.warning(
+                "UnifiedDispatchReadinessGate: BLOCKED_PEER_TRUST device_id=%r —— 该对端已被显式拉黑,拒绝派发",
+                device_id,
+            )
+            return DispatchReadinessResult(
+                device_id=device_id,
+                dispatch_ready=False,
+                registered=False,
+                status=DispatchReadinessStatus.BLOCKED_PEER_TRUST.value,
+                reason=(
+                    f"Peer trust for device_id={device_id!r} is 'blocked'. "
+                    "Dispatch is refused regardless of registration or transport state. "
+                    "Raise the trust level via the pairing API to re-enable."
+                ),
+                peer_trust=trust_value,
+                blocking_notes=notes + ["peer_trust=blocked"],
+            )
+    except Exception as exc:  # noqa: BLE001
+        # 信任层不可用时**放行**并告警:这一层是在既有链路上加固,不是新的
+        # 单点故障源;它自己坏掉不该让整个 Mesh 停止派发。但必须可见,
+        # 否则"拉黑不再生效"会完全无声。
+        logger.warning(
+            "UnifiedDispatchReadinessGate: 对端信任检查失败(%s):device_id=%r 按未拉黑继续(fail-open)",
+            exc,
+            device_id,
+        )
+
+    # ----------------------------------------------------------------
     # Gate 1: Registration gap check
     # Must be evaluated early because a gap means attachment steps failed
     # and subsequent checks may not have reliable data.
@@ -414,6 +470,7 @@ def _evaluate_impl(
             ),
             registration_gaps=gaps,
             blocking_notes=notes,
+            peer_trust=trust_value,
         )
 
     # ----------------------------------------------------------------
@@ -435,6 +492,7 @@ def _evaluate_impl(
             status=DispatchReadinessStatus.NOT_REGISTERED.value,
             reason="Device is not registered in UDM.",
             blocking_notes=notes,
+            peer_trust=trust_value,
         )
 
     support_result = _check_device_operational_support(
@@ -453,6 +511,7 @@ def _evaluate_impl(
             device_type=support_result["device_type"],
             operational_support_status=support_result["support_tier"],
             operational_support_reason=support_result["reason"],
+            peer_trust=trust_value,
         )
 
     # ----------------------------------------------------------------
@@ -476,6 +535,7 @@ def _evaluate_impl(
             device_type=support_result["device_type"],
             operational_support_status=support_result["support_tier"],
             operational_support_reason=support_result["reason"],
+            peer_trust=trust_value,
         )
 
     # ----------------------------------------------------------------
@@ -507,6 +567,7 @@ def _evaluate_impl(
             device_type=support_result["device_type"],
             operational_support_status=support_result["support_tier"],
             operational_support_reason=support_result["reason"],
+            peer_trust=trust_value,
         )
 
     # ----------------------------------------------------------------
@@ -535,6 +596,7 @@ def _evaluate_impl(
                 device_type=support_result["device_type"],
                 operational_support_status=support_result["support_tier"],
                 operational_support_reason=support_result["reason"],
+                peer_trust=trust_value,
             )
 
     # ----------------------------------------------------------------
@@ -562,6 +624,7 @@ def _evaluate_impl(
                 device_type=support_result["device_type"],
                 operational_support_status=support_result["support_tier"],
                 operational_support_reason=support_result["reason"],
+                peer_trust=trust_value,
             )
 
     # ----------------------------------------------------------------
@@ -587,6 +650,7 @@ def _evaluate_impl(
         device_type=support_result["device_type"],
         operational_support_status=support_result["support_tier"],
         operational_support_reason=support_result["reason"],
+        peer_trust=trust_value,
     )
 
 

--- a/tests/test_peer_trust_and_pairing.py
+++ b/tests/test_peer_trust_and_pairing.py
@@ -1,0 +1,364 @@
+"""对端信任 + 智能体名片配对的行为测试。
+
+覆盖三件事,每件都要求"真的接上了",而不只是模块能 import:
+
+1. :mod:`core.peer_trust` 的五级判定与自动放行模式;
+2. :mod:`core.agent_card` 的签名防篡改、过期、短码一次性;
+3. **接入证明** —— 端点真的挂进了 ``create_api_routes()``,
+   且 ``evaluate_dispatch_readiness()`` 真的会因 blocked 而拒绝派发。
+
+第 3 类是重点:本仓库反复出现"模块造好了但没有任何生产调用方"
+(``core/capability_token.py`` 在本次改动前就是如此,全仓只有测试在用它)。
+因此这里不满足于"函数能调通",而是从真实路由表和真实派发门去断言。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from route_introspection import iter_flat_routes  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(tmp_path, monkeypatch):
+    """每个用例一份独立的信任档案与配对码表,避免互相污染。"""
+    monkeypatch.setenv("GALAXY_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("GALAXY_PEER_DEFAULT_TRUST", raising=False)
+    import core.agent_card as ac
+    import core.peer_trust as pt
+
+    pt.reset_peer_trust_book()
+    ac.reset_pairing_code_registry()
+    yield
+    pt.reset_peer_trust_book()
+    ac.reset_pairing_code_registry()
+
+
+# ── 1. 信任判定 ───────────────────────────────────────────────────────────
+class TestTrustDecisions:
+    def test_blocked_is_hard_denial_regardless_of_intent(self):
+        from core.peer_trust import PermissionResult, TrustLevel, get_peer_trust_book
+
+        book = get_peer_trust_book()
+        # 即便给了通配自动放行,blocked 也必须拒绝 —— 拉黑优先于一切
+        book.upsert("evil", trust=TrustLevel.BLOCKED, auto_accept=["*"])
+        assert book.check("evil", "messaging.send") is PermissionResult.DENIED
+        assert book.check("evil", "") is PermissionResult.DENIED
+
+    def test_trusted_allows_without_patterns(self):
+        from core.peer_trust import PermissionResult, TrustLevel, get_peer_trust_book
+
+        book = get_peer_trust_book()
+        book.upsert("main-pc", trust=TrustLevel.TRUSTED)
+        assert book.check("main-pc", "anything.at.all") is PermissionResult.ALLOWED
+
+    def test_friend_only_auto_accepts_matching_patterns(self):
+        from core.peer_trust import PermissionResult, TrustLevel, get_peer_trust_book
+
+        book = get_peer_trust_book()
+        book.upsert("phone", trust=TrustLevel.FRIEND, auto_accept=["messaging.*", "scheduling.query"])
+        assert book.check("phone", "messaging.send") is PermissionResult.ALLOWED
+        assert book.check("phone", "scheduling.query") is PermissionResult.ALLOWED
+        # 未命中的意图仍要人确认 —— 这正是"只问该问的"
+        assert book.check("phone", "shell.exec") is PermissionResult.REQUIRE_APPROVAL
+        assert book.check("phone", "scheduling.cancel") is PermissionResult.REQUIRE_APPROVAL
+
+    def test_unpaired_peer_uses_conservative_default(self):
+        from core.peer_trust import PermissionResult, TrustLevel, get_peer_trust_book
+
+        book = get_peer_trust_book()
+        assert book.trust_of("never-seen") is TrustLevel.ASK
+        assert book.check("never-seen", "messaging.send") is PermissionResult.REQUIRE_APPROVAL
+
+    def test_default_trust_is_configurable(self, monkeypatch):
+        import core.peer_trust as pt
+
+        monkeypatch.setenv("GALAXY_PEER_DEFAULT_TRUST", "blocked")
+        pt.reset_peer_trust_book()
+        assert pt.get_peer_trust_book().check("stranger", "x") is pt.PermissionResult.DENIED
+
+    def test_trust_survives_reload_from_disk(self):
+        import core.peer_trust as pt
+
+        pt.get_peer_trust_book().upsert("persist-me", trust=pt.TrustLevel.TRUSTED, auto_accept=["a.*"])
+        pt.reset_peer_trust_book()  # 丢弃单例,强制重新从盘上读
+        rec = pt.get_peer_trust_book().get("persist-me")
+        assert rec is not None and rec.trust == "trusted" and rec.auto_accept == ["a.*"]
+
+    def test_str_enum_uses_value_not_repr(self):
+        """(str, Enum) 上 str(member) 会得到 'TrustLevel.ASK',落盘必须用 .value。"""
+        import json
+
+        import core.peer_trust as pt
+
+        pt.get_peer_trust_book().upsert("x", trust=pt.TrustLevel.FRIEND)
+        raw = json.load(open(os.path.join(os.environ["GALAXY_DATA_DIR"], "peer_trust.json"), encoding="utf-8"))
+        assert raw["peers"]["x"]["trust"] == "friend"
+
+
+# ── 2. 名片 ───────────────────────────────────────────────────────────────
+class TestAgentCard:
+    def test_roundtrip_preserves_content(self):
+        from core.agent_card import create_agent_card, from_link, to_link
+
+        card = create_agent_card("dev-1", name="手机", capabilities=["messaging"], endpoints={"websocket": "ws://x/y"})
+        v = from_link(to_link(card))
+        assert v.valid
+        assert v.card.device_id == "dev-1"
+        assert v.card.capabilities == ["messaging"]
+        assert v.card.endpoints == {"websocket": "ws://x/y"}
+
+    def test_tampered_link_is_rejected_and_returns_no_card(self):
+        """校验失败时绝不能返回半张名片 —— 否则伪造名片就进了信任链。"""
+        from core.agent_card import create_agent_card, from_link, to_link
+
+        link = to_link(create_agent_card("dev-1"))
+        v = from_link(link[:-4] + "AAAA")
+        assert v.valid is False
+        assert v.card is None
+        assert "签名" in v.reason
+
+    def test_expired_card_is_rejected(self):
+        from core.agent_card import create_agent_card, from_link, to_link
+
+        card = create_agent_card("dev-1", ttl_s=10.0, now=1000.0)
+        assert from_link(to_link(card), now=1005.0).valid is True
+        assert from_link(to_link(card), now=2000.0).valid is False
+
+    def test_non_pairing_link_rejected(self):
+        from core.agent_card import from_link
+
+        assert from_link("https://evil.example/pair?c=a&s=b").valid is False
+
+    def test_pairing_code_is_single_use(self):
+        from core.agent_card import create_agent_card, get_pairing_code_registry, to_link
+
+        reg = get_pairing_code_registry()
+        code, _ = reg.issue(to_link(create_agent_card("dev-1")))
+        assert reg.resolve(code) is not None
+        assert reg.resolve(code) is None
+
+    def test_pairing_code_expires(self):
+        from core.agent_card import create_agent_card, get_pairing_code_registry, to_link
+
+        reg = get_pairing_code_registry()
+        code, _ = reg.issue(to_link(create_agent_card("dev-1")), ttl_s=60.0, now=1000.0)
+        assert reg.resolve(code, now=2000.0) is None
+
+
+# ── 3. 接入证明 ───────────────────────────────────────────────────────────
+class TestActuallyWiredIn:
+    """不满足于"能调通",而是断言它进了真实路由表和真实派发门。"""
+
+    def test_pairing_endpoints_are_mounted_in_create_api_routes(self):
+        from core.api_routes import create_api_routes
+
+        paths = {getattr(r, "path", "") for r in iter_flat_routes(create_api_routes())}
+        for expected in (
+            "/api/v1/pair/card",
+            "/api/v1/pair/claim",
+            "/api/v1/pair/peers",
+            "/api/v1/pair/trust",
+            "/api/v1/pair/check",
+        ):
+            assert expected in paths, f"{expected} 未挂进 create_api_routes —— 端点会 404"
+
+    def test_blocked_peer_is_refused_by_the_dispatch_gate(self):
+        """派发门是"唯一权威前置检查",拉黑必须在这里生效,而不只是存在档案里。"""
+        from core.peer_trust import TrustLevel, get_peer_trust_book
+        from core.unified_dispatch_readiness_gate import DispatchReadinessStatus, evaluate_dispatch_readiness
+
+        get_peer_trust_book().upsert("evil", trust=TrustLevel.BLOCKED)
+        r = evaluate_dispatch_readiness("evil")
+        assert r.dispatch_ready is False
+        assert r.status == DispatchReadinessStatus.BLOCKED_PEER_TRUST.value
+        assert r.peer_trust == "blocked"
+
+    def test_gate_reports_peer_trust_on_every_path(self):
+        """peer_trust 不能只在被拦时才有值,否则这个字段对调用方没用。"""
+        from core.peer_trust import TrustLevel, get_peer_trust_book
+        from core.unified_dispatch_readiness_gate import evaluate_dispatch_readiness
+
+        get_peer_trust_book().upsert("known", trust=TrustLevel.TRUSTED)
+        assert evaluate_dispatch_readiness("known").peer_trust == "trusted"
+        # 未登记设备走的是另一条 return 分支,同样要带出默认信任
+        assert evaluate_dispatch_readiness("unknown-dev").peer_trust == "ask"
+        assert "peer_trust" in evaluate_dispatch_readiness("known").to_dict()
+
+    def test_gate_fails_open_when_trust_layer_unavailable(self, monkeypatch):
+        """信任层是加固,不该成为新的单点故障:它坏了,派发不能整体停摆。"""
+        import core.peer_trust as pt
+        from core.unified_dispatch_readiness_gate import DispatchReadinessStatus, evaluate_dispatch_readiness
+
+        def _boom():
+            raise RuntimeError("信任层故障")
+
+        monkeypatch.setattr(pt, "get_peer_trust_book", _boom)
+        r = evaluate_dispatch_readiness("some-dev")
+        assert r.status != DispatchReadinessStatus.BLOCKED_PEER_TRUST.value
+
+
+class TestHitlWaiver:
+    """信任豁免人工确认 —— 这是分级信任的"便利性"落点:只问该问的。
+
+    这些用例必须真的走到 readiness_gate 的第 9 步(确认门)。默认策略是
+    ``observe_only``,会在第 7 步就 blocked,根本到不了第 9 步 —— 因此这里注入一个
+    "允许执行但要求确认"的真实 ExecutionPolicy。用假对象会因 policy_band 缺 .value
+    而落进 safe fallback,测试看起来通过实则什么都没验到。
+    """
+
+    @pytest.fixture
+    def gate_with_confirming_policy(self, monkeypatch):
+        import core.execution.readiness_gate as rg
+        from core.execution_policy.execution_policy import ExecutionPolicy, PolicyBand
+
+        policy = ExecutionPolicy(
+            policy_band=PolicyBand.BOUNDED_EXECUTE,
+            action_budget=10,
+            requires_confirmation=True,
+            reason="test: permit execution but demand confirmation",
+        )
+        monkeypatch.setattr(rg.ExecutionReadinessGate, "_resolve_policy", lambda self, sc, notes: policy, raising=True)
+        return rg
+
+    @staticmethod
+    def _profile(target_ref, target_type, intent):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            action_level="direct",
+            target_ref=target_ref,
+            target_type=target_type,
+            runtime_session_id="s1",
+            runtime_domain="local",
+            intent_id=intent,
+        )
+
+    def test_trusted_device_skips_confirmation(self, gate_with_confirming_policy):
+        from core.peer_trust import TrustLevel, get_peer_trust_book
+
+        get_peer_trust_book().upsert("pc", trust=TrustLevel.TRUSTED)
+        r = gate_with_confirming_policy.evaluate_readiness(
+            intent_profile=self._profile("pc", "device", "messaging.send")
+        )
+        assert r.requires_confirmation is False
+        assert r.status == "ready"
+
+    def test_friend_skips_only_matching_intents(self, gate_with_confirming_policy):
+        from core.peer_trust import TrustLevel, get_peer_trust_book
+
+        get_peer_trust_book().upsert("phone", trust=TrustLevel.FRIEND, auto_accept=["messaging.*"])
+        matched = gate_with_confirming_policy.evaluate_readiness(
+            intent_profile=self._profile("phone", "device", "messaging.send")
+        )
+        unmatched = gate_with_confirming_policy.evaluate_readiness(
+            intent_profile=self._profile("phone", "device", "shell.exec")
+        )
+        assert matched.requires_confirmation is False
+        assert unmatched.requires_confirmation is True
+
+    def test_unpaired_device_still_requires_confirmation(self, gate_with_confirming_policy):
+        r = gate_with_confirming_policy.evaluate_readiness(
+            intent_profile=self._profile("stranger", "device", "messaging.send")
+        )
+        assert r.requires_confirmation is True
+
+    def test_non_device_target_is_never_treated_as_a_peer(self, gate_with_confirming_policy):
+        """target_ref 也可能是 app 名/窗口标题;拿它去查对端信任是张冠李戴。"""
+        from core.peer_trust import TrustLevel, get_peer_trust_book
+
+        get_peer_trust_book().upsert("Notepad", trust=TrustLevel.TRUSTED)
+        r = gate_with_confirming_policy.evaluate_readiness(
+            intent_profile=self._profile("Notepad", "app", "messaging.send")
+        )
+        assert r.requires_confirmation is True
+
+    def test_trust_layer_failure_fails_closed_here(self, gate_with_confirming_policy, monkeypatch):
+        """与派发门相反:这里失败必须保持"要确认",放行等于绕过人工确认。"""
+        import core.peer_trust as pt
+
+        monkeypatch.setattr(pt, "check_peer", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("信任层故障")))
+        r = gate_with_confirming_policy.evaluate_readiness(
+            intent_profile=self._profile("pc", "device", "messaging.send")
+        )
+        assert r.requires_confirmation is True
+
+
+class TestPairingFlow:
+    @pytest.fixture
+    def client(self):
+        from core.routes.pairing import create_router
+
+        app = FastAPI()
+        app.include_router(create_router())
+        return TestClient(app)
+
+    def test_claim_by_code_registers_peer_and_issues_token(self, client):
+        from core.capability_token import verify_token
+
+        card = client.get("/api/v1/pair/card").json()
+        r = client.post(
+            "/api/v1/pair/claim",
+            json={"code": card["code"], "trust": "friend", "auto_accept": ["messaging.*"]},
+        ).json()
+        assert r["success"] is True
+        assert r["peer"]["trust"] == "friend"
+        # capability_token 在本次改动前全仓无生产调用方 —— 这条锁定它已被接活
+        assert r["token_issued"] is True
+        assert verify_token(r["capability_token"], required_scope="device:tap").valid is True
+        assert verify_token(r["capability_token"], required_scope="admin:wipe").valid is False
+
+    def test_token_scopes_follow_trust_level(self, client):
+        from core.capability_token import verify_token
+
+        card = client.get("/api/v1/pair/card").json()
+        r = client.post("/api/v1/pair/claim", json={"link": card["link"], "trust": "trusted"}).json()
+        assert r["token_scopes"] == ["*"]
+        assert verify_token(r["capability_token"], required_scope="admin:wipe").valid is True
+
+    def test_claim_rejects_tampered_link(self, client):
+        card = client.get("/api/v1/pair/card").json()
+        r = client.post("/api/v1/pair/claim", json={"link": card["link"][:-4] + "AAAA"})
+        assert r.status_code == 400
+        assert r.json()["success"] is False
+
+    def test_claim_requires_link_or_code(self, client):
+        assert client.post("/api/v1/pair/claim", json={}).status_code == 400
+
+    def test_unpaired_peer_lookup_reports_effective_trust_not_404(self, client):
+        r = client.get("/api/v1/pair/peers/nobody").json()
+        assert r["success"] is True and r["registered"] is False
+        assert r["effective_trust"] == "ask"
+
+    def test_check_endpoint_explains_decision(self, client):
+        card = client.get("/api/v1/pair/card").json()
+        did = client.post(
+            "/api/v1/pair/claim",
+            json={"code": card["code"], "trust": "friend", "auto_accept": ["messaging.*"]},
+        ).json()["peer"]["device_id"]
+
+        assert (
+            client.post("/api/v1/pair/check", json={"device_id": did, "intent": "messaging.send"}).json()["result"]
+            == "allowed"
+        )
+        assert (
+            client.post("/api/v1/pair/check", json={"device_id": did, "intent": "shell.exec"}).json()["result"]
+            == "require_approval"
+        )
+
+    def test_trust_can_be_raised_and_revoked(self, client):
+        card = client.get("/api/v1/pair/card").json()
+        did = client.post("/api/v1/pair/claim", json={"code": card["code"]}).json()["peer"]["device_id"]
+
+        client.post("/api/v1/pair/trust", json={"device_id": did, "trust": "blocked"})
+        assert client.post("/api/v1/pair/check", json={"device_id": did}).json()["result"] == "denied"
+
+        assert client.delete(f"/api/v1/pair/peers/{did}").json()["removed"] is True
+        assert client.get(f"/api/v1/pair/peers/{did}").json()["registered"] is False

--- a/tests/test_peer_trust_and_pairing.py
+++ b/tests/test_peer_trust_and_pairing.py
@@ -353,6 +353,31 @@ class TestPairingFlow:
             == "require_approval"
         )
 
+    def test_internal_errors_do_not_leak_exception_text(self, client, monkeypatch):
+        """CodeQL: Information exposure through an exception。
+
+        配对是信任链入口,内部异常文本(可能含文件路径、模块名、密钥文件位置)
+        绝不能回给调用方;但要留下 error_code,让人能凭它去服务端日志定位。
+        """
+        import core.peer_trust as pt
+
+        secret = "/very/secret/path/.galaxy_mesh_key"
+        monkeypatch.setattr(pt, "get_peer_trust_book", lambda: (_ for _ in ()).throw(RuntimeError(f"{secret} 打不开")))
+        r = client.get("/api/v1/pair/peers")
+        assert r.status_code == 500
+        assert secret not in r.text
+        assert "RuntimeError" not in r.text
+        assert r.json()["error_code"] == "pair_list_peers"
+
+    def test_card_rejection_reason_carries_no_exception_text(self, client):
+        """from_link 的 reason 会被原样回传,同样不能带异常文本。"""
+        r = client.post("/api/v1/pair/claim", json={"link": "galaxy://pair?c=@@@bad@@@&s=@@@"})
+        assert r.status_code == 400
+        body = r.text
+        assert "Traceback" not in body and "Error:" not in body
+        # 仍要给出可行动的原因,而不是一句无信息的"失败"
+        assert r.json()["error"]
+
     def test_trust_can_be_raised_and_revoked(self, client):
         card = client.get("/api/v1/pair/card").json()
         did = client.post("/api/v1/pair/claim", json={"code": card["code"]}).json()["peer"]["device_id"]


### PR DESCRIPTION
承接已合并的 #1537。那一轮把静默异常做成了**分层筛选**(乐观返回值、被吞的写入、取数函数返回空容器、安全校验 fail-open、后台循环吞异常),但我当时明确说过覆盖面还有缺口——没扫过的形态还有两类。这个 PR 补上其中的发现。

## 这次扫的两类形态

对全仓 5669 处宽泛 except 的完整分类里,还剩两种形态没查过:

- **A. `for` 循环里静默 `pass`/`continue`** —— 一批 N 个条目悄悄只处理了 M 个,27 处候选
- **B. `__init__` 里静默吞异常** —— 对象构造出来是半残的但看着正常,11 处候选

逐条核对后,B 组**全部排除**,A 组确认两处真缺陷。

## 1. `task_graph_runtime.py::_load_checkpoint` —— 续跑丢依赖边且完全无痕

同一个函数里节点和边的处理是**不对称**的:

| | 损坏时的行为 | 计数 |
| --- | --- | --- |
| 节点 | `logger.debug("跳过损坏节点记录")` | 有 `n_loaded` |
| 边 | 裸 `except: pass`,一个字不留 | 无 |

末尾的汇总也只报节点数。构造一个含 2 条边记录(1 条损坏)的检查点实测:

```
修复前  DEBUG 跳过损坏节点记录 ...
        INFO  从检查点重建 2 个节点        ← 边只字未提,生产 INFO 级别下完全不可见

修复后  WARNING 检查点中有 1 条边无法重建(已重建 1 条);续跑的 DAG 依赖关系可能不完整
        INFO    从检查点重建 2 个节点 / 1 条边
```

**为什么用 warning 而不是 debug**:`GraphEdge` 承载 `depends_on`(字段 `source_node_id`/`target_node_id`)。丢边不会让续跑报错,而是让重建出来的 DAG 少一条依赖——任务会以错误的顺序执行,或在前置根本没跑完时就启动。这比丢节点更隐蔽(丢节点至少任务不见了),所以要比节点那条更醒目。

顺带核实了 `hasattr(GraphEdge, "from_dict")` 这个守卫:`from_dict` 确实存在,所以不存在"所有边被整体静默丢弃"的更坏情况,缺陷范围仅限单条损坏记录。

## 2. `android_backflow.py::_load` —— 损坏行静默跳过,计数只报成功数

逐行 `json.loads` 失败时裸 `continue`,而随后那句 `logger.info` 只报成功载入的条数。一个半数损坏的文件与完整文件在日志上一模一样。实测 4 行、2 行损坏:

```
修复后  WARNING Android 回流记忆:2 行损坏已跳过(成功载入 2 条)
```

## 核对后确认无需改动的

- **`__init__` 那 11 处全部是 `emit_legacy_guardrail` 遥测模式**(逐条核对 11/11,不是抽样推断)。遥测不得阻断对象构造,有意为之。
- `routes/_helpers.py:59` —— 逐个试探"有 execute 方法的类"能否实例化,失败即试下一个,是探测循环;全失败返回 `None`,调用方能察觉。
- `huggingface_model_manager.py:316` —— 逐个 repo 探测 GGUF,全失败会 `raise ValueError`,是 fail-closed。
- `lan_discovery.py:105` —— `stop()` 里 `browser.cancel()` 失败;关停路径,无影响。
- `lan_discovery.py:230` —— 单条 property 解码失败;外层已记 debug,且解不出的属性本就无值可用。

没有为了凑数去改这些——改了也不会让任何调用方多知道一件事。

## 验证

按 `.github/workflows/ci.yml:21-26` **原样复跑三条**:

| 命令 | 结果 |
| --- | --- |
| `flake8 core/ --max-line-length=120 --count --statistics` | `0` |
| `black --check core/ tests/` | 1980 files unchanged |
| `isort --check-only core/ tests/` | rc=0 |

首次跑 black 时命中一处隐式字符串拼接需合并,已改为单行字符串。这正是 #1537 里让 lint 变红的同类问题,这次在推送前就拦住了。

`pytest -k "task_graph or backflow or checkpoint"` → **228 passed, 3 skipped**。

两处修复都是先构造损坏输入、实测修复前后的可见性差异,再落的代码——不是照着模式改完就算。

## 说明

`File Complexity Budget` 若在本 PR 上失败,属 `main` 上既有的系统性门禁:已多次用 `scripts/check_file_complexity.py --strict` 对比 `origin/main`,阻塞性 ❌ 清单字节级一致,本 PR 未触及其中任何文件。


---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_