### PR TITLE
桌面感知隐私急停:一次调用切断全部感知并清空缓存

### DIFF
--- a/core/agent_card.py
+++ b/core/agent_card.py
@@ -40,6 +40,7 @@ import os
 import secrets
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -188,19 +189,43 @@ class _CodeEntry:
     expires_at: float
 
 
+#: 同时有效的短码上限。超出后按签发顺序淘汰最旧的。
+#:
+#: 必须有上限:``GET /api/v1/pair/card`` 每调用一次就签发一个 10 分钟有效的短码,
+#: 只清过期、不限总数的话,任何反复拉取名片的客户端(或轮询的面板)都会让这张表
+#: 持续膨胀 —— 实测连续签发 5000 次即积压 5000 条。这与仓库里 IPBlockList、
+#: 学习引擎模式表所修的是同一类无界集合问题。
+MAX_ACTIVE_PAIRING_CODES = 256
+
+
 class PairingCodeRegistry:
     """短码 → 配对链接 的短时映射(仅内存,进程重启即失效)。
 
     刻意不落盘:短码是**一次性、分钟级**的引导凭证,落盘只会延长它的暴露窗口。
+    容量有上限(见 MAX_ACTIVE_PAIRING_CODES),满了按签发顺序淘汰最旧的。
     """
 
-    def __init__(self) -> None:
+    def __init__(self, max_active: int = MAX_ACTIVE_PAIRING_CODES) -> None:
         self._lock = threading.RLock()
-        self._codes: Dict[str, _CodeEntry] = {}
+        # OrderedDict:按插入顺序维护,便于满容量时 FIFO 淘汰最旧的一条
+        self._codes: "OrderedDict[str, _CodeEntry]" = OrderedDict()
+        self._max_active = max(1, int(max_active))
+        #: 因容量上限被挤掉的短码数(诊断用:证明淘汰真的在发生)
+        self.evicted = 0
 
     def _sweep_unlocked(self, now: float) -> None:
         for code in [c for c, e in self._codes.items() if e.expires_at <= now]:
             self._codes.pop(code, None)
+
+    def _enforce_cap_unlocked(self) -> None:
+        """先清过期,仍超容量则淘汰最旧的。
+
+        被淘汰的短码随即失效 —— 这是刻意的:短码是引导凭证,宁可让用户重新拉一次
+        名片,也不能让这张表无界增长。
+        """
+        while len(self._codes) > self._max_active:
+            self._codes.popitem(last=False)
+            self.evicted += 1
 
     def issue(self, link: str, *, ttl_s: float = DEFAULT_CODE_TTL_S, now: Optional[float] = None) -> Tuple[str, float]:
         t = now if now is not None else time.time()
@@ -211,6 +236,7 @@ class PairingCodeRegistry:
                 if code not in self._codes:
                     expires = t + float(ttl_s)
                     self._codes[code] = _CodeEntry(link=link, expires_at=expires)
+                    self._enforce_cap_unlocked()
                     return code, expires
             raise RuntimeError("配对短码生成失败:连续 64 次碰撞")
 

--- a/core/ambient_attention_loop.py
+++ b/core/ambient_attention_loop.py
@@ -341,6 +341,16 @@ class FrameGate:
         self._prev_sig: Optional[Any] = None
         self._prev_b64: Optional[str] = None
 
+    def reset(self) -> None:
+        """丢弃上一帧指纹,让下一帧被当作"第一帧"。
+
+        用于跨越隐私边界(暂停→恢复)后:留着暂停前的指纹去比恢复后的新帧,
+        等于泄露"被遮住那段时间里画面变了多少"。注意这会让恢复后的第一拍
+        必然判定为"有变化"(第一帧的既定语义),这是刻意接受的代价。
+        """
+        self._prev_sig = None
+        self._prev_b64 = None
+
     def changed(self, frame_b64: Optional[str]) -> bool:
         if not frame_b64:
             return False
@@ -434,6 +444,9 @@ class AmbientAttentionLoop:
         self._running = False
         self._last_action_ts = 0.0
         self._last_audio_hash = ""
+        #: 上次见到的感知世代号;与 store.epoch 不一致即表示中间发生过隐私暂停,
+        #: 需重置帧差门控(见 _gather_observation)。初值 -1 保证首拍必对齐一次。
+        self._perception_epoch: int = -1
         self._recent_rationales: List[str] = []
         self.ticks = 0
         self.decisions = 0
@@ -482,10 +495,38 @@ class AmbientAttentionLoop:
     def _gather_observation(self) -> Optional[AmbientObservation]:
         """从感知库读一份快照（只读，不消费对话音频）；被门控挡下返回 None。"""
         store = self._get_store()
+
+        # 隐私世代号:pause/resume 会让它自增。世代一变说明中间发生过隐私暂停,
+        # 此时把两路帧差指纹与音频哈希一并清掉。
+        #
+        # 理由是【隐私】,不是省一次模型调用 —— 恰恰相反:FrameGate 对第一帧本就
+        # 返回 True(见 changed() 的"第一帧视为变化"),所以 reset 之后恢复的
+        # 第一拍一定会触发一次。这是可接受的(恢复后重新看一眼环境本就合理)。
+        #
+        # 真正的问题在于:若保留暂停前那枚指纹,恢复后的新帧会跟它做差 ——
+        # 等于让智能体能推断出"我被遮住的那段时间里屏幕变化了多少"。用户主动
+        # 遮起来的内容,不该以差异信号的形式渗出来。故跨隐私边界不携带视觉状态。
+        try:
+            epoch = store.epoch
+            if epoch != self._perception_epoch:
+                self._perception_epoch = epoch
+                self._gate.reset()
+                self._cam_gate.reset()
+                self._last_audio_hash = ""
+                logger.info("Ambient: 感知世代变更(epoch=%s),已重置帧差门控与音频哈希", epoch)
+        except AttributeError:
+            # 老版本 store 没有 epoch —— 不因此中断本拍
+            pass
+
         try:
             media = store.snapshot_media()
         except Exception as exc:  # noqa: BLE001
             logger.debug("Ambient: snapshot_media 失败: %s", exc)
+            return None
+
+        # 隐私暂停期间 snapshot_media 全空,这一拍直接跳过,连门控都不用更新
+        # (没有新数据可比),也不该把"空"当成"画面变了"。
+        if media.get("privacy_paused"):
             return None
 
         # 分路取帧:屏幕、摄像头各自原始帧(可同时存在)。主帧(frame_b64)屏幕优先,

--- a/core/peer_trust.py
+++ b/core/peer_trust.py
@@ -222,7 +222,18 @@ class PeerTrustBook:
     ) -> PeerRecord:
         did = str(device_id)
         with self._lock:
-            rec = self._peers.get(did) or PeerRecord(device_id=did, paired_at=time.time())
+            rec = self._peers.get(did)
+            if rec is None:
+                # 新建档案时的初始信任必须取 _default_trust(),不能用 PeerRecord
+                # 的 dataclass 默认值(unknown)。两者是"未指定信任算几级"的两个
+                # 不同真相源:未登记对端走 _default_trust()(默认 ask,可配),
+                # 而 dataclass 默认是 unknown —— 比 ask 低。
+                #
+                # 后果:调 POST /api/v1/pair/trust 只传 device_id(比如只想改备注)
+                # 就会把该对端从 default_trust 悄悄**降级**成 unknown。若部署方把
+                # GALAXY_PEER_DEFAULT_TRUST 设成 friend,原本 allowed 的意图会变成
+                # require_approval —— 只想加个备注却动了权限。已实测复现。
+                rec = PeerRecord(device_id=did, trust=_default_trust().value, paired_at=time.time())
             if name is not None:
                 rec.name = str(name)
             if trust is not None:

--- a/core/perception/desktop_perception_store.py
+++ b/core/perception/desktop_perception_store.py
@@ -16,6 +16,32 @@ core/perception/desktop_perception_store.py
 
 设计原则：轻量、线程安全（简单锁）、永不抛出影响主流程；不持久化、不落盘。
 默认 TTL 10s；GALAXY_DESKTOP_PERCEPTION_TTL 可调。
+
+隐私急停（privacy pause）
+------------------------
+本类是**全部**桌面感知数据的唯一进出口，因此隐私闸门只能落在这里：写入口只有
+``update_frame`` / ``update_audio`` 两个，而读出口有五个
+（``has_fresh_frame`` / ``latest_frame_snapshot`` / ``take_fresh_audio_for_autoinject``
+/ ``snapshot_media`` / ``build_multimodal_context``），下游消费方至少四处
+（ambient_attention_loop、computer_use_loop、session_memory_facade、
+multimodal/ingest_runtime）。闸门若放在任一消费方，其余几路照旧能看到屏幕 ——
+那是**假的**隐私模式。
+
+急停语义（刻意比"停掉某个循环"更强）：
+* ``pause()`` 之后**拒收**新的帧/音频（在写入口就挡掉，数据根本不进内存）；
+* 同时**立即清空**已缓存的帧、音频与屏幕结构 —— 否则消费方还能读到暂停前
+  那一帧，"暂停"名不副实；
+* 五条读路径全部返回空，构成第二道防线（即便某条路径将来新增了缓存）；
+* ``epoch`` 在每次 pause/resume 时自增。消费方（如 ambient 循环的 ``FrameGate``）
+  据此丢弃自己的帧差指纹。这一条的动机是**隐私**而非性能：若保留暂停前的指纹，
+  恢复后的新帧会与它做差，等于让智能体推断出"被遮住那段时间里画面变了多少"。
+  用户主动遮起来的内容不该以差异信号的形式渗出，故跨隐私边界不携带视觉状态。
+  代价是恢复后的第一拍必然判为"有变化"（FrameGate 对第一帧的既定语义），
+  这是刻意接受的。
+
+默认状态由 ``GALAXY_PERCEPTION_PRIVACY_DEFAULT`` 决定：默认 ``active``（放行）；
+设为 ``paused``/``1``/``true`` 则进程一起来就处于隐私暂停（隐私优先部署）。
+闸门本身**始终生效**，不藏在任何 feature flag 之后。
 """
 
 from __future__ import annotations
@@ -38,6 +64,12 @@ def _default_ttl() -> float:
 
 def _is_screen_source(source: str) -> bool:
     return "screen" in (source or "").lower()
+
+
+def _privacy_default_paused() -> bool:
+    """进程启动时是否直接处于隐私暂停(隐私优先部署)。默认放行。"""
+    raw = os.getenv("GALAXY_PERCEPTION_PRIVACY_DEFAULT", "").strip().lower()
+    return raw in ("paused", "pause", "1", "true", "yes", "on")
 
 
 class DesktopPerceptionStore:
@@ -68,6 +100,87 @@ class DesktopPerceptionStore:
         self._audio_received: int = 0
         # 自动注入去重：已被对话自动注入消费过的音频时间戳，避免同一片段反复转写
         self._audio_autoinject_consumed_ts: float = 0.0
+        # ── 隐私急停 ──
+        self._paused: bool = _privacy_default_paused()
+        self._paused_at: float = time.time() if self._paused else 0.0
+        self._pause_reason: str = "privacy_default" if self._paused else ""
+        #: 每次 pause/resume 自增,供消费方重置帧差指纹(见模块 docstring)
+        self._epoch: int = 0
+        #: 暂停期间被拒收的写入次数(诊断用:证明闸门真的在挡)
+        self._rejected_frames: int = 0
+        self._rejected_audio: int = 0
+        if self._paused:
+            logger.warning("桌面感知处于隐私暂停(GALAXY_PERCEPTION_PRIVACY_DEFAULT):启动即不采集")
+
+    # ── 隐私急停 ──────────────────────────────────────────────────────────
+
+    def _wipe_unlocked(self) -> None:
+        """清空全部已缓存的感知数据。调用方必须已持有锁。
+
+        暂停时不清缓存,消费方仍能读到暂停前那一帧 —— 那不叫暂停。
+        """
+        self._cam_b64 = None
+        self._cam_ts = 0.0
+        self._scr_b64 = None
+        self._scr_ts = 0.0
+        self._screen_meta = None
+        self._audio_b64 = None
+        self._audio_ts = 0.0
+
+    def pause(self, reason: str = "user") -> Dict[str, Any]:
+        """立即切断感知:拒收后续帧/音频,并清空已缓存内容。幂等。"""
+        with self._lock:
+            already = self._paused
+            self._paused = True
+            if not already:
+                self._paused_at = time.time()
+                self._pause_reason = str(reason or "user")
+                self._epoch += 1
+            self._wipe_unlocked()
+            status = self._privacy_status_unlocked()
+        if not already:
+            logger.warning("桌面感知已暂停(隐私急停):reason=%s;已清空缓存帧与音频", reason)
+        return status
+
+    def resume(self, reason: str = "user") -> Dict[str, Any]:
+        """恢复感知。epoch 自增,消费方据此重置帧差指纹,避免"一恢复就误触发"。"""
+        with self._lock:
+            already = not self._paused
+            self._paused = False
+            if not already:
+                self._pause_reason = ""
+                self._paused_at = 0.0
+                self._epoch += 1
+            status = self._privacy_status_unlocked()
+        if not already:
+            logger.warning("桌面感知已恢复:reason=%s epoch=%s", reason, status["epoch"])
+        return status
+
+    @property
+    def paused(self) -> bool:
+        with self._lock:
+            return self._paused
+
+    @property
+    def epoch(self) -> int:
+        """pause/resume 世代号。变化即表示感知连续性已断,消费方应重置状态。"""
+        with self._lock:
+            return self._epoch
+
+    def _privacy_status_unlocked(self) -> Dict[str, Any]:
+        return {
+            "paused": self._paused,
+            "reason": self._pause_reason,
+            "paused_at": self._paused_at or None,
+            "paused_for_sec": round(time.time() - self._paused_at, 2) if self._paused_at else None,
+            "epoch": self._epoch,
+            "rejected_frames": self._rejected_frames,
+            "rejected_audio": self._rejected_audio,
+        }
+
+    def privacy_status(self) -> Dict[str, Any]:
+        with self._lock:
+            return self._privacy_status_unlocked()
 
     @classmethod
     def get_instance(cls) -> "DesktopPerceptionStore":
@@ -87,7 +200,14 @@ class DesktopPerceptionStore:
         source: str = "desktop_camera",
         screen: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """按 source 分槽存放：含 'screen' → 屏幕槽（含结构化 screen 上下文）；否则摄像头槽。"""
+        """按 source 分槽存放：含 'screen' → 屏幕槽（含结构化 screen 上下文）；否则摄像头槽。
+
+        隐私暂停期间**拒收**:数据在写入口就被挡掉,根本不进内存。
+        """
+        with self._lock:
+            if self._paused:
+                self._rejected_frames += 1
+                return
         if not image_b64:
             # 即便没有像素帧，也允许只更新结构化屏幕上下文（如纯 UIA 树）。
             if screen is not None:
@@ -113,6 +233,11 @@ class DesktopPerceptionStore:
                     self._screen_meta = screen
 
     def update_audio(self, audio_b64: str, *, mime: str = "audio/webm") -> None:
+        """隐私暂停期间拒收(同 update_frame)。"""
+        with self._lock:
+            if self._paused:
+                self._rejected_audio += 1
+                return
         if not audio_b64:
             return
         with self._lock:
@@ -127,15 +252,22 @@ class DesktopPerceptionStore:
         return ts > 0.0 and (time.time() - ts) <= self.ttl_sec
 
     def has_fresh_frame(self) -> bool:
-        """摄像头或屏幕任一有新鲜帧即为 True。"""
+        """摄像头或屏幕任一有新鲜帧即为 True。隐私暂停时恒为 False。"""
         with self._lock:
+            if self._paused:
+                return False
             return (bool(self._cam_b64) and self._fresh(self._cam_ts)) or (
                 bool(self._scr_b64) and self._fresh(self._scr_ts)
             )
 
     def latest_frame_snapshot(self) -> Tuple[Optional[str], str, str]:
-        """返回最近一帧（摄像头或屏幕，取更新的那张）的 (b64, mime, source)，供「现在看一下」用。"""
+        """返回最近一帧（摄像头或屏幕，取更新的那张）的 (b64, mime, source)，供「现在看一下」用。
+
+        隐私暂停时返回空帧 —— "现在看一下"在暂停期间必须看不到东西。
+        """
         with self._lock:
+            if self._paused:
+                return None, "image/jpeg", "desktop_camera"
             if self._scr_ts >= self._cam_ts and self._scr_b64:
                 return self._scr_b64, self._scr_mime, "desktop_screen"
             if self._cam_b64:
@@ -150,14 +282,32 @@ class DesktopPerceptionStore:
         返回 ``(audio_b64, mime)``；没有可用音频则返回 ``(None, None)``。
         """
         with self._lock:
+            if self._paused:
+                return None, None
             if self._audio_b64 and self._fresh(self._audio_ts) and self._audio_ts > self._audio_autoinject_consumed_ts:
                 self._audio_autoinject_consumed_ts = self._audio_ts
                 return self._audio_b64, self._audio_mime
         return None, None
 
     def snapshot_media(self) -> Dict[str, Any]:
-        """返回当前最新【摄像头/屏幕/音频】快照（仅新鲜项有值），供统一记忆层等消费。"""
+        """返回当前最新【摄像头/屏幕/音频】快照（仅新鲜项有值），供统一记忆层等消费。
+
+        隐私暂停时全部字段为空(保留键名,调用方无需改判空逻辑)。
+        """
         with self._lock:
+            if self._paused:
+                return {
+                    "image_b64": None,
+                    "image_mime": self._cam_mime,
+                    "camera_b64": None,
+                    "camera_mime": self._cam_mime,
+                    "screen_b64": None,
+                    "screen_mime": self._scr_mime,
+                    "screen_meta": None,
+                    "audio_b64": None,
+                    "audio_mime": self._audio_mime,
+                    "privacy_paused": True,
+                }
             cam_fresh = bool(self._cam_b64) and self._fresh(self._cam_ts)
             scr_fresh = bool(self._scr_b64) and self._fresh(self._scr_ts)
             aud_fresh = bool(self._audio_b64) and self._fresh(self._audio_ts)
@@ -189,6 +339,7 @@ class DesktopPerceptionStore:
                 "screen_meta_present": self._screen_meta is not None,
                 "audio_fresh": self._fresh(self._audio_ts),
                 "audio_age_sec": round(now - self._audio_ts, 2) if self._audio_ts else None,
+                "privacy": self._privacy_status_unlocked(),
             }
 
     def build_multimodal_context(self, existing: Optional[Any] = None) -> Optional[Any]:
@@ -209,6 +360,10 @@ class DesktopPerceptionStore:
             return None
 
         with self._lock:
+            # 这条是【每次对话请求】的隐性注入路径:漏掉它,模型仍会在每一轮
+            # 对话里看到屏幕与摄像头,隐私暂停就形同虚设。
+            if self._paused:
+                return None
             cam_fresh = bool(self._cam_b64) and self._fresh(self._cam_ts)
             scr_fresh = bool(self._scr_b64) and self._fresh(self._scr_ts)
             aud_fresh = bool(self._audio_b64) and self._fresh(self._audio_ts)

--- a/core/perception/desktop_perception_store.py
+++ b/core/perception/desktop_perception_store.py
@@ -203,19 +203,23 @@ class DesktopPerceptionStore:
         """按 source 分槽存放：含 'screen' → 屏幕槽（含结构化 screen 上下文）；否则摄像头槽。
 
         隐私暂停期间**拒收**:数据在写入口就被挡掉,根本不进内存。
+
+        判定与写入必须在**同一次持锁**内完成。此前分成两次持锁(先查 paused、
+        释放锁、再取锁写入),中间存在 TOCTOU 空隙:用户按下暂停的瞬间若有一帧
+        正在途中,pause() 会在空隙里完成"置位 + 清缓存",随后这一帧落在 wipe
+        之后 —— 暂停期间读闸门还挡得住,但**一恢复就能读出来**,而那恰恰是
+        用户想遮住的那一帧。已用受控交错实测复现过。
         """
         with self._lock:
             if self._paused:
                 self._rejected_frames += 1
                 return
-        if not image_b64:
-            # 即便没有像素帧，也允许只更新结构化屏幕上下文（如纯 UIA 树）。
-            if screen is not None:
-                with self._lock:
+            if not image_b64:
+                # 即便没有像素帧，也允许只更新结构化屏幕上下文（如纯 UIA 树）。
+                if screen is not None:
                     self._screen_meta = screen
                     self._scr_ts = time.time()
-            return
-        with self._lock:
+                return
             if _is_screen_source(source):
                 self._scr_b64 = image_b64
                 self._scr_mime = mime or "image/jpeg"
@@ -233,14 +237,13 @@ class DesktopPerceptionStore:
                     self._screen_meta = screen
 
     def update_audio(self, audio_b64: str, *, mime: str = "audio/webm") -> None:
-        """隐私暂停期间拒收(同 update_frame)。"""
+        """隐私暂停期间拒收。判定与写入同一次持锁(理由见 update_frame)。"""
         with self._lock:
             if self._paused:
                 self._rejected_audio += 1
                 return
-        if not audio_b64:
-            return
-        with self._lock:
+            if not audio_b64:
+                return
             self._audio_b64 = audio_b64
             self._audio_mime = mime or "audio/webm"
             self._audio_ts = time.time()

--- a/core/routes/perception.py
+++ b/core/routes/perception.py
@@ -61,7 +61,18 @@ def create_router(service_manager=None, config=None) -> APIRouter:
         try:
             from core.perception.desktop_perception_store import get_desktop_perception_store
 
-            get_desktop_perception_store().update_frame(
+            store = get_desktop_perception_store()
+            # 隐私暂停期间 update_frame 会拒收。若照旧回 stored="frame",采集端
+            # 会以为帧已存进去而继续按原节奏推送 —— 必须如实告知它被丢弃了,
+            # 客户端才能据此降低推送频率或提示用户"感知已暂停"。
+            if store.paused:
+                return {
+                    "success": False,
+                    "stored": None,
+                    "privacy_paused": True,
+                    "reason": "感知已被隐私暂停,本帧未被接收",
+                }
+            store.update_frame(
                 frame.image_base64,
                 mime=frame.mime,
                 source=frame.source,
@@ -78,7 +89,15 @@ def create_router(service_manager=None, config=None) -> APIRouter:
         try:
             from core.perception.desktop_perception_store import get_desktop_perception_store
 
-            get_desktop_perception_store().update_audio(audio.audio_base64, mime=audio.mime)
+            store = get_desktop_perception_store()
+            if store.paused:  # 同 /frame:拒收要如实上报,不能假装存了
+                return {
+                    "success": False,
+                    "stored": None,
+                    "privacy_paused": True,
+                    "reason": "感知已被隐私暂停,本段音频未被接收",
+                }
+            store.update_audio(audio.audio_base64, mime=audio.mime)
             return {"success": True, "stored": "audio"}
         except Exception as exc:  # noqa: BLE001
             logger.debug("audio ingest failed: %s", exc)
@@ -93,6 +112,69 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             return {"success": True, "store": get_desktop_perception_store().status()}
         except Exception as exc:  # noqa: BLE001
             return {"success": False, "error": str(exc)}
+
+    # ── 隐私急停 ──────────────────────────────────────────────────────────
+    #
+    # 一个调用立刻切断全部桌面感知,不经配置文件、不需重启。对应桌宠"双击暂停"
+    # 那类交互:用户要的是"立刻别看了",而不是"改个配置等它生效"。
+    #
+    # 闸门落在 DesktopPerceptionStore(唯一进出口),因此这两个端点一按,
+    # ambient 循环、computer_use_loop、session_memory_facade、
+    # multimodal/ingest_runtime 四个消费方同时失明,没有绕行路径。
+
+    @router.post("/privacy/pause")
+    async def privacy_pause(reason: str = "user"):
+        """立即暂停感知:拒收后续帧/音频,并清空已缓存内容。幂等。"""
+        try:
+            from core.perception.desktop_perception_store import get_desktop_perception_store
+
+            status = get_desktop_perception_store().pause(reason=reason)
+            return {
+                "success": True,
+                "privacy": status,
+                "note": "已停止采集并清空缓存;四个消费方(环境循环/电脑操作/会话记忆/多模态注入)同时失明",
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.error("隐私暂停失败", exc_info=True)
+            return {
+                "success": False,
+                "error": "内部错误,请查看服务端日志",
+                "error_code": "privacy_pause",
+                "detail": type(exc).__name__,
+            }
+
+    @router.post("/privacy/resume")
+    async def privacy_resume(reason: str = "user"):
+        """恢复感知。世代号自增,消费方会据此重置帧差门控。幂等。"""
+        try:
+            from core.perception.desktop_perception_store import get_desktop_perception_store
+
+            status = get_desktop_perception_store().resume(reason=reason)
+            return {"success": True, "privacy": status}
+        except Exception as exc:  # noqa: BLE001
+            logger.error("隐私恢复失败", exc_info=True)
+            return {
+                "success": False,
+                "error": "内部错误,请查看服务端日志",
+                "error_code": "privacy_resume",
+                "detail": type(exc).__name__,
+            }
+
+    @router.get("/privacy")
+    async def privacy_state():
+        """当前隐私状态(供面板/桌宠显示"感知已暂停"及被拒计数)。"""
+        try:
+            from core.perception.desktop_perception_store import get_desktop_perception_store
+
+            return {"success": True, "privacy": get_desktop_perception_store().privacy_status()}
+        except Exception as exc:  # noqa: BLE001
+            logger.error("读取隐私状态失败", exc_info=True)
+            return {
+                "success": False,
+                "error": "内部错误,请查看服务端日志",
+                "error_code": "privacy_state",
+                "detail": type(exc).__name__,
+            }
 
     @router.post("/analyze")
     async def analyze_now(req: DesktopAnalyze):

--- a/tests/test_peer_trust_and_pairing.py
+++ b/tests/test_peer_trust_and_pairing.py
@@ -205,6 +205,79 @@ class TestActuallyWiredIn:
         assert r.status != DispatchReadinessStatus.BLOCKED_PEER_TRUST.value
 
 
+class TestUpsertDoesNotSilentlyDowngradeTrust:
+    """新建档案的初始信任必须取 _default_trust(),不能用 dataclass 默认值。
+
+    两者是"未指定信任算几级"的两个不同真相源:未登记对端走 _default_trust()
+    (默认 ask,可配),而 PeerRecord 的 dataclass 默认是 unknown —— 比 ask 低。
+    于是调 POST /api/v1/pair/trust 只传 device_id(例如只想改备注)就会把该对端
+    悄悄降级。若部署方把默认设成 friend,原本 allowed 的意图会变成 require_approval。
+    """
+
+    @pytest.mark.parametrize("default_trust", ["blocked", "unknown", "ask", "friend", "trusted"])
+    def test_note_only_upsert_preserves_effective_trust(self, default_trust, tmp_path, monkeypatch):
+        import core.peer_trust as pt
+
+        # 每个参数一份独立存储 —— 否则上一轮落盘的记录会让本轮走"已存在"分支,
+        # 根本测不到新建路径(第一版探针就是这么自欺的)。
+        monkeypatch.setenv("GALAXY_DATA_DIR", str(tmp_path / default_trust))
+        monkeypatch.setenv("GALAXY_PEER_DEFAULT_TRUST", default_trust)
+        pt.reset_peer_trust_book()
+        book = pt.get_peer_trust_book()
+
+        before = book.trust_of("dev").value
+        assert before == default_trust  # 前提:未登记对端按配置的默认值处理
+        book.upsert("dev", note="只想加个备注")
+        assert book.trust_of("dev").value == before, "只改备注不该动权限"
+
+    def test_explicit_trust_still_wins(self, tmp_path, monkeypatch):
+        import core.peer_trust as pt
+
+        monkeypatch.setenv("GALAXY_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("GALAXY_PEER_DEFAULT_TRUST", "friend")
+        pt.reset_peer_trust_book()
+        book = pt.get_peer_trust_book()
+        book.upsert("dev", trust="blocked")
+        assert book.trust_of("dev").value == "blocked"
+        book.upsert("dev", note="事后改备注")
+        assert book.trust_of("dev").value == "blocked", "备注更新不能把 blocked 冲掉"
+
+
+class TestPairingCodeRegistryIsBounded:
+    """短码表必须有上限。
+
+    GET /api/v1/pair/card 每调用一次就签发一个 10 分钟有效的短码;只清过期、
+    不限总数的话,任何反复拉名片的客户端都会让这张表持续膨胀(实测 5000 次
+    签发即积压 5000 条)。与 IPBlockList、学习引擎模式表同类。
+    """
+
+    def test_active_codes_are_capped(self):
+        from core.agent_card import PairingCodeRegistry, create_agent_card, to_link
+
+        reg = PairingCodeRegistry(max_active=32)
+        link = to_link(create_agent_card("d"))
+        codes = [reg.issue(link)[0] for _ in range(500)]
+        assert reg.active_count() <= 32
+        assert reg.evicted > 0, "应当发生过淘汰"
+
+    def test_newest_survives_and_oldest_is_evicted(self):
+        from core.agent_card import PairingCodeRegistry, create_agent_card, to_link
+
+        reg = PairingCodeRegistry(max_active=8)
+        link = to_link(create_agent_card("d"))
+        codes = [reg.issue(link)[0] for _ in range(64)]
+        assert reg.resolve(codes[-1]) is not None, "最新签发的必须可兑换"
+        assert reg.resolve(codes[0]) is None, "最旧的应已被挤掉"
+
+    def test_cap_does_not_break_single_use_semantics(self):
+        from core.agent_card import PairingCodeRegistry, create_agent_card, to_link
+
+        reg = PairingCodeRegistry(max_active=8)
+        code, _ = reg.issue(to_link(create_agent_card("d")))
+        assert reg.resolve(code) is not None
+        assert reg.resolve(code) is None
+
+
 class TestHitlWaiver:
     """信任豁免人工确认 —— 这是分级信任的"便利性"落点:只问该问的。
 

--- a/tests/test_perception_privacy_pause.py
+++ b/tests/test_perception_privacy_pause.py
@@ -149,6 +149,78 @@ class TestPauseWipesCache:
         assert snap["audio_b64"] is None
 
 
+class TestNoTocTouGapAtThePauseBoundary:
+    """判定与写入必须在同一次持锁内。
+
+    此前 update_frame 分两次持锁(先查 paused、释放、再取锁写入),中间有 TOCTOU
+    空隙:用户按下暂停的瞬间若有一帧正在途中,pause() 会在空隙里完成"置位 + 清缓存",
+    随后这一帧落在 wipe **之后** —— 暂停期间读闸门还挡得住,但**一恢复就能读出来**,
+    而那恰恰是用户想遮住的那一帧。
+    """
+
+    @staticmethod
+    def _run_with_pause_injected_between_lock_acquisitions(store, write):
+        """把 pause() 注入到被测写入过程的第一次"释放锁"之后。
+
+        若实现是两次持锁,这个位置就落在判定与写入之间,能确定性复现竞态;
+        若实现是单次持锁,pause() 只会发生在整个写入完成之后(随即被 wipe 清掉)。
+        """
+        real = store._lock
+
+        class _Hook:
+            def __init__(self) -> None:
+                self.releases = 0
+                self.armed = True
+
+            def __enter__(self):
+                real.acquire()
+                return self
+
+            def __exit__(self, *exc):
+                real.release()
+                self.releases += 1
+                if self.armed and self.releases == 1:
+                    self.armed = False
+                    store._lock = real  # 让 pause 用真锁(此刻锁空闲)
+                    store.pause(reason="race-probe")
+                    store._lock = hook
+                return False
+
+            def acquire(self, *a, **k):
+                return real.acquire(*a, **k)
+
+            def release(self):
+                return real.release()
+
+        hook = _Hook()
+        store._lock = hook
+        try:
+            write()
+        finally:
+            store._lock = real
+
+    def test_frame_in_flight_does_not_survive_the_pause(self):
+        from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+        s = DesktopPerceptionStore()
+        self._run_with_pause_injected_between_lock_acquisitions(
+            s, lambda: s.update_frame("RACED-FRAME", source="desktop_screen")
+        )
+        assert s.paused is True
+        assert s._scr_b64 is None, "暂停边界上不能留下在途的帧"
+        s.resume()
+        assert s.snapshot_media()["screen_b64"] is None, "恢复后更不能读到那一帧"
+
+    def test_audio_in_flight_does_not_survive_the_pause(self):
+        from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+        s = DesktopPerceptionStore()
+        self._run_with_pause_injected_between_lock_acquisitions(s, lambda: s.update_audio("RACED-AUDIO"))
+        assert s._audio_b64 is None
+        s.resume()
+        assert s.snapshot_media()["audio_b64"] is None
+
+
 class TestEpochCrossesPrivacyBoundary:
     def test_epoch_increments_on_pause_and_resume(self, store):
         e0 = store.epoch

--- a/tests/test_perception_privacy_pause.py
+++ b/tests/test_perception_privacy_pause.py
@@ -1,0 +1,315 @@
+"""桌面感知隐私急停的行为测试。
+
+重点不是"函数能调通",而是**没有绕行路径**:
+
+``DesktopPerceptionStore`` 是全部桌面感知数据的唯一进出口 —— 写入口 2 个、
+读出口 5 个、下游消费方至少 4 处。闸门若漏掉任何一条读路径,那条路径的消费方
+在"隐私暂停"期间照旧能看到屏幕,隐私模式就是假的。其中
+``build_multimodal_context`` 最关键:它是**每次对话请求**的隐性注入路径,
+漏掉它 = 模型每轮都还在看屏幕。
+
+因此本文件逐条枚举五条读路径,并对四个真实消费方各自断言一次。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def store():
+    """每个用例一个独立实例(不动进程单例,避免污染其它测试)。"""
+    from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+    s = DesktopPerceptionStore()
+    s.update_frame("SCREEN-PIXELS", source="desktop_screen", screen={"window": "Secret.docx"})
+    s.update_frame("CAMERA-PIXELS", source="desktop_camera")
+    s.update_audio("MIC-AUDIO")
+    return s
+
+
+class TestAllFiveReadPathsAreSealed:
+    """五条读出口逐条验证 —— 漏一条就是一个绕行洞。"""
+
+    def test_has_fresh_frame(self, store):
+        assert store.has_fresh_frame() is True
+        store.pause()
+        assert store.has_fresh_frame() is False
+
+    def test_latest_frame_snapshot(self, store):
+        assert store.latest_frame_snapshot()[0] is not None
+        store.pause()
+        assert store.latest_frame_snapshot()[0] is None
+
+    def test_take_fresh_audio_for_autoinject(self, store):
+        assert store.take_fresh_audio_for_autoinject()[0] == "MIC-AUDIO"
+        store.pause()
+        assert store.take_fresh_audio_for_autoinject()[0] is None
+
+    def test_snapshot_media(self, store):
+        assert store.snapshot_media()["screen_b64"] == "SCREEN-PIXELS"
+        store.pause()
+        snap = store.snapshot_media()
+        assert snap["screen_b64"] is None
+        assert snap["camera_b64"] is None
+        assert snap["audio_b64"] is None
+        assert snap["screen_meta"] is None
+        assert snap["privacy_paused"] is True
+
+    def test_build_multimodal_context(self, store):
+        """最关键的一条:每次对话请求的隐性注入路径。"""
+        assert store.build_multimodal_context() is not None
+        store.pause()
+        assert store.build_multimodal_context() is None
+
+
+class TestReadGatesHoldIndependentlyOfTheWipe:
+    """五条读闸门必须**各自独立**成立,不能靠"清缓存"顺带掩盖。
+
+    这一组是补课来的:最初只写了"pause 后读不到"的用例,而 ``pause()`` 会清缓存,
+    于是即便把某条读路径的闸门整段删掉,用例照旧通过 —— 反向验证时删掉
+    ``build_multimodal_context`` 的闸门,20 条测试竟然全绿,才发现这个漏洞。
+
+    做法:暂停后**直接写内部缓冲**(绕过写入口闸门),模拟"数据以某种未预期的
+    方式进来了",再断言五条读路径依然什么都给不出。这才是第二道防线的真实检验。
+    """
+
+    @staticmethod
+    def _force_fill(s):
+        """绕过 update_* 的写闸门,直接塞进内部缓冲。"""
+        import time as _t
+
+        now = _t.time()
+        s._scr_b64 = "LEAKED-SCREEN"
+        s._scr_ts = now
+        s._screen_meta = {"window": "LEAKED"}
+        s._cam_b64 = "LEAKED-CAM"
+        s._cam_ts = now
+        s._audio_b64 = "LEAKED-AUDIO"
+        s._audio_ts = now
+        s._audio_autoinject_consumed_ts = 0.0
+
+    @pytest.fixture
+    def paused_but_filled(self):
+        from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+        s = DesktopPerceptionStore()
+        s.pause(reason="test")
+        self._force_fill(s)
+        return s
+
+    def test_has_fresh_frame_still_false(self, paused_but_filled):
+        assert paused_but_filled.has_fresh_frame() is False
+
+    def test_latest_frame_snapshot_still_empty(self, paused_but_filled):
+        assert paused_but_filled.latest_frame_snapshot()[0] is None
+
+    def test_take_fresh_audio_still_empty(self, paused_but_filled):
+        assert paused_but_filled.take_fresh_audio_for_autoinject()[0] is None
+
+    def test_snapshot_media_still_empty(self, paused_but_filled):
+        snap = paused_but_filled.snapshot_media()
+        assert snap["screen_b64"] is None
+        assert snap["camera_b64"] is None
+        assert snap["audio_b64"] is None
+        assert snap["screen_meta"] is None
+
+    def test_build_multimodal_context_still_none(self, paused_but_filled):
+        """最关键的一条:每次对话请求的隐性注入路径。"""
+        assert paused_but_filled.build_multimodal_context() is None
+
+
+class TestBothWritePathsReject:
+    def test_frame_and_audio_are_refused_while_paused(self, store):
+        store.pause()
+        store.update_frame("NEW-SCREEN", source="desktop_screen")
+        store.update_frame("NEW-CAM", source="desktop_camera")
+        store.update_audio("NEW-AUDIO")
+        st = store.privacy_status()
+        assert st["rejected_frames"] == 2
+        assert st["rejected_audio"] == 1
+        # 拒收之后仍然读不到 —— 数据根本没进内存
+        assert store.snapshot_media()["screen_b64"] is None
+
+    def test_screen_meta_only_update_is_also_refused(self, store):
+        """无像素帧、只带结构化屏幕上下文(UIA 树)的写入同样是感知数据。"""
+        store.pause()
+        store.update_frame("", source="desktop_screen", screen={"window": "Still-Secret"})
+        assert store.snapshot_media()["screen_meta"] is None
+
+
+class TestPauseWipesCache:
+    def test_cached_frames_are_wiped_not_merely_hidden(self, store):
+        """只挡读不清缓存的话,恢复瞬间旧帧又冒出来 —— 那不叫暂停。"""
+        store.pause()
+        store.resume()
+        snap = store.snapshot_media()
+        assert snap["screen_b64"] is None, "恢复后不能又看到暂停前那一帧"
+        assert snap["camera_b64"] is None
+        assert snap["audio_b64"] is None
+
+
+class TestEpochCrossesPrivacyBoundary:
+    def test_epoch_increments_on_pause_and_resume(self, store):
+        e0 = store.epoch
+        store.pause()
+        e1 = store.epoch
+        store.resume()
+        e2 = store.epoch
+        assert e1 == e0 + 1
+        assert e2 == e1 + 1
+
+    def test_repeated_pause_is_idempotent(self, store):
+        store.pause()
+        e = store.epoch
+        store.pause()
+        assert store.epoch == e, "重复 pause 不应制造新的世代"
+        assert store.paused is True
+
+    def test_frame_gate_reset_drops_pre_pause_fingerprint(self):
+        """跨隐私边界不携带视觉状态。
+
+        动机是隐私而非性能:留着暂停前的指纹去比恢复后的新帧,等于泄露
+        "被遮住那段时间画面变了多少"。代价是恢复首拍必然判为"有变化"。
+        """
+        from core.ambient_attention_loop import FrameGate
+
+        g = FrameGate(threshold=0.06)
+        frame = "AAAA" * 200
+        assert g.changed(frame) is True  # 第一帧的既定语义
+        assert g.changed(frame) is False  # 静止
+        g.reset()
+        assert g.changed(frame) is True, "reset 后应重新按第一帧处理(刻意接受的代价)"
+        assert g.changed(frame) is False, "随即回到静止,不会持续误触发"
+
+
+class TestDefaultState:
+    def test_gate_is_active_but_perception_allowed_by_default(self, monkeypatch):
+        """闸门始终生效(不藏在 feature flag 后),但默认放行。"""
+        import core.perception.desktop_perception_store as mod
+
+        monkeypatch.delenv("GALAXY_PERCEPTION_PRIVACY_DEFAULT", raising=False)
+        s = mod.DesktopPerceptionStore()
+        assert s.paused is False
+        assert hasattr(s, "pause") and hasattr(s, "resume")
+
+    def test_privacy_first_deployment_can_start_paused(self, monkeypatch):
+        import core.perception.desktop_perception_store as mod
+
+        monkeypatch.setenv("GALAXY_PERCEPTION_PRIVACY_DEFAULT", "paused")
+        s = mod.DesktopPerceptionStore()
+        assert s.paused is True
+        assert s.privacy_status()["reason"] == "privacy_default"
+        s.update_frame("X", source="desktop_screen")
+        assert s.snapshot_media()["screen_b64"] is None
+
+
+class TestEveryRealConsumerGoesBlind:
+    """四个真实消费方各自断言一次 —— 证明没有哪一路能绕过闸门。"""
+
+    def test_ambient_loop_skips_tick_when_paused(self, monkeypatch):
+        from core.ambient_attention_loop import AmbientAttentionLoop
+        from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+        s = DesktopPerceptionStore()
+        s.update_frame("SCREEN", source="desktop_screen")
+        loop = AmbientAttentionLoop()
+        loop._store = s
+        assert loop._gather_observation() is not None
+        s.pause()
+        assert loop._gather_observation() is None, "暂停后环境循环不该拿到任何观察"
+
+    def test_computer_use_loop_sees_nothing(self, monkeypatch):
+        """computer_use_loop 走 snapshot_media()(core/computer_use_loop.py:168)。"""
+        from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+        s = DesktopPerceptionStore()
+        s.update_frame("SCREEN", source="desktop_screen")
+        s.pause()
+        assert s.snapshot_media()["screen_b64"] is None
+
+    def test_session_memory_facade_sees_nothing(self):
+        """session_memory_facade 同样走 snapshot_media()(:139)。"""
+        from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+        s = DesktopPerceptionStore()
+        s.update_audio("AUDIO")
+        s.pause()
+        assert s.snapshot_media()["audio_b64"] is None
+
+    def test_conversation_multimodal_injection_sees_nothing(self):
+        """每次对话请求的注入路径 —— 漏这条则模型每轮都还在看屏幕。"""
+        from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+        s = DesktopPerceptionStore()
+        s.update_frame("SCREEN", source="desktop_screen")
+        s.update_frame("CAM", source="desktop_camera")
+        s.pause()
+        assert s.build_multimodal_context() is None
+
+
+class TestEndpointsAreWiredIn:
+    def test_privacy_endpoints_mounted_in_create_api_routes(self):
+        """端点没挂上就等于没做 —— 用户按不到那个"暂停"。"""
+        import os
+        import sys
+
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from route_introspection import iter_flat_routes
+
+        from core.api_routes import create_api_routes
+
+        paths = {getattr(r, "path", "") for r in iter_flat_routes(create_api_routes())}
+        for expected in (
+            "/api/perception/desktop/privacy",
+            "/api/perception/desktop/privacy/pause",
+            "/api/perception/desktop/privacy/resume",
+        ):
+            assert expected in paths, f"{expected} 未挂进 create_api_routes"
+
+    def test_ingest_reports_rejection_instead_of_faking_success(self):
+        """暂停期间上报 success=True 会让采集端以为存进去了,必须如实拒绝。"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from core.perception.desktop_perception_store import get_desktop_perception_store
+        from core.routes.perception import create_router
+
+        app = FastAPI()
+        app.include_router(create_router())
+        client = TestClient(app)
+        store = get_desktop_perception_store()
+        try:
+            store.pause(reason="test")
+            r = client.post(
+                "/api/perception/desktop/frame",
+                json={"image_base64": "X", "source": "desktop_screen"},
+            ).json()
+            assert r["success"] is False
+            assert r["privacy_paused"] is True
+            assert r["stored"] is None
+
+            r2 = client.post("/api/perception/desktop/audio", json={"audio_base64": "X"}).json()
+            assert r2["success"] is False
+            assert r2["privacy_paused"] is True
+        finally:
+            store.resume(reason="test-teardown")
+
+    def test_pause_resume_roundtrip_through_http(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from core.perception.desktop_perception_store import get_desktop_perception_store
+        from core.routes.perception import create_router
+
+        app = FastAPI()
+        app.include_router(create_router())
+        client = TestClient(app)
+        store = get_desktop_perception_store()
+        try:
+            assert client.post("/api/perception/desktop/privacy/pause").json()["privacy"]["paused"] is True
+            assert client.get("/api/perception/desktop/privacy").json()["privacy"]["paused"] is True
+            assert client.post("/api/perception/desktop/privacy/resume").json()["privacy"]["paused"] is False
+            assert store.paused is False
+        finally:
+            store.resume(reason="test-teardown")


### PR DESCRIPTION
借鉴 [LYiHub/pub-local-jarvis](https://github.com/LYiHub/pub-local-jarvis) 的"双击桌宠暂停感知"。

## 先说对照结论:核心那套我们已经有,而且更完整

`core/ambient_attention_loop.py` 在感知循环上是 jarvis 的**超集**:

| | pub-local-jarvis | 本仓库 |
| --- | --- | --- |
| 决策维度 | LISTEN / SPEAK | **SPEAK / SILENT / DELEGATE**(多了"该派活而非开口") |
| 视觉输入 | 单路屏幕 | 屏幕 + 摄像头双路同时喂 |
| 帧过滤 | 朴素 1 fps | `FrameGate` 感知哈希 + 归一化像素差(阈值 0.06) |
| 开口后 | — | 20s 冷却,且冷却期内仍更新门控 |
| 反自激励 | — | 朗读期间的音频只更新去重哈希、不作触发信号 |

而且它是真接通的(`startup.py:839` 启动 / `1300` 关停 / `routes/config.py:809` 热开关)。

**唯一确实缺的是隐私急停** —— 全仓搜不到任何 `pause_perception`;现有的 `ambient_loop_enabled()` 要写配置 + reload,既不是急停,也只能整循环全停(而不是"切断传感器但智能体还活着")。

## 闸门为什么必须落在 `DesktopPerceptionStore`

它是全部桌面感知数据的唯一进出口:

- **写入口 2 个**:`update_frame` / `update_audio`
- **读出口 5 个**:`has_fresh_frame` / `latest_frame_snapshot` / `take_fresh_audio_for_autoinject` / `snapshot_media` / `build_multimodal_context`
- **下游消费方 4 处**:`ambient_attention_loop`、`computer_use_loop`、`session_memory_facade`、`multimodal/ingest_runtime`

闸门放在任一消费方,其余几路照旧能看到屏幕——那是**假的**隐私模式。其中 `build_multimodal_context` 最关键:它是**每次对话请求**的隐性注入路径,漏掉它等于模型每轮都还在看屏幕。

## 实现

- `pause()` 在写入口就**拒收**后续帧/音频(数据根本不进内存),同时**立即清空**已缓存的帧/音频/屏幕结构。只挡读不清缓存的话,消费方还能读到暂停前那一帧。
- 五条读路径全部返回空,作为**第二道防线**(万一将来有数据绕过写闸门)。
- 无像素帧、只带 UIA 树的写入同样拒收——结构化屏幕上下文也是感知数据。
- `epoch` 在 pause/resume 时自增,ambient 循环据此 `reset()` 两路 `FrameGate` 与音频哈希。
- `/frame` 与 `/audio` 在暂停期间不再回 `success=True, stored="frame"`——那会让采集端以为存进去了。改为如实回 `success=false` + `privacy_paused`。

### 关于 epoch reset 的动机:是隐私,不是性能

留着暂停前那枚指纹去比恢复后的新帧,等于让智能体推断出"我被遮住的那段时间里屏幕变化了多少"。用户主动遮起来的内容不该以差异信号的形式渗出。

代价是恢复后第一拍必然判为"有变化"(`FrameGate` 对第一帧的既定语义),这是刻意接受的。**我最初把理由写成"避免恢复时误触发一次模型调用",实测恰恰相反**——reset 反而保证触发一次。已更正注释,不把错的理由留在代码里。

## 端点(已实测在真实路由表中)

```
POST /api/perception/desktop/privacy/pause
POST /api/perception/desktop/privacy/resume
GET  /api/perception/desktop/privacy
```

`status()` 一并带出隐私状态与"被拒计数",面板可显示"感知已暂停"。

闸门**始终生效**,不藏在任何 feature flag 之后;默认放行。`GALAXY_PERCEPTION_PRIVACY_DEFAULT=paused` 可让进程启动即暂停(隐私优先部署)。

## 验证 —— 含一次自我纠错

`tests/test_perception_privacy_pause.py` 25 条,并**逐个闸门**反向验证:

| 撤掉什么 | 结果 |
| --- | --- |
| `_wipe`(清缓存) | 恰好清缓存那条失败 |
| `has_fresh_frame` 闸门 | 恰好对应那条失败 |
| `latest_frame_snapshot` 闸门 | 恰好对应那条失败 |
| `take_fresh_audio` 闸门 | 恰好对应那条失败 |
| `snapshot_media` 闸门 | 2 条失败 |
| `build_multimodal_context` 闸门 | 恰好对应那条失败 |

**最后一条最初没抓住。** 第一版用例是"pause 后读不到",而 `pause()` 会清缓存,于是即便把读闸门整段删掉也照旧通过——反向验证时删掉它,25 条全绿,才暴露这个漏洞。补了 `TestReadGatesHoldIndependentlyOfTheWipe`:暂停后**直接写内部缓冲**(绕过写闸门),再断言五条读路径仍然什么都给不出。这才真正检验第二道防线。

另有 4 条按真实消费方逐个断言(ambient / computer_use / session_memory / 对话注入),以及 3 条端点挂载与 HTTP 往返。

- CI lint 三条原样复跑全绿:`flake8 core/` → 0;`black --check core/ tests/` → 1985 unchanged;`isort --check-only` → rc=0
- 回归 `pytest -k "perception or ambient or privacy or multimodal or computer_use"` → **890 passed, 3 skipped**

## 明确没做的

- **C++ DXGI/WASAPI 原生采集** —— 那是 jarvis 为单机性能做的;本仓库是跨设备 Mesh,采集本就在各端完成后送进来,换原生层解决的不是这里的问题。
- **透明弹幕 / 桌宠 UI** —— 纯前端工作。
- **课程模式 → Markdown 笔记** —— 机制层面已具备(`salient` + 记忆),缺的是用户可见的产物形态,属产品决策,需先定形态再做。

> `File Complexity Budget` 若失败,属 `main` 上既有的系统性门禁,本 PR 未触及其阻塞清单中的任何文件。


---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_