### PR TITLE
语音全双工三层(回声消除 / 应答不打断 / 双工会话)+ 系统播放声采集 + 排错七处

### DIFF
--- a/core/ambient_attention_loop.py
+++ b/core/ambient_attention_loop.py
@@ -379,11 +379,26 @@ class FrameGate:
 # 常驻注意力循环
 # ---------------------------------------------------------------------------
 def _ai_is_speaking() -> bool:
-    """AI 当前是否正在朗读（反自激励门控用）。降级安全:取不到就当没在说。"""
+    """AI 是否正在(或刚刚)朗读（反自激励门控用）。降级安全:取不到就当没在说。
+
+    两个来源取并集,因为单靠 ``is_speaking()`` 挡不住:它只反映
+    ``speech_output._active_speaker``,而那个变量只在【流式】朗读路径上被设置——
+    整段批处理(``GALAXY_TTS_STREAMING=0``)和原生发声两条路径都不设它,那两种模式
+    下 ``is_speaking()`` 恒为 False,本门形同虚设。``voice_echo_guard`` 登记在
+    "文字真的变成声音"的那一刻,三条发声路径一视同仁;它还带一段尾巴时间,能覆盖
+    "声音已播完、但麦克风侧那段缓冲刚转写出来"的滞后窗口。
+    """
     try:
         from core.speech_output import is_speaking
 
-        return bool(is_speaking())
+        if bool(is_speaking()):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from core.voice_echo_guard import recently_spoke
+
+        return bool(recently_spoke())
     except Exception:  # noqa: BLE001
         return False
 

--- a/core/device_token_registry.py
+++ b/core/device_token_registry.py
@@ -22,6 +22,21 @@ UI 能填、``/api/v1/config`` 也不吐 token,更没有"给某台设备发一�
 - 存储路径默认在仓库【之外】(``~/.galaxy/device_tokens.json``),不进 git;可用
   ``GALAXY_DEVICE_TOKEN_STORE`` 覆盖。
 
+保留期(为什么需要)
+--------------------
+``issue()`` 对同一 device_id 每次都**新增**一条记录(轮换),``revoke_device()`` 只把
+``revoked`` 置 True、从不删除,而 ``_persist()`` 每次把**全表**重写一遍。所以一台反复
+重装/换机的设备会永久留下 N 条记录:存储文件单调增长,每次发放的落盘开销也随总条数
+线性上升。已吊销记录的留存价值只有**审计**(``list_devices`` 要能显示曾被吊销),过了
+保留期就该清掉。
+
+- ``GALAXY_DEVICE_TOKEN_RETENTION_DAYS``(默认 30):已吊销记录保留多久。
+- ``GALAXY_DEVICE_TOKEN_MAX_RECORDS``(默认 512):记录总条数上限。
+
+淘汰**只动已吊销的记录,永不淘汰未吊销的** —— 删掉一条还在用的记录等于悄悄把那台设备
+踢下线,症状是"设备突然连不上、日志里什么都没有",比存储增长严重得多。若活跃记录本身
+就超过上限,如实升 WARNING 让人看见,不自作主张删 working 凭证。
+
 本模块只管"凭证的发放/校验/吊销/枚举",不含配对流程/智能体准入(那是上层
 端点的职责)——保持单一职责,便于单测。
 """
@@ -40,6 +55,45 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger("Galaxy.DeviceTokenRegistry")
 
 _STORE_SCHEMA_VERSION = 1
+
+#: 已吊销记录的默认保留期(天)。留一段时间是为了**审计**:``list_devices`` 要能显示
+#: "这台设备的凭证在什么时候被吊销过"。过了保留期就没有留存价值了。
+_DEFAULT_RETENTION_DAYS = 30.0
+
+#: 记录总条数的硬上限。见 ``_prune_unlocked`` 里为什么这个上限**永远不会**淘汰
+#: 未吊销的记录。
+_DEFAULT_MAX_RECORDS = 512
+
+
+def _retention_seconds() -> float:
+    """已吊销记录的保留时长(秒)。设为 0 表示吊销即刻可清。"""
+    raw = os.environ.get("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", "").strip()
+    if not raw:
+        return _DEFAULT_RETENTION_DAYS * 86400.0
+    try:
+        return max(0.0, float(raw)) * 86400.0
+    except ValueError:
+        logger.warning(
+            "GALAXY_DEVICE_TOKEN_RETENTION_DAYS=%r 不是合法数值,已退回默认 %s 天",
+            raw,
+            _DEFAULT_RETENTION_DAYS,
+        )
+        return _DEFAULT_RETENTION_DAYS * 86400.0
+
+
+def _max_records() -> int:
+    raw = os.environ.get("GALAXY_DEVICE_TOKEN_MAX_RECORDS", "").strip()
+    if not raw:
+        return _DEFAULT_MAX_RECORDS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning(
+            "GALAXY_DEVICE_TOKEN_MAX_RECORDS=%r 不是合法整数,已退回默认 %s",
+            raw,
+            _DEFAULT_MAX_RECORDS,
+        )
+        return _DEFAULT_MAX_RECORDS
 
 
 def _default_store_path() -> Path:
@@ -98,6 +152,79 @@ class DeviceTokenRegistry:
                 h = rec.get("token_sha256")
                 if isinstance(h, str) and h:
                     self._by_hash[h] = rec
+            # 进程重启是清理过期吊销记录的自然时机(不必等到下一次发放)
+            self._prune_unlocked()
+
+    # ── 保留期 / 上限 ─────────────────────────────────────────────────────
+
+    def _prune_unlocked(self) -> int:
+        """清掉过了保留期的【已吊销】记录并收敛到上限。返回清掉的条数。
+
+        调用方必须已持有锁。
+
+        为什么原先会无界增长:``issue()`` 对同一 device_id 每次都新增一条记录(轮换),
+        ``revoke_device()`` 只把 ``revoked`` 置 True、从不删除,而 ``_persist()`` 每次
+        都把**全表**重写一遍。于是一台反复重装/换机的设备会永久留下 N 条记录,存储文件
+        单调增长,每次发放的落盘开销也随总条数线性上升。
+
+        **淘汰只动已吊销的记录,永不淘汰未吊销的。** 删掉一条还在用的记录等于悄悄把那台
+        设备踢下线,而且症状是"设备突然连不上、日志里什么都没有"—— 那比存储增长严重得多。
+        因此当活跃记录本身就超过上限时,这里如实升 WARNING 让人看见,而不是自作主张挑一
+        条working 凭证删掉。
+        """
+        now = time.time()
+        retention = _retention_seconds()
+        removed = 0
+
+        # 1) 过了保留期的已吊销记录
+        for h, rec in list(self._by_hash.items()):
+            if not rec.get("revoked"):
+                continue
+            revoked_at = rec.get("revoked_at")
+            if not isinstance(revoked_at, (int, float)):
+                # 吊销时间缺失(手改过存储/老版本数据)→ 按 issued_at 兜底,取不到就当刚吊销
+                revoked_at = rec.get("issued_at")
+            if not isinstance(revoked_at, (int, float)):
+                continue
+            if now - revoked_at >= retention:
+                del self._by_hash[h]
+                removed += 1
+
+        # 2) 仍超上限 → 继续淘汰最老的【已吊销】记录
+        cap = _max_records()
+        if len(self._by_hash) > cap:
+            revoked = [
+                (rec.get("revoked_at") or rec.get("issued_at") or 0.0, h)
+                for h, rec in self._by_hash.items()
+                if rec.get("revoked")
+            ]
+            revoked.sort()
+            for _ts, h in revoked:
+                if len(self._by_hash) <= cap:
+                    break
+                del self._by_hash[h]
+                removed += 1
+
+        if len(self._by_hash) > cap:
+            # 只剩活跃记录还是超上限 —— 不动它们,如实报警
+            logger.warning(
+                "设备 token 记录数 %d 已超上限 %d,且余下全部为【未吊销】记录 —— "
+                "不会自动淘汰在用凭证(那会让设备突然掉线)。请吊销不再使用的设备,"
+                "或调高 GALAXY_DEVICE_TOKEN_MAX_RECORDS。",
+                len(self._by_hash),
+                cap,
+            )
+        if removed:
+            logger.info("清理设备 token 记录:已清 %d 条(过保留期或超上限的已吊销记录)", removed)
+        return removed
+
+    def prune(self) -> int:
+        """对外的清理入口(供运维/测试显式触发)。返回清掉的条数,必要时落盘。"""
+        with self._lock:
+            removed = self._prune_unlocked()
+            if removed:
+                self._persist()
+        return removed
 
     def _persist(self) -> None:
         """原子落盘:临时文件 + os.replace,避免写坏半个文件。"""
@@ -149,6 +276,9 @@ class DeviceTokenRegistry:
         }
         with self._lock:
             self._by_hash[rec["token_sha256"]] = rec
+            # 发放是唯一的增长点,所以清理挂在这里:每次新增顺手收一次,记录数就不会
+            # 随重装/换机次数单调增长(_persist 每次重写全表,条数还直接决定落盘开销)。
+            self._prune_unlocked()
             self._persist()
         logger.info("为设备发放 token: device_id=%s type=%s name=%s", device_id, device_type, name)
         return raw

--- a/core/multimodal/acoustic_echo_canceller.py
+++ b/core/multimodal/acoustic_echo_canceller.py
@@ -1,0 +1,485 @@
+"""core/multimodal/acoustic_echo_canceller.py —— 声学回声消除(AEC)。
+
+这一层解决什么
+--------------
+``core/voice_echo_guard.py`` 在**文本层**解决了归属问题:一段转写到底是"用户说的"
+还是"AI 自己的回声"。但它挡不住更前面的损害 —— 麦克风信号里始终混着扬声器放出去的
+声音,于是:
+
+- VAD 在 AI 朗读期间一直判"有人在说话",整段音频被白白攒起来送去转写;
+- ASR 拿到的是"用户语音 + AI 语音"的混合波形,即便用户真的开口,转写质量也被污染;
+- 真正的"边说边听"根本无从谈起 —— 上行通路里永远有下行信号。
+
+AEC 在**信号层**把扬声器正在播的内容从麦克风信号里减掉。它需要一路"参考信号"
+(far-end / 远端信号),也就是扬声器实际在播的波形 —— 那正是
+``core/multimodal/system_audio_ingest.py`` 采集的系统播放声回环。两者是配套的:
+没有回环采集就没有参考信号,AEC 无从实现。
+
+算法:分区频域自适应滤波(PBFDAF)
+----------------------------------
+1. **整体时延估计**(``_estimate_delay``)—— 麦克风与回环是**两条独立的流**,采集
+   起点不同、缓冲深度不同,两者之间有一个未知的整体偏移。先用能量归一化互相关找出
+   这个偏移,把参考信号对齐到麦克风时间轴上。不对齐的话自适应滤波器要用大量抽头去
+   "表示这段延迟",收敛慢且效果差。时延会周期性重估,以跟上两条流之间的缓慢时钟漂移。
+
+2. **分区频域自适应滤波** —— 滤波器按块长切成 K 个分区,每个分区在频域各持一组权重;
+   用 overlap-save 做线性卷积(FFT 长度 2N,取后 N 个样本为有效输出)。
+
+   **为什么不是时域 NLMS。** 最初的实现就是时域块状 NLMS,实测在本场景下收敛慢到
+   不可用:合成线性回声路径上,跑满 2000 块(≈200 秒音频)才到 12 dB ERLE。原因是
+   语音类信号强相关,LMS 的收敛速度受输入自相关矩阵的**特征值扩散**支配,有色输入下
+   极差 —— 这是算法选择错误,不是调参问题。频域做法给**每个频点各自按该频点的功率
+   归一化**,等效于把输入去相关,各频段收敛速度趋于一致。同一条合成测试路径上:
+   时域 2000 块才 12 dB,频域 120 块(12 秒)即 **27 dB**
+   (见 ``tests/test_acoustic_echo_cancellation.py``)。
+
+   实现上有两处细节必须做对,否则同样跑飞 —— 两处都是实测踩出来的:
+
+   - **频点功率估计要用首块实测值初始化**,不能从全零平滑上来:从 0 起平滑时首块的
+     功率只有真实值的 ``1-power_smooth``(默认 10%),步长因此放大 10 倍,开头几块直接
+     过冲,实测 ERLE 冲到 −20 dB(等于 AEC 把回声放大了)。
+   - **步长要再除分区数 K**:功率估计是所有分区之和,而 K 个分区各自都按这个步长更新
+     一次,不除就等于把有效步长放大 K 倍;不除时 ``mu`` 稍大即发散,而且改 ``tail_ms``
+     会顺带把稳定性改掉。
+
+3. **双讲检测(DTD)** —— 用户和 AI 同时说话时**必须冻结自适应**。否则滤波器会试图
+   把用户的声音也"解释"成回声,权重被带跑偏,结果是既消不掉回声、又把用户的语音
+   削掉一块。
+
+   判据**不能**是"麦克风能量是否超出回声估计":滤波器没收敛时回声估计≈0,于是那个
+   条件恒成立,DTD 把一切判成双讲 → 永不自适应 → 永不收敛,死锁。最初的实现正是踩了
+   这个坑(120 块里只有 8 块真的更新了权重)。
+
+   改成跟踪**回声路径增益**:回声只由参考信号产生,所以"麦克风 RMS / 参考 RMS"这个比值
+   在只有回声时是稳定的(就是路径增益);近端语音叠上来会让比值显著跳高。增益估计用
+   带衰减的滑动上界跟踪,与滤波器收敛程度**无关**,因此不存在死锁。
+
+不做什么(说明白)
+------------------
+- **不做非线性处理**(NLP / 残余回声抑制)。扬声器过载削波、外壳振动带来的非线性回声
+  是线性滤波器原理上消不掉的,残余回声仍会存在。文本层的 ``voice_echo_guard`` 正是为
+  这部分残余兜底 —— 两层是互补的,不是重复的。
+- **不做去噪 / 自动增益**。那是另外两件事,混在一个模块里只会让每件都做不好。
+- 时钟漂移只靠周期性整体时延重估来跟,不做重采样级的精细同步。漂移剧烈时效果会退化,
+  ``stats()`` 里的 ``erle_db`` 会如实反映出来。
+
+降级永远安全:参考信号缺失、长度异常、numpy 不可用 —— 一律**原样返回麦克风信号**,
+绝不因为 AEC 失灵而让上行通路断掉。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Deque, Dict, Optional
+
+logger = logging.getLogger("Galaxy.AEC")
+
+#: 数值下限,防除零
+_EPS = 1e-10
+
+
+def _flag(name: str, default: str = "1") -> bool:
+    return os.getenv(name, default).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _num(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("%s=%r 不是合法数值,已退回默认 %s", name, raw, default)
+        return default
+
+
+def enabled() -> bool:
+    """AEC 是否启用(默认开启)。"""
+    return _flag("GALAXY_AEC", "1")
+
+
+@dataclass
+class AECConfig:
+    """AEC 参数。
+
+    Attributes
+    ----------
+    sample_rate       采样率(Hz)。麦克风与参考信号必须同采样率。
+    tail_ms           滤波器覆盖的回声尾长(毫秒)。要盖住房间混响。整体时延由时延估计
+                      单独处理,不占用抽头。
+    mu                频域步长(0~1)。每个频点已按自身功率归一化,故这里是相对步长。
+    max_delay_ms      整体时延搜索上限(毫秒)。
+    delay_recheck_blocks  每多少块重估一次整体时延(跟时钟漂移)。
+    dtd_margin_db     麦克风/参考 能量比超出已跟踪的路径增益多少 dB 才判双讲。
+    dtd_after_blocks  前多少块不启用双讲检测(给路径增益估计一点起步样本)。
+    ref_silence_rms   参考信号 RMS 低于此值即认为"扬声器没在放",跳过处理与自适应。
+    power_smooth      频点功率的滑动平滑系数(越大越平滑、步长越稳)。
+    gain_track_decay  路径增益上界的衰减系数(越接近 1 记得越久)。
+    """
+
+    sample_rate: int = 16000
+    tail_ms: float = 128.0
+    mu: float = 0.35
+    max_delay_ms: float = 400.0
+    delay_recheck_blocks: int = 50
+    dtd_margin_db: float = 6.0
+    dtd_after_blocks: int = 4
+    ref_silence_rms: float = 1e-4
+    power_smooth: float = 0.9
+    gain_track_decay: float = 0.999
+
+    @property
+    def taps(self) -> int:
+        return max(64, int(self.sample_rate * self.tail_ms / 1000.0))
+
+    @property
+    def max_delay_samples(self) -> int:
+        return max(0, int(self.sample_rate * self.max_delay_ms / 1000.0))
+
+    @classmethod
+    def from_env(cls, sample_rate: int = 16000) -> "AECConfig":
+        return cls(
+            sample_rate=sample_rate,
+            tail_ms=_num("GALAXY_AEC_TAIL_MS", 128.0),
+            mu=_num("GALAXY_AEC_MU", 0.35),
+            max_delay_ms=_num("GALAXY_AEC_MAX_DELAY_MS", 400.0),
+            dtd_margin_db=_num("GALAXY_AEC_DTD_MARGIN_DB", 6.0),
+        )
+
+
+@dataclass
+class AECStats:
+    """可观测状态。``erle_db`` 是判断 AEC 是否真的在起作用的唯一硬指标。"""
+
+    blocks_processed: int = 0
+    blocks_bypassed: int = 0
+    blocks_adapted: int = 0
+    blocks_double_talk: int = 0
+    delay_samples: int = 0
+    erle_db: float = 0.0
+    converged: bool = False
+    last_bypass_reason: str = ""
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "blocks_processed": self.blocks_processed,
+            "blocks_bypassed": self.blocks_bypassed,
+            "blocks_adapted": self.blocks_adapted,
+            "blocks_double_talk": self.blocks_double_talk,
+            "delay_samples": self.delay_samples,
+            "delay_ms": round(self.extra.get("delay_ms", 0.0), 1),
+            "erle_db": round(self.erle_db, 2),
+            "converged": self.converged,
+            "last_bypass_reason": self.last_bypass_reason,
+        }
+
+
+class AcousticEchoCanceller:
+    """分区频域自适应(PBFDAF)声学回声消除器。
+
+    用法::
+
+        aec = AcousticEchoCanceller()
+        aec.push_reference(loopback_block)       # 扬声器正在播的(远端)
+        clean = aec.process(mic_block)           # 去回声后的近端信号
+
+    线程安全:参考信号来自回环采集线程,麦克风块来自采集回调线程,两者并发,故全部
+    状态由一把锁守护。
+
+    ``process()`` 永不抛出:任何异常都记日志并**原样返回麦克风信号**。上行语音通路
+    不能因为 AEC 出问题就断掉 —— 那比留着回声严重得多。
+    """
+
+    def __init__(self, config: Optional[AECConfig] = None) -> None:
+        self.config = config or AECConfig()
+        self._lock = threading.RLock()
+        self.stats = AECStats()
+        self._np: Any = None
+        self._ref_buf: Any = None  # 参考信号历史(numpy 1-D)
+        self._ref_len = 0
+        self._blocks = 0
+        self._delay = 0
+        self._delay_locked = False
+        self._erle_num = 0.0  # ERLE 的滑动累积(麦克风能量)
+        self._erle_den = 0.0  # ERLE 的滑动累积(残差能量)
+        # ── 频域滤波器状态(块长在首次 process() 时按实际输入锁定)──
+        self._n = 0  # 块长 N
+        self._m = 0  # FFT 长度 = 2N
+        self._parts = 0  # 分区数 K
+        self._W: Any = None  # (K, M//2+1) 复数权重
+        self._Xh: Any = None  # (K, M//2+1) 最近 K 个参考窗的频谱
+        self._pow: Any = None  # (M//2+1,) 频点功率滑动估计
+        self._gain_est = 0.0  # 回声路径增益上界估计(DTD 用,与收敛无关)
+        self._init_numpy()
+
+    # ── 初始化 ────────────────────────────────────────────────────────────
+
+    def _init_numpy(self) -> None:
+        try:
+            import numpy as np
+        except Exception as exc:  # noqa: BLE001 — 没有 numpy 就整体旁通
+            logger.warning("numpy 不可用,AEC 关闭(麦克风信号原样通过): %s", exc)
+            return
+        self._np = np
+        # 参考历史要够长:抽头 + 最大时延 + 一整秒余量
+        self._ref_len = self.config.taps + self.config.max_delay_samples + self.config.sample_rate
+        self._ref_buf = np.zeros(self._ref_len, dtype=np.float64)
+
+    def _init_filter(self, n: int) -> None:
+        """按实际块长 N 建立频域滤波器。调用方必须已持有锁。
+
+        块长取**首次实际到来的块**的长度而不是配置值:采集链路的块长由
+        ``chunk_duration_ms`` 与设备实际给的帧数共同决定,写死会导致每块都走
+        "长度不符→旁通",AEC 等于没接。块长变化时重建并记一条日志。
+        """
+        np = self._np
+        self._n = int(n)
+        self._m = 2 * self._n
+        self._parts = max(1, -(-self.config.taps // self._n))  # ceil
+        bins = self._m // 2 + 1
+        self._W = np.zeros((self._parts, bins), dtype=np.complex128)
+        self._Xh = np.zeros((self._parts, bins), dtype=np.complex128)
+        self._pow = np.zeros(bins, dtype=np.float64)
+        self._pow_init = False
+        logger.info(
+            "AEC 滤波器就绪:块长=%d 样本 FFT=%d 分区=%d(尾长≈%.0fms)",
+            self._n,
+            self._m,
+            self._parts,
+            1000.0 * self._parts * self._n / max(1, self.config.sample_rate),
+        )
+
+    @property
+    def available(self) -> bool:
+        return self._np is not None
+
+    # ── 参考信号(远端 / 扬声器正在播的)────────────────────────────────
+
+    def push_reference(self, ref: Any) -> None:
+        """喂入一块参考信号(扬声器正在播的波形)。降级安全,永不抛出。"""
+        if self._np is None:
+            return
+        try:
+            np = self._np
+            arr = np.asarray(ref, dtype=np.float64).reshape(-1)
+            if arr.size == 0:
+                return
+            with self._lock:
+                if arr.size >= self._ref_len:
+                    self._ref_buf[:] = arr[-self._ref_len :]
+                else:
+                    self._ref_buf = np.roll(self._ref_buf, -arr.size)
+                    self._ref_buf[-arr.size :] = arr
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("push_reference 失败(本块参考信号丢弃): %s", exc)
+
+    # ── 时延估计 ──────────────────────────────────────────────────────────
+
+    def _estimate_delay(self, mic: Any) -> int:
+        """用能量归一化互相关估计麦克风相对参考信号的整体时延(样本数)。
+
+        返回"参考信号要往后取多少样本才与麦克风对齐"。找不到可信峰值时返回当前值。
+        """
+        np = self._np
+        search = self.config.max_delay_samples
+        if search <= 0:
+            return 0
+        # 取参考历史的尾部作为搜索区间;mic 作为模板
+        n = mic.size
+        span = min(self._ref_buf.size, search + n)
+        seg = self._ref_buf[-span:]
+        if seg.size < n + 1:
+            return self._delay
+        # 归一化互相关:去均值 + 除以能量,避免被幅度差主导
+        m = mic - mic.mean()
+        m_norm = float(np.sqrt(np.dot(m, m))) + _EPS
+        corr = np.correlate(seg, m, mode="valid")  # 长度 = span - n + 1
+        if corr.size == 0:
+            return self._delay
+        # 逐 lag 的参考能量,用于归一化(累积和求滑动窗口能量)
+        sq = np.concatenate(([0.0], np.cumsum(seg * seg)))
+        win_energy = sq[n:] - sq[: sq.size - n]  # 长度 = span - n + 1
+        denom = np.sqrt(np.maximum(win_energy, 0.0)) * m_norm + _EPS
+        ncc = np.abs(corr) / denom
+        best = int(np.argmax(ncc))
+        peak = float(ncc[best])
+        # 峰值太弱说明这块里没有可辨认的回声(比如扬声器没在放),不动时延
+        if peak < 0.2:
+            return self._delay
+        # best 是 seg 内的起点;换算成"距参考历史末端的偏移"
+        delay = (seg.size - n) - best
+        return int(max(0, min(delay, search)))
+
+    # ── 主处理 ────────────────────────────────────────────────────────────
+
+    def process(self, mic: Any) -> Any:
+        """对一块麦克风信号做回声消除,返回去回声后的信号。
+
+        永不抛出:任何问题都原样返回输入。
+        """
+        if self._np is None or not enabled():
+            with self._lock:
+                self.stats.blocks_bypassed += 1
+                self.stats.last_bypass_reason = "disabled" if self._np is not None else "no_numpy"
+            return mic
+        try:
+            return self._process_inner(mic)
+        except Exception as exc:  # noqa: BLE001 — 上行通路绝不能因 AEC 断掉
+            logger.warning("AEC 处理失败,本块麦克风信号原样通过: %s", exc, exc_info=True)
+            with self._lock:
+                self.stats.blocks_bypassed += 1
+                self.stats.last_bypass_reason = "error"
+            return mic
+
+    def _process_inner(self, mic_in: Any) -> Any:
+        np = self._np
+        mic = np.asarray(mic_in, dtype=np.float64).reshape(-1)
+        n = mic.size
+        if n == 0:
+            return mic_in
+
+        with self._lock:
+            # 块长按首次实际到来的块锁定(理由见 _init_filter)
+            if self._n != n:
+                if self._n != 0:
+                    logger.info("AEC 块长变化 %s → %s,重建滤波器", self._n, n)
+                self._init_filter(n)
+            taps = self._parts * self._n
+
+            # 参考信号安静 → 扬声器没在放 → 没有回声可消。也不能在这种情况下自适应:
+            # 那等于让滤波器去拟合噪声,把已经收敛的权重带跑偏。
+            ref_tail = self._ref_buf[-(n + taps) :]
+            ref_rms = float(np.sqrt(np.mean(ref_tail * ref_tail)))
+            if ref_rms < self.config.ref_silence_rms:
+                self.stats.blocks_bypassed += 1
+                self.stats.last_bypass_reason = "reference_silent"
+                return mic_in
+
+            self._blocks += 1
+
+            # 整体时延:首次必估;之后周期性重估以跟时钟漂移
+            if not self._delay_locked or (self._blocks % max(1, self.config.delay_recheck_blocks) == 0):
+                est = self._estimate_delay(mic)
+                if est != self._delay:
+                    logger.debug("AEC 时延更新: %s → %s 样本", self._delay, est)
+                self._delay = est
+                self._delay_locked = True
+
+            # 取出与本块麦克风对齐的参考窗:overlap-save 要 2N 个样本(前 N 个是上一块的
+            # 尾巴,用来提供跨块的卷积历史),末端回退 delay 个样本做对齐。
+            end = self._ref_buf.size - self._delay
+            start = end - self._m
+            if start < 0 or end <= 0:
+                self.stats.blocks_bypassed += 1
+                self.stats.last_bypass_reason = "reference_too_short"
+                return mic_in
+            x_win = self._ref_buf[start:end]
+
+            # 新参考窗入历史(最近的排在索引 0)
+            X = np.fft.rfft(x_win, self._m)
+            self._Xh = np.roll(self._Xh, 1, axis=0)
+            self._Xh[0] = X
+
+            # 回声估计:各分区频域相乘后求和,irfft 取后 N 个样本(前 N 个是循环卷积
+            # 的绕回部分,overlap-save 按定义丢弃)。
+            Y = (self._W * self._Xh).sum(axis=0)
+            y_hat = np.fft.irfft(Y, self._m)[self._n :]
+            if y_hat.size != n:  # 理论上不会发生;真发生了宁可旁通也不返回错长度的块
+                self.stats.blocks_bypassed += 1
+                self.stats.last_bypass_reason = "length_mismatch"
+                return mic_in
+            err = mic - y_hat
+
+            # ── 双讲检测:跟踪回声路径增益,与滤波器收敛程度无关(见模块 docstring)──
+            mic_rms = float(np.sqrt(np.dot(mic, mic) / n))
+            ratio = mic_rms / (ref_rms + _EPS)
+            dtd_active = self._blocks > self.config.dtd_after_blocks
+            margin = 10.0 ** (self.config.dtd_margin_db / 20.0)  # 幅度比 → 20·log10
+            double_talk = bool(dtd_active and ratio > margin * (self._gain_est + _EPS))
+            if not double_talk:
+                # 只在"确信没有近端语音"时更新增益估计,否则近端语音会把上界抬高、
+                # 让 DTD 自己失灵(经典的自我毒化)。带衰减以便跟上路径变化。
+                self._gain_est = max(ratio, self._gain_est * self.config.gain_track_decay)
+
+            if double_talk:
+                self.stats.blocks_double_talk += 1
+            else:
+                # 频域自适应:每个频点按自身功率归一化 —— 这正是相对时域 NLMS 的关键
+                # 改进(输入去相关,各频段收敛速度趋于一致)。
+                E = np.fft.rfft(np.concatenate((np.zeros(self._n), err)), self._m)
+                p = (np.abs(self._Xh) ** 2).sum(axis=0)
+                a = self.config.power_smooth
+                if not self._pow_init:
+                    # 功率估计必须用【首块实测值】初始化,不能从全零平滑上来:
+                    # 从 0 起平滑时首块的 _pow 只有真实功率的 (1-a) = 10%,步长
+                    # 因此放大 10 倍,前几块直接过冲 —— 实测表现为开头一段 ERLE
+                    # 冲到 −20 dB(AEC 把回声放大了),之后才慢慢拉回来。
+                    self._pow = p.copy()
+                    self._pow_init = True
+                else:
+                    self._pow = a * self._pow + (1.0 - a) * p
+                # 再除分区数:_pow 是【所有分区功率之和】,而每个分区各自都要按这个
+                # 步长更新一次,K 个分区同时走等于把有效步长放大 K 倍。除掉之后 mu 的
+                # 含义与尾长(分区数)解耦 —— 改 tail_ms 不会顺带把稳定性改掉。
+                step = self.config.mu / (self._parts * (self._pow + _EPS))
+                self._W += step * np.conj(self._Xh) * E
+                self.stats.blocks_adapted += 1
+
+            # ── ERLE(回声抑制量,dB)—— AEC 是否真在起作用的唯一硬指标 ──
+            self._erle_num = 0.95 * self._erle_num + float(np.dot(mic, mic))
+            self._erle_den = 0.95 * self._erle_den + float(np.dot(err, err))
+            if self._erle_den > _EPS:
+                self.stats.erle_db = 10.0 * float(np.log10((self._erle_num + _EPS) / self._erle_den))
+            self.stats.blocks_processed += 1
+            self.stats.delay_samples = self._delay
+            self.stats.extra["delay_ms"] = 1000.0 * self._delay / max(1, self.config.sample_rate)
+            self.stats.converged = self.stats.erle_db > 6.0
+            out = err
+
+        return out.astype(np.float32) if getattr(mic_in, "dtype", None) == np.float32 else out
+
+    # ── 观测 / 复位 ──────────────────────────────────────────────────────
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return self.stats.to_dict()
+
+    def reset(self) -> None:
+        """清空滤波器与参考历史(换设备 / 换会话时用)。"""
+        with self._lock:
+            if self._np is not None:
+                self._w = self._np.zeros(self.config.taps, dtype=self._np.float64)
+                self._ref_buf = self._np.zeros(self._ref_len, dtype=self._np.float64)
+            self._blocks = 0
+            self._delay = 0
+            self._delay_locked = False
+            self._erle_num = 0.0
+            self._erle_den = 0.0
+            self.stats = AECStats()
+
+
+# ── 进程级单例(麦克风采集链路用)────────────────────────────────────────
+
+_aec: Optional[AcousticEchoCanceller] = None
+_aec_lock = threading.Lock()
+_BACKGROUND_REFS: Optional[Deque] = None  # 占位:保持与其它模块一致的导入形状
+
+
+def get_echo_canceller(sample_rate: int = 16000) -> AcousticEchoCanceller:
+    """返回进程级 AEC 单例。采样率变化时重建(滤波器长度与采样率绑定)。"""
+    global _aec
+    with _aec_lock:
+        if _aec is None or _aec.config.sample_rate != sample_rate:
+            _aec = AcousticEchoCanceller(AECConfig.from_env(sample_rate=sample_rate))
+        return _aec
+
+
+def reset_echo_canceller() -> None:
+    """重置单例(测试用)。"""
+    global _aec
+    with _aec_lock:
+        _aec = None

--- a/core/multimodal/audio_ingest.py
+++ b/core/multimodal/audio_ingest.py
@@ -202,6 +202,16 @@ class AudioIngestPipeline:
         self._running = True
         self._quality = SignalQuality.ok()
 
+        # AEC 要有参考信号才有意义,而参考信号来自系统播放声回环采集。在这里顺手确保
+        # 它起来,避免出现"AEC 装上了但没人喂参考"这种写了没接的状态 —— 那种状态下
+        # AEC 会永远走 reference_silent 旁通,且毫无声响。不可用时它自己会记 WARNING。
+        try:
+            from core.multimodal.system_audio_capture_service import ensure_started
+
+            ensure_started(self.config.sample_rate)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("回环采集自启跳过(麦克风链路不受影响): %s", exc)
+
         try:
             with sd.InputStream(
                 samplerate=self.config.sample_rate,
@@ -260,9 +270,29 @@ class AudioIngestPipeline:
             self._running = False
             logger.info("Audio ingest stopped")
 
+    def _cancel_echo(self, chunk: np.ndarray) -> np.ndarray:
+        """把扬声器正在放的内容从麦克风信号里减掉(AEC)。降级安全,永不抛出。
+
+        必须发生在 **VAD 之前**:AI 朗读期间麦克风采到的回声会让 VAD 一直判"有人在
+        说话",整段音频被攒起来送去转写,ASR 拿到的是"用户语音 + AI 语音"的混合波形。
+        在这里减掉,下游 VAD / 特征提取 / ASR 全部受益,不必各自处理。
+
+        参考信号由 ``system_audio_capture_service`` 的回环采集提供;没有参考信号时
+        AEC 自己会走 ``reference_silent`` 旁通、原样返回,所以这条路径在没有回环设备的
+        机器上完全无害。
+        """
+        try:
+            from core.multimodal.acoustic_echo_canceller import get_echo_canceller
+
+            return get_echo_canceller(self.config.sample_rate).process(chunk)
+        except Exception as exc:  # noqa: BLE001 — 上行通路绝不能因 AEC 断掉
+            logger.debug("AEC 跳过(本块原样通过): %s", exc)
+            return chunk
+
     async def _process_chunk(self, chunk: np.ndarray) -> None:
         """Update VAD + features and invoke registered callbacks."""
         now = time.monotonic()
+        chunk = self._cancel_echo(chunk)
         vad_state = self._vad.process_frame(chunk)
         state = extract_audio_features(chunk, vad_state, self._last_update_ts, self.config.sample_rate)
         self._last_update_ts = now

--- a/core/multimodal/system_audio_capture_service.py
+++ b/core/multimodal/system_audio_capture_service.py
@@ -1,0 +1,369 @@
+"""core/multimodal/system_audio_capture_service.py —— 系统播放声回环采集循环。
+
+它把一路回环采集同时喂给**两个**下游,这两个下游的用途完全不同:
+
+1. **AEC 的参考信号**(``core/multimodal/acoustic_echo_canceller.py``)—— 回声消除
+   必须知道"扬声器此刻在放什么"才能从麦克风信号里把它减掉。这是逐块、低延迟的。
+2. **感知库的系统声槽位**(``core/perception/desktop_perception_store.py``)—— 让模型
+   知道"用户此刻在听什么"。这是每隔几秒攒一段、编码成 WAV base64 再送进去的。
+
+为什么两个下游共用一路采集:回环流是**独占性**资源(同一个输出设备开两条 loopback 流
+在 WASAPI 上会互相干扰),而且重复采集纯属浪费。所以采集只做一次,分发在本模块内完成。
+
+为什么本机采集而不是等电脑端壳来 POST
+--------------------------------------
+``/api/perception/desktop/system_audio`` 那条路由是给 Electron 壳用的,壳不在本仓库里。
+但 AEC 的参考信号**不能**走 HTTP:它要求与麦克风块在同一时间尺度上对齐(毫秒级),
+绕一趟 HTTP + base64 编解码根本没法用。所以本模块在**服务端进程内**直接采集 ——
+这也顺带让整条链路不依赖任何外部壳:装了 sounddevice 的机器上,AEC 与"用户在听什么"
+两件事都能自己跑起来。
+
+隐私
+----
+系统播放声比麦克风更敏感(等于把用户正在听的一切完整送出去)。因此:
+
+* 送进感知库走的是 ``update_system_audio()``,那条路**已经在隐私闸门后面** ——
+  暂停期间写入口直接拒收。
+* 隐私暂停期间**连采集本身都停**(见 ``_privacy_paused``):不只是"采了不用",而是
+  不往任何缓冲里放。AEC 参考信号也一并断掉 —— 代价是暂停期间没有回声消除,但暂停期间
+  本来就不该有音频进上行通路。
+
+降级永远安全:探测不可用 → ``start()`` 如实返回 False 并说明原因,绝不抛出、绝不
+影响麦克风链路。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.SystemAudioCapture")
+
+#: 攒多少秒的系统声才编码一段送进感知库(太频繁纯属浪费 CPU 与带宽)
+_DEFAULT_SNAPSHOT_SEC = 3.0
+
+#: 内部 PCM 缓冲的硬上限(秒)。防止感知库不可用时缓冲无界增长。
+_MAX_BUFFER_SEC = 12.0
+
+_BACKGROUND_TASKS: set = set()
+
+
+def _flag(name: str, default: str = "1") -> bool:
+    return os.getenv(name, default).strip().lower() not in ("0", "false", "no", "off")
+
+
+def enabled() -> bool:
+    """回环采集是否启用(默认开启)。"""
+    return _flag("GALAXY_SYSTEM_AUDIO_CAPTURE", "1")
+
+
+def feed_perception_enabled() -> bool:
+    """是否把系统声送进感知库(默认开启;设 0 则只做 AEC 参考信号)。
+
+    分成两个开关是因为两件事的隐私含量不同:AEC 参考信号只在进程内做减法、不出网、
+    不进任何上下文;送进感知库则意味着这段音频会**进模型上下文**。想只要回声消除、
+    不想让模型听见自己在放什么的用户,应该能只关后者。
+    """
+    return _flag("GALAXY_SYSTEM_AUDIO_TO_PERCEPTION", "1")
+
+
+def pcm_to_wav_base64(pcm: Any, sample_rate: int) -> str:
+    """把 float32/float64 单声道 PCM 编码成 16-bit WAV 的 base64。
+
+    用 WAV 而不是 webm/opus:标准库 ``wave`` 就能写,不引入编码器依赖;体积换来的是
+    零依赖与确定性。感知库那一侧只关心 mime 与 base64,不在意具体容器。
+    """
+    import numpy as np
+
+    arr = np.asarray(pcm, dtype=np.float64).reshape(-1)
+    if arr.size == 0:
+        return ""
+    # 限幅后转 16-bit;不做自动增益(那会改变"用户听到的相对音量"这一信息)
+    clipped = np.clip(arr, -1.0, 1.0)
+    ints = (clipped * 32767.0).astype("<i2")
+
+    import wave
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(int(sample_rate))
+        wf.writeframes(ints.tobytes())
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+class SystemAudioCaptureService:
+    """回环采集循环:一路采集,分发给 AEC 参考信号与感知库系统声槽位。
+
+    用法::
+
+        svc = SystemAudioCaptureService(sample_rate=16000)
+        ok = await svc.start()          # False = 本机不支持,原因见 svc.status()
+        ...
+        await svc.stop()
+    """
+
+    def __init__(self, sample_rate: int = 16000, snapshot_sec: Optional[float] = None) -> None:
+        self.sample_rate = int(sample_rate)
+        self.snapshot_sec = float(snapshot_sec if snapshot_sec is not None else _DEFAULT_SNAPSHOT_SEC)
+        self._lock = threading.Lock()
+        self._stream: Any = None
+        self._running = False
+        self._unavailable_reason = ""
+        self._target_desc = ""
+        # 攒给感知库的 PCM 片段(逐块 append,定时编码)
+        self._pcm: List[Any] = []
+        self._pcm_samples = 0
+        self._last_snapshot_ts = 0.0
+        # 观测
+        self.blocks_captured = 0
+        self.blocks_dropped_paused = 0
+        self.snapshots_pushed = 0
+        self.ref_pushed = 0
+
+    # ── 生命周期 ──────────────────────────────────────────────────────────
+
+    async def start(self) -> bool:
+        """启动回环采集。返回是否真的起来了;不可用时如实返回 False 并记录原因。"""
+        if not enabled():
+            self._unavailable_reason = "disabled_by_env"
+            logger.info("系统播放声采集被 GALAXY_SYSTEM_AUDIO_CAPTURE=0 关闭")
+            return False
+        with self._lock:
+            if self._running:
+                return True
+        try:
+            from core.multimodal.system_audio_ingest import (
+                open_loopback_stream,
+                probe,
+                resolve_loopback_target,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._unavailable_reason = f"import_failed: {exc}"
+            logger.warning("系统播放声采集模块不可用: %s", exc)
+            return False
+
+        info = probe()
+        if not info.get("available"):
+            self._unavailable_reason = str(info.get("reason") or "unavailable")
+            # WARNING 而非 debug:这条链路不通意味着**没有回声消除**,用户会听到
+            # "AI 老是打断自己"之类的症状,必须能从日志里查到根因。
+            logger.warning(
+                "系统播放声采集不可用 → AEC 没有参考信号,回声消除将不生效。原因:%s",
+                info.get("reason_text") or self._unavailable_reason,
+            )
+            return False
+
+        try:
+            import sounddevice as sd  # noqa: F401
+
+            from core.multimodal.system_audio_ingest import downmix_to_mono
+
+            devices = [dict(d) for d in sd.query_devices()]
+            hostapis = [dict(h) for h in sd.query_hostapis()]
+            import platform
+
+            target, reason = resolve_loopback_target(
+                devices,
+                hostapis,
+                os_name=platform.system(),
+                has_wasapi_settings=hasattr(sd, "WasapiSettings"),
+            )
+            if target is None:
+                self._unavailable_reason = reason
+                logger.warning("系统播放声采集目标解析失败: %s", reason)
+                return False
+            self._target_desc = target.describe()
+
+            def _cb(indata, frames, time_info, status) -> None:  # noqa: ANN001
+                if status:
+                    logger.debug("回环采集 status: %s", status)
+                try:
+                    self._on_block(downmix_to_mono(indata))
+                except Exception as exc:  # noqa: BLE001 — 回调里绝不能抛
+                    logger.debug("回环采集块处理失败(丢弃本块): %s", exc)
+
+            stream = open_loopback_stream(target, sample_rate=self.sample_rate, callback=_cb)
+            stream.start()
+        except Exception as exc:  # noqa: BLE001
+            self._unavailable_reason = f"open_failed: {exc}"
+            logger.warning("回环采集流打开失败,AEC 将没有参考信号: %s", exc)
+            return False
+
+        with self._lock:
+            self._stream = stream
+            self._running = True
+            self._last_snapshot_ts = time.time()
+        logger.info("系统播放声采集已启动:%s", self._target_desc)
+        return True
+
+    async def stop(self) -> None:
+        """停止采集并清空缓冲。幂等、永不抛出。"""
+        with self._lock:
+            stream, self._stream = self._stream, None
+            self._running = False
+            self._pcm = []
+            self._pcm_samples = 0
+        if stream is not None:
+            try:
+                stream.stop()
+                stream.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("关闭回环采集流失败(忽略): %s", exc)
+            logger.info("系统播放声采集已停止")
+
+    @property
+    def running(self) -> bool:
+        with self._lock:
+            return self._running
+
+    # ── 采集回调 ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _privacy_paused() -> bool:
+        """隐私是否处于暂停。取不到就当**没暂停**吗?不 —— 取不到当暂停。
+
+        这里刻意 fail-closed,与本仓库其它地方的 fail-open 相反:判断不了隐私状态时
+        继续采集系统声,是在拿用户正在听的全部内容赌一个未知状态。宁可少采一段。
+        """
+        try:
+            from core.perception.desktop_perception_store import (
+                get_desktop_perception_store,
+            )
+
+            return bool(get_desktop_perception_store().paused)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("读取隐私状态失败,按【已暂停】处理(fail-closed): %s", exc)
+            return True
+
+    def _on_block(self, mono: Any) -> None:
+        """每个回环块:先隐私闸门,再喂 AEC 参考,再攒给感知库。"""
+        if self._privacy_paused():
+            with self._lock:
+                self.blocks_dropped_paused += 1
+                # 暂停期间连缓冲都清掉,不留"恢复后一次性送出暂停期间内容"的口子
+                self._pcm = []
+                self._pcm_samples = 0
+            return
+
+        with self._lock:
+            self.blocks_captured += 1
+
+        # 1) AEC 参考信号 —— 逐块、低延迟,这是回声消除的命脉
+        try:
+            from core.multimodal.acoustic_echo_canceller import get_echo_canceller
+
+            get_echo_canceller(self.sample_rate).push_reference(mono)
+            with self._lock:
+                self.ref_pushed += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("推送 AEC 参考信号失败(本块跳过): %s", exc)
+
+        # 2) 攒给感知库,定时编码送出
+        if not feed_perception_enabled():
+            return
+        try:
+            import numpy as np
+
+            with self._lock:
+                self._pcm.append(np.asarray(mono, dtype=np.float32).copy())
+                self._pcm_samples += int(np.asarray(mono).size)
+                # 硬上界:感知库不可用时不能让缓冲无界增长
+                max_samples = int(_MAX_BUFFER_SEC * self.sample_rate)
+                while self._pcm_samples > max_samples and self._pcm:
+                    dropped = self._pcm.pop(0)
+                    self._pcm_samples -= int(np.asarray(dropped).size)
+                due = (time.time() - self._last_snapshot_ts) >= self.snapshot_sec
+                if not due or self._pcm_samples <= 0:
+                    return
+                chunks = self._pcm
+                self._pcm = []
+                self._pcm_samples = 0
+                self._last_snapshot_ts = time.time()
+            self._push_snapshot(np.concatenate(chunks))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("系统声快照攒帧失败: %s", exc)
+
+    def _push_snapshot(self, pcm: Any) -> None:
+        """把一段系统声编码成 WAV base64 送进感知库。永不抛出。"""
+        try:
+            b64 = pcm_to_wav_base64(pcm, self.sample_rate)
+            if not b64:
+                return
+            from core.perception.desktop_perception_store import (
+                get_desktop_perception_store,
+            )
+
+            get_desktop_perception_store().update_system_audio(b64, mime="audio/wav")
+            with self._lock:
+                self.snapshots_pushed += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("送入感知库系统声槽位失败: %s", exc)
+
+    # ── 观测 ──────────────────────────────────────────────────────────────
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "running": self._running,
+                "enabled": enabled(),
+                "feeds_perception": feed_perception_enabled(),
+                "target": self._target_desc or None,
+                "unavailable_reason": self._unavailable_reason or None,
+                "sample_rate": self.sample_rate,
+                "snapshot_sec": self.snapshot_sec,
+                "blocks_captured": self.blocks_captured,
+                "blocks_dropped_paused": self.blocks_dropped_paused,
+                "ref_pushed": self.ref_pushed,
+                "snapshots_pushed": self.snapshots_pushed,
+                "buffered_samples": self._pcm_samples,
+            }
+
+
+# ── 进程级单例 ───────────────────────────────────────────────────────────────
+
+_svc: Optional[SystemAudioCaptureService] = None
+_svc_lock = threading.Lock()
+
+
+def get_system_audio_capture(sample_rate: int = 16000) -> SystemAudioCaptureService:
+    global _svc
+    with _svc_lock:
+        if _svc is None or _svc.sample_rate != sample_rate:
+            _svc = SystemAudioCaptureService(sample_rate=sample_rate)
+        return _svc
+
+
+def reset_system_audio_capture() -> None:
+    """重置单例(测试用)。"""
+    global _svc
+    with _svc_lock:
+        _svc = None
+
+
+def ensure_started(sample_rate: int = 16000) -> None:
+    """在**已有事件循环**的上下文里确保回环采集已启动(fire-and-forget)。
+
+    供麦克风采集链路调用:AEC 需要参考信号,而参考信号来自这里。做成"顺手确保"
+    而不是要求调用方显式编排,是为了避免出现"AEC 装上了但没人喂参考信号"这种
+    写了没接的状态 —— 那种状态下 AEC 会永远走 reference_silent 旁通,而且毫无声响。
+    """
+    try:
+        svc = get_system_audio_capture(sample_rate)
+        if svc.running:
+            return
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(svc.start())
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
+    except RuntimeError:
+        logger.debug("没有运行中的事件循环,跳过回环采集自启(麦克风链路仍正常)")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("回环采集自启失败(不影响麦克风链路): %s", exc)

--- a/core/multimodal/system_audio_capture_service.py
+++ b/core/multimodal/system_audio_capture_service.py
@@ -27,6 +27,11 @@
 * 隐私暂停期间**连采集本身都停**(见 ``_privacy_paused``):不只是"采了不用",而是
   不往任何缓冲里放。AEC 参考信号也一并断掉 —— 代价是暂停期间没有回声消除,但暂停期间
   本来就不该有音频进上行通路。
+* **跨越隐私边界的待送缓冲一律作废**(见 ``_drop_buffer_if_privacy_changed``)。光靠
+  "下一块到来时看见 paused 再清"是不够的,实测过的真实泄露路径:采了几秒 → 用户按暂停
+  (``pause()`` 只清感知库自己的缓存,碰不到本服务的待送缓冲)→ 用户恢复 → 下一块到来时
+  ``paused`` 已经是 False,那段**暂停之前**攒的音频就被原样送进了感知库。改用感知库的
+  ``epoch`` 世代号判断,"暂停过"这件事在恢复之后依然可见。
 
 降级永远安全:探测不可用 → ``start()`` 如实返回 False 并说明原因,绝不抛出、绝不
 影响麦克风链路。
@@ -121,12 +126,19 @@ class SystemAudioCaptureService:
         # 攒给感知库的 PCM 片段(逐块 append,定时编码)
         self._pcm: List[Any] = []
         self._pcm_samples = 0
-        self._last_snapshot_ts = 0.0
+        # 初始化成"现在"而不是 0.0:留 0.0 的话 (time.time() - 0) 恒大于任何 snapshot_sec,
+        # 于是**第一块**永远立刻触发一次快照,无视配置的间隔。生产路径上 start() 会重设
+        # 它所以看不出来,但这条隐含依赖很脆 —— 任何不经 start() 直接喂块的调用方
+        # (含测试)都会撞上,而且症状是"间隔配置好像没生效"。
+        self._last_snapshot_ts = time.time()
         # 观测
         self.blocks_captured = 0
         self.blocks_dropped_paused = 0
         self.snapshots_pushed = 0
         self.ref_pushed = 0
+        self.buffers_dropped_epoch = 0
+        #: 上次见到的隐私世代号。初始化成当前值,避免首块就误丢一次空缓冲。
+        self._epoch = self._privacy_epoch()
 
     # ── 生命周期 ──────────────────────────────────────────────────────────
 
@@ -243,8 +255,51 @@ class SystemAudioCaptureService:
             logger.debug("读取隐私状态失败,按【已暂停】处理(fail-closed): %s", exc)
             return True
 
+    @staticmethod
+    def _privacy_epoch() -> int:
+        """感知库的 pause/resume 世代号。取不到返回 -1(会被当作"变了"→丢缓冲)。"""
+        try:
+            from core.perception.desktop_perception_store import (
+                get_desktop_perception_store,
+            )
+
+            return int(get_desktop_perception_store().epoch)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("读取隐私世代号失败,按【已变化】处理: %s", exc)
+            return -1
+
+    def _drop_buffer_if_privacy_changed(self) -> bool:
+        """隐私世代变过就丢掉待送缓冲。返回是否丢弃了。
+
+        为什么光靠"下一块到来时看见 paused 再清"不够 —— 实测过的真实泄露路径:
+        采了几秒 → 用户按暂停(``pause()`` 只清感知库自己的缓存,**碰不到**本服务的
+        待送缓冲)→ 用户恢复 → 下一块到来时 ``paused`` 已经是 False,于是那段
+        **暂停之前**攒的音频被原样编码送进感知库。若暂停期间回环流本就没有新块
+        (比如扬声器静音),连"看见 paused"的机会都没有。
+
+        改用世代号:``epoch`` 在每次 pause/resume 都自增,所以"暂停过"这件事即便在
+        恢复之后也依然可见 —— 这正是 ``epoch`` 当初为 ambient 帧差指纹设计的用途,
+        同一个机制在这里同样适用。
+        """
+        now_epoch = self._privacy_epoch()
+        with self._lock:
+            if now_epoch == self._epoch:
+                return False
+            had = self._pcm_samples > 0
+            self._epoch = now_epoch
+            self._pcm = []
+            self._pcm_samples = 0
+            if had:
+                self.buffers_dropped_epoch += 1
+        if had:
+            logger.info("隐私世代变化(epoch=%s),已丢弃待送的系统声缓冲", now_epoch)
+        return had
+
     def _on_block(self, mono: Any) -> None:
         """每个回环块:先隐私闸门,再喂 AEC 参考,再攒给感知库。"""
+        # 跨越过隐私边界的缓冲一律作废(理由见 _drop_buffer_if_privacy_changed)
+        self._drop_buffer_if_privacy_changed()
+
         if self._privacy_paused():
             with self._lock:
                 self.blocks_dropped_paused += 1
@@ -324,6 +379,8 @@ class SystemAudioCaptureService:
                 "ref_pushed": self.ref_pushed,
                 "snapshots_pushed": self.snapshots_pushed,
                 "buffered_samples": self._pcm_samples,
+                "buffers_dropped_epoch": self.buffers_dropped_epoch,
+                "privacy_epoch": self._epoch,
             }
 
 

--- a/core/multimodal/system_audio_ingest.py
+++ b/core/multimodal/system_audio_ingest.py
@@ -1,0 +1,279 @@
+"""core/multimodal/system_audio_ingest.py —— 系统播放声(回环)采集。
+
+采的是什么、为什么必须单独采
+----------------------------
+麦克风回答"用户说了什么"。这里回答的是另一个问题:**用户此刻在听什么** —— 视频、
+网课、游戏、会议里正在播的声音。两者语义完全不同,所以在
+``DesktopPerceptionStore`` 里也是分槽的。
+
+这条通路无法用现有的麦克风链路替代,也无法从浏览器侧拿到:
+
+- ``getUserMedia`` 只给输入设备(麦克风),拿不到系统输出。
+- ``getDisplayMedia`` 在 Chrome/Windows 上可以带 tab/系统音,但只覆盖被共享的那个
+  来源,要用户每次手动授权选窗口,且 Firefox/Safari 支持残缺 —— 做不成"常驻感知"。
+- 用麦克风"隔空听扬声器"不是替代:信号被房间噪声和音量设置污染,而且这样采回来的
+  声音会和用户自己说的话混在同一路,再也分不开(反自激励门存在的原因正是这个)。
+
+所以这件事只能在**电脑端本机**做。这是能力差异,不是性能优化 —— 换句话说,不做
+原生/本机采集就根本没有这一路数据。
+
+用 Python 做,不需要 C++ 层
+--------------------------
+Windows 上 WASAPI 支持 loopback:把一个**输出**设备当作输入流打开,采到的就是它正在
+播的声音。``sounddevice``(PortAudio)通过 ``sd.WasapiSettings(loopback=True)`` 直接
+暴露了这个能力,和现有麦克风链路用的是同一个库、同一套 ``InputStream``。
+Linux 上 PulseAudio/PipeWire 把每个输出设备的 ``.monitor`` 源直接列成普通输入设备,
+按名字挑出来即可。macOS 没有系统级回环(需 BlackHole 等虚拟声卡),故不支持。
+
+优雅降级(与 ``audio_ingest.py`` 同一约定)
+-----------------------------------------
+``sounddevice`` 缺失、平台不支持、版本太老没有 ``WasapiSettings``、找不到回环设备 ——
+全部返回结构化的"不可用 + 原因",不抛异常、不影响任何主流程。原因是**明确文字**而
+不是静默 False:这条链路一旦不通,症状是"模型不知道你在看什么",不给原因根本没法排查。
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Galaxy.SystemAudioIngest")
+
+#: Linux 上 PulseAudio/PipeWire 的回环源名字里必带的记号
+_LINUX_MONITOR_MARKERS = ("monitor of", ".monitor", "monitor")
+
+#: 不可用原因(结构化,便于路由/诊断面板直接展示)
+REASON_OK = "ok"
+REASON_NO_SOUNDDEVICE = "sounddevice_not_installed"
+REASON_UNSUPPORTED_OS = "unsupported_os"
+REASON_NO_WASAPI_SUPPORT = "sounddevice_too_old_no_wasapi_settings"
+REASON_NO_WASAPI_HOSTAPI = "no_wasapi_hostapi"
+REASON_NO_LOOPBACK_DEVICE = "no_loopback_device_found"
+REASON_QUERY_FAILED = "device_query_failed"
+
+
+@dataclass
+class LoopbackTarget:
+    """一个可用的回环采集目标。"""
+
+    device: int
+    name: str
+    channels: int
+    #: 是否需要 ``extra_settings=sd.WasapiSettings(loopback=True)``(Windows 专用)
+    needs_wasapi_loopback: bool
+    hostapi_name: str = ""
+
+    def describe(self) -> str:
+        mode = "WASAPI loopback" if self.needs_wasapi_loopback else "monitor source"
+        return f"{self.name} [index={self.device}, ch={self.channels}, {mode}]"
+
+
+# ── 设备解析:抽成纯函数,可用假设备表完整单测 ────────────────────────────────
+
+
+def _hostapi_name(hostapis: List[Dict[str, Any]], idx: Any) -> str:
+    try:
+        return str(hostapis[int(idx)].get("name", ""))
+    except (IndexError, TypeError, ValueError):
+        return ""
+
+
+def resolve_loopback_target(
+    devices: List[Dict[str, Any]],
+    hostapis: List[Dict[str, Any]],
+    *,
+    os_name: str,
+    has_wasapi_settings: bool,
+) -> Tuple[Optional[LoopbackTarget], str]:
+    """从设备表里挑出回环采集目标。返回 ``(target, reason)``。
+
+    纯函数:只吃设备表,不碰音频栈。``sounddevice`` 的 ``query_devices()`` /
+    ``query_hostapis()`` 返回的就是这两张表,所以真实行为可以用假表完整覆盖 ——
+    这一层的判断逻辑不必等到有 Windows 机器才能验证。
+    """
+    system = (os_name or "").lower()
+
+    if system == "windows":
+        if not has_wasapi_settings:
+            # PortAudio 支持,但 sounddevice 太老没有暴露 WasapiSettings
+            return None, REASON_NO_WASAPI_SUPPORT
+        wasapi_idx = [i for i, h in enumerate(hostapis) if "wasapi" in str(h.get("name", "")).lower()]
+        if not wasapi_idx:
+            return None, REASON_NO_WASAPI_HOSTAPI
+        # WASAPI loopback 要打开的是【输出】设备(max_output_channels > 0)。
+        # 优先该 hostapi 的默认输出设备 —— 那才是用户真正在听的那一个。
+        preferred: List[int] = []
+        for i in wasapi_idx:
+            default_out = hostapis[i].get("default_output_device")
+            if isinstance(default_out, int) and default_out >= 0:
+                preferred.append(default_out)
+        ordered = preferred + [
+            idx
+            for idx, dev in enumerate(devices)
+            if idx not in preferred
+            and int(dev.get("hostapi", -1)) in wasapi_idx
+            and int(dev.get("max_output_channels", 0) or 0) > 0
+        ]
+        for idx in ordered:
+            try:
+                dev = devices[idx]
+            except IndexError:
+                continue
+            if int(dev.get("hostapi", -1)) not in wasapi_idx:
+                continue
+            ch = int(dev.get("max_output_channels", 0) or 0)
+            if ch <= 0:
+                continue
+            return (
+                LoopbackTarget(
+                    device=idx,
+                    name=str(dev.get("name", f"device-{idx}")),
+                    # 回环流的通道数取输出设备的通道数(通常 2);下游会降混成单声道
+                    channels=min(2, ch),
+                    needs_wasapi_loopback=True,
+                    hostapi_name=_hostapi_name(hostapis, dev.get("hostapi")),
+                ),
+                REASON_OK,
+            )
+        return None, REASON_NO_LOOPBACK_DEVICE
+
+    if system == "linux":
+        # PulseAudio/PipeWire 把输出设备的 monitor 源列成普通输入设备
+        for idx, dev in enumerate(devices):
+            name = str(dev.get("name", ""))
+            ch = int(dev.get("max_input_channels", 0) or 0)
+            if ch <= 0:
+                continue
+            if any(mark in name.lower() for mark in _LINUX_MONITOR_MARKERS):
+                return (
+                    LoopbackTarget(
+                        device=idx,
+                        name=name,
+                        channels=min(2, ch),
+                        needs_wasapi_loopback=False,
+                        hostapi_name=_hostapi_name(hostapis, dev.get("hostapi")),
+                    ),
+                    REASON_OK,
+                )
+        return None, REASON_NO_LOOPBACK_DEVICE
+
+    # macOS 没有系统级回环(需 BlackHole 之类虚拟声卡),其它平台同样不支持。
+    return None, REASON_UNSUPPORTED_OS
+
+
+def _reason_text(reason: str) -> str:
+    """把结构化原因翻成可直接给人看的一句话(含修复动作)。"""
+    return {
+        REASON_OK: "可用",
+        REASON_NO_SOUNDDEVICE: "未安装 sounddevice —— 运行: pip install sounddevice",
+        REASON_UNSUPPORTED_OS: (
+            "当前系统没有系统级回环采集:Windows 走 WASAPI loopback、"
+            "Linux 走 PulseAudio/PipeWire 的 .monitor 源;macOS 需装 BlackHole 之类虚拟声卡"
+        ),
+        REASON_NO_WASAPI_SUPPORT: ("sounddevice 版本过旧,没有 WasapiSettings —— 运行: pip install -U sounddevice"),
+        REASON_NO_WASAPI_HOSTAPI: "PortAudio 未编出 WASAPI 后端,无法做回环采集",
+        REASON_NO_LOOPBACK_DEVICE: (
+            "找不到回环设备。Windows:确认有默认播放设备;"
+            "Linux:确认 PulseAudio/PipeWire 在跑(pactl list sources short 应能看到 .monitor)"
+        ),
+        REASON_QUERY_FAILED: "查询音频设备失败(音频栈异常)",
+    }.get(reason, reason)
+
+
+def probe() -> Dict[str, Any]:
+    """探测本机能否做系统播放声采集。永不抛出。
+
+    返回 ``{available, reason, reason_text, target, os}``。这是给
+    ``/api/perception/desktop/system_audio/probe`` 和诊断面板用的**唯一**判断入口 ——
+    调用方不要自己去猜平台。
+    """
+    os_name = platform.system()
+    try:
+        import sounddevice as sd
+    except Exception as exc:  # noqa: BLE001 — 缺包是预期情形,不是错误
+        logger.debug("sounddevice 不可用,系统播放声采集关闭: %s", exc)
+        return {
+            "available": False,
+            "reason": REASON_NO_SOUNDDEVICE,
+            "reason_text": _reason_text(REASON_NO_SOUNDDEVICE),
+            "target": None,
+            "os": os_name,
+        }
+
+    try:
+        devices = [dict(d) for d in sd.query_devices()]
+        hostapis = [dict(h) for h in sd.query_hostapis()]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("查询音频设备失败,系统播放声采集不可用: %s", exc)
+        return {
+            "available": False,
+            "reason": REASON_QUERY_FAILED,
+            "reason_text": f"{_reason_text(REASON_QUERY_FAILED)}: {exc}",
+            "target": None,
+            "os": os_name,
+        }
+
+    target, reason = resolve_loopback_target(
+        devices,
+        hostapis,
+        os_name=os_name,
+        has_wasapi_settings=hasattr(sd, "WasapiSettings"),
+    )
+    if target is None:
+        # WARNING 而非 debug:这条链路不通的症状是"模型不知道你在看什么",
+        # 在 debug 级别下用户永远查不到原因。
+        logger.warning("系统播放声采集不可用(%s):%s", reason, _reason_text(reason))
+    else:
+        logger.info("系统播放声采集目标:%s", target.describe())
+    return {
+        "available": target is not None,
+        "reason": reason,
+        "reason_text": _reason_text(reason),
+        "target": target.describe() if target else None,
+        "os": os_name,
+    }
+
+
+def open_loopback_stream(
+    target: LoopbackTarget,
+    *,
+    sample_rate: int = 16000,
+    blocksize: int = 0,
+    callback: Any = None,
+) -> Any:
+    """按目标打开回环输入流。返回未启动的 ``sd.InputStream``;失败抛原始异常。
+
+    刻意**不**吞异常:调用方(采集循环)才知道该重试、该降级还是该放弃,在这里静默
+    吞掉只会变成"流没开起来但谁也不知道"。
+    """
+    import sounddevice as sd
+
+    extra = None
+    if target.needs_wasapi_loopback:
+        extra = sd.WasapiSettings(loopback=True)
+    return sd.InputStream(
+        samplerate=sample_rate,
+        channels=target.channels,
+        dtype="float32",
+        blocksize=blocksize,
+        device=target.device,
+        callback=callback,
+        extra_settings=extra,
+    )
+
+
+def downmix_to_mono(block: Any) -> Any:
+    """把多声道回环数据降混成单声道(ASR/模型都只要单声道)。
+
+    ``block`` 形状为 ``(frames, channels)``;单声道时原样压平。
+    """
+    import numpy as np
+
+    arr = np.asarray(block)
+    if arr.ndim == 1:
+        return arr
+    if arr.shape[1] == 1:
+        return arr[:, 0]
+    return arr.mean(axis=1)

--- a/core/perception/desktop_perception_store.py
+++ b/core/perception/desktop_perception_store.py
@@ -3,15 +3,23 @@ core/perception/desktop_perception_store.py
 ============================================
 桌面端连续感知的「最新帧」存储（隐蔽上下文来源）。
 
-电脑端壳（Tauri / Electron）在【第一态】持续原生采集 **摄像头 / 屏幕 / 麦克风**，
-以 base64 帧 POST 到网关 /api/perception/desktop/*。本模块是这些帧的进程内最新值
-存储（单例），带 TTL 新鲜度判定，并把三路【一体化】合并成单个 MultiModalContext：
+电脑端壳（Tauri / Electron）在【第一态】持续原生采集 **摄像头 / 屏幕 / 麦克风 /
+系统播放声**，以 base64 帧 POST 到网关 /api/perception/desktop/*。本模块是这些帧的
+进程内最新值存储（单例），带 TTL 新鲜度判定，并把四路【一体化】合并成单个
+MultiModalContext：
 
 - 摄像头帧（source=desktop_camera）与屏幕帧（source=desktop_screen）分槽存放，互不覆盖；
   屏幕帧还可附带结构化 screen 上下文（如前台窗口 UIA 树）。
+- 麦克风（source=desktop_microphone）与系统播放声（source=desktop_system_audio）同样
+  **分槽**。这不是冗余：麦克风回答"用户说了什么"，系统声回答"用户此刻在听什么"
+  （视频、网课、游戏、会议的声音）。合成一槽会互相覆盖，而且一旦混流就再也分不出
+  "这段声音是人说的还是扬声器放的"——那正是模型最需要区分的一件事。
+  系统播放声只能在电脑端本机采集（浏览器的 getUserMedia 拿不到系统输出），
+  见 ``core/multimodal/system_audio_ingest.py``。
 - 当一次正常请求进入 OpenClawd.process() 且本身不带图像时，把【新鲜】的摄像头帧 +
-  屏幕帧 + 屏幕结构 + 音频一起作为原生多模态上下文注入——模型同时「看到摄像头、看到
-  屏幕、听到麦克风」，即第一态的连续原生多模态一体化感知。
+  屏幕帧 + 屏幕结构 + 麦克风 + 系统声一起作为原生多模态上下文注入——模型同时
+  「看到摄像头、看到屏幕、听到用户、听到用户在听的东西」，即第一态的连续原生多模态
+  一体化感知。
 - 不新鲜（超过 TTL）的项不会被注入，避免把过期画面/声音喂给模型。
 
 设计原则：轻量、线程安全（简单锁）、永不抛出影响主流程；不持久化、不落盘。
@@ -20,9 +28,10 @@ core/perception/desktop_perception_store.py
 隐私急停（privacy pause）
 ------------------------
 本类是**全部**桌面感知数据的唯一进出口，因此隐私闸门只能落在这里：写入口只有
-``update_frame`` / ``update_audio`` 两个，而读出口有五个
+``update_frame`` / ``update_audio`` / ``update_system_audio`` 三个，而读出口有六个
 （``has_fresh_frame`` / ``latest_frame_snapshot`` / ``take_fresh_audio_for_autoinject``
-/ ``snapshot_media`` / ``build_multimodal_context``），下游消费方至少四处
+/ ``take_fresh_system_audio_for_autoinject`` / ``snapshot_media``
+/ ``build_multimodal_context``），下游消费方至少四处
 （ambient_attention_loop、computer_use_loop、session_memory_facade、
 multimodal/ingest_runtime）。闸门若放在任一消费方，其余几路照旧能看到屏幕 ——
 那是**假的**隐私模式。
@@ -31,7 +40,9 @@ multimodal/ingest_runtime）。闸门若放在任一消费方，其余几路照�
 * ``pause()`` 之后**拒收**新的帧/音频（在写入口就挡掉，数据根本不进内存）；
 * 同时**立即清空**已缓存的帧、音频与屏幕结构 —— 否则消费方还能读到暂停前
   那一帧，"暂停"名不副实；
-* 五条读路径全部返回空，构成第二道防线（即便某条路径将来新增了缓存）；
+* 六条读路径全部返回空，构成第二道防线（即便某条路径将来新增了缓存）；
+* 系统播放声走**同一道**闸门，不另开旁路 —— 它比麦克风更敏感：等于把用户正在听的
+  一切内容（会议、私信语音、视频）完整送出去；
 * ``epoch`` 在每次 pause/resume 时自增。消费方（如 ambient 循环的 ``FrameGate``）
   据此丢弃自己的帧差指纹。这一条的动机是**隐私**而非性能：若保留暂停前的指纹，
   恢复后的新帧会与它做差，等于让智能体推断出"被遮住那段时间里画面变了多少"。
@@ -90,16 +101,25 @@ class DesktopPerceptionStore:
         self._scr_mime: str = "image/jpeg"
         self._scr_ts: float = 0.0
         self._screen_meta: Optional[Dict[str, Any]] = None
-        # audio (麦克风)
+        # audio (麦克风：听人说话)
         self._audio_b64: Optional[str] = None
         self._audio_mime: str = "audio/webm"
         self._audio_ts: float = 0.0
+        # system audio (系统播放声：听"用户正在听什么"——视频/游戏/网课的声音)
+        # 与麦克风【分槽】,不是冗余:两者语义完全不同。麦克风回答"用户说了什么",
+        # 系统声回答"用户此刻在听什么"。混在一槽里会互相覆盖,而且一旦混流就再也
+        # 分不出"这段声音是人说的还是扬声器放的"。
+        self._sys_audio_b64: Optional[str] = None
+        self._sys_audio_mime: str = "audio/webm"
+        self._sys_audio_ts: float = 0.0
         # counters (diagnostics)
         self._cam_received: int = 0
         self._scr_received: int = 0
         self._audio_received: int = 0
+        self._sys_audio_received: int = 0
         # 自动注入去重：已被对话自动注入消费过的音频时间戳，避免同一片段反复转写
         self._audio_autoinject_consumed_ts: float = 0.0
+        self._sys_audio_autoinject_consumed_ts: float = 0.0
         # ── 隐私急停 ──
         self._paused: bool = _privacy_default_paused()
         self._paused_at: float = time.time() if self._paused else 0.0
@@ -109,6 +129,7 @@ class DesktopPerceptionStore:
         #: 暂停期间被拒收的写入次数(诊断用:证明闸门真的在挡)
         self._rejected_frames: int = 0
         self._rejected_audio: int = 0
+        self._rejected_system_audio: int = 0
         if self._paused:
             logger.warning("桌面感知处于隐私暂停(GALAXY_PERCEPTION_PRIVACY_DEFAULT):启动即不采集")
 
@@ -126,6 +147,8 @@ class DesktopPerceptionStore:
         self._screen_meta = None
         self._audio_b64 = None
         self._audio_ts = 0.0
+        self._sys_audio_b64 = None
+        self._sys_audio_ts = 0.0
 
     def pause(self, reason: str = "user") -> Dict[str, Any]:
         """立即切断感知:拒收后续帧/音频,并清空已缓存内容。幂等。"""
@@ -176,6 +199,7 @@ class DesktopPerceptionStore:
             "epoch": self._epoch,
             "rejected_frames": self._rejected_frames,
             "rejected_audio": self._rejected_audio,
+            "rejected_system_audio": self._rejected_system_audio,
         }
 
     def privacy_status(self) -> Dict[str, Any]:
@@ -249,6 +273,24 @@ class DesktopPerceptionStore:
             self._audio_ts = time.time()
             self._audio_received += 1
 
+    def update_system_audio(self, audio_b64: str, *, mime: str = "audio/webm") -> None:
+        """存最新一段【系统播放声】(扬声器输出的回环采集)。
+
+        隐私暂停期间拒收 —— 系统声比麦克风更敏感:它等于把用户正在听的一切内容
+        (会议、私信语音、视频)完整送出去,所以必须走同一道闸门,而不是另开一条
+        绕过隐私急停的旁路。判定与写入同一次持锁(理由见 ``update_frame``)。
+        """
+        with self._lock:
+            if self._paused:
+                self._rejected_system_audio += 1
+                return
+            if not audio_b64:
+                return
+            self._sys_audio_b64 = audio_b64
+            self._sys_audio_mime = mime or "audio/webm"
+            self._sys_audio_ts = time.time()
+            self._sys_audio_received += 1
+
     # ── 读取 / 新鲜度 ───────────────────────────────────────────────────────
 
     def _fresh(self, ts: float) -> bool:
@@ -292,6 +334,26 @@ class DesktopPerceptionStore:
                 return self._audio_b64, self._audio_mime
         return None, None
 
+    def take_fresh_system_audio_for_autoinject(self):
+        """取一段「新鲜且未被自动注入消费过」的**系统播放声**。
+
+        与麦克风那条各自独立去重:两路的到达节奏不同,共用一个消费水位会让先到的
+        那路把后到的那路一起标记为"已消费",另一路从此永远取不到东西。
+
+        返回 ``(audio_b64, mime)``;隐私暂停或无可用音频则返回 ``(None, None)``。
+        """
+        with self._lock:
+            if self._paused:
+                return None, None
+            if (
+                self._sys_audio_b64
+                and self._fresh(self._sys_audio_ts)
+                and self._sys_audio_ts > self._sys_audio_autoinject_consumed_ts
+            ):
+                self._sys_audio_autoinject_consumed_ts = self._sys_audio_ts
+                return self._sys_audio_b64, self._sys_audio_mime
+        return None, None
+
     def snapshot_media(self) -> Dict[str, Any]:
         """返回当前最新【摄像头/屏幕/音频】快照（仅新鲜项有值），供统一记忆层等消费。
 
@@ -309,11 +371,14 @@ class DesktopPerceptionStore:
                     "screen_meta": None,
                     "audio_b64": None,
                     "audio_mime": self._audio_mime,
+                    "system_audio_b64": None,
+                    "system_audio_mime": self._sys_audio_mime,
                     "privacy_paused": True,
                 }
             cam_fresh = bool(self._cam_b64) and self._fresh(self._cam_ts)
             scr_fresh = bool(self._scr_b64) and self._fresh(self._scr_ts)
             aud_fresh = bool(self._audio_b64) and self._fresh(self._audio_ts)
+            sys_fresh = bool(self._sys_audio_b64) and self._fresh(self._sys_audio_ts)
             return {
                 # 兼容旧字段名（image_* 指摄像头帧）+ 新增 screen_* 字段
                 "image_b64": self._cam_b64 if cam_fresh else None,
@@ -325,6 +390,8 @@ class DesktopPerceptionStore:
                 "screen_meta": self._screen_meta if scr_fresh else None,
                 "audio_b64": self._audio_b64 if aud_fresh else None,
                 "audio_mime": self._audio_mime,
+                "system_audio_b64": self._sys_audio_b64 if sys_fresh else None,
+                "system_audio_mime": self._sys_audio_mime,
             }
 
     def status(self) -> Dict[str, Any]:
@@ -335,6 +402,7 @@ class DesktopPerceptionStore:
                 "camera_received": self._cam_received,
                 "screen_received": self._scr_received,
                 "audio_received": self._audio_received,
+                "system_audio_received": self._sys_audio_received,
                 "camera_fresh": self._fresh(self._cam_ts),
                 "camera_age_sec": round(now - self._cam_ts, 2) if self._cam_ts else None,
                 "screen_fresh": self._fresh(self._scr_ts),
@@ -342,6 +410,8 @@ class DesktopPerceptionStore:
                 "screen_meta_present": self._screen_meta is not None,
                 "audio_fresh": self._fresh(self._audio_ts),
                 "audio_age_sec": round(now - self._audio_ts, 2) if self._audio_ts else None,
+                "system_audio_fresh": self._fresh(self._sys_audio_ts),
+                "system_audio_age_sec": (round(now - self._sys_audio_ts, 2) if self._sys_audio_ts else None),
                 "privacy": self._privacy_status_unlocked(),
             }
 
@@ -370,13 +440,15 @@ class DesktopPerceptionStore:
             cam_fresh = bool(self._cam_b64) and self._fresh(self._cam_ts)
             scr_fresh = bool(self._scr_b64) and self._fresh(self._scr_ts)
             aud_fresh = bool(self._audio_b64) and self._fresh(self._audio_ts)
+            sys_fresh = bool(self._sys_audio_b64) and self._fresh(self._sys_audio_ts)
             meta_fresh = self._screen_meta is not None and self._fresh(self._scr_ts)
-            if not (cam_fresh or scr_fresh or aud_fresh or meta_fresh):
+            if not (cam_fresh or scr_fresh or aud_fresh or sys_fresh or meta_fresh):
                 return None
             cam = (self._cam_b64, self._cam_mime) if cam_fresh else (None, None)
             scr = (self._scr_b64, self._scr_mime) if scr_fresh else (None, None)
             screen_meta = self._screen_meta if meta_fresh else None
             aud = (self._audio_b64, self._audio_mime) if aud_fresh else (None, None)
+            sysaud = (self._sys_audio_b64, self._sys_audio_mime) if sys_fresh else (None, None)
 
         # 若调用方已带图像，尊重之，不注入（避免覆盖显式上传）
         existing_images = list(getattr(existing, "images", []) or []) if existing is not None else []
@@ -392,12 +464,29 @@ class DesktopPerceptionStore:
         audio = []
         if aud[0]:
             audio.append(MultiModalAudio(mime=aud[1] or "audio/webm", data=aud[0], source="desktop_microphone"))
+        if sysaud[0]:
+            # source 必须与麦克风那条区分开:模型要能判断"这段是人在说话"还是
+            # "这段是屏幕里在放的声音",两者混成同一个 source 就无从分辨了。
+            audio.append(
+                MultiModalAudio(
+                    mime=sysaud[1] or "audio/webm",
+                    data=sysaud[0],
+                    source="desktop_system_audio",
+                )
+            )
 
         metadata = {
             "injected_by": "desktop_perception_store",
             "ambient": True,
             "modalities": [
-                m for m, on in (("camera", bool(cam[0])), ("screen", bool(scr[0])), ("audio", bool(aud[0]))) if on
+                m
+                for m, on in (
+                    ("camera", bool(cam[0])),
+                    ("screen", bool(scr[0])),
+                    ("audio", bool(aud[0])),
+                    ("system_audio", bool(sysaud[0])),
+                )
+                if on
             ],
         }
         screen = screen_meta

--- a/core/policy/hitl_policy.py
+++ b/core/policy/hitl_policy.py
@@ -356,10 +356,22 @@ class HITLPolicy:
             reason:      Human-readable rationale.
 
         Returns:
-            The :class:`HITLDecision`, or ``None`` if request not found.
+            The :class:`HITLDecision`, or ``None`` if request not found — including
+            when another caller已经把它裁决掉了(见下面的并发说明)。
+
+        并发
+        ----
+        ``pop`` 在**同一次持锁**内完成"查到 + 摘走",两件事不能分开做。此前是先
+        ``get``、释放锁、走完整段裁决、再取锁 ``pop``:两个线程可以都拿到同一个非
+        None 的 ``req``,于是同一条审批被裁决两次 —— history 里落两条记录、事件发两
+        次,而 ``req.decision`` 取决于哪个线程最后写,不确定。若两次裁决方向相反
+        (面板点了通过、接口同时调了拒绝,或者用户双击),最终结果就是随机的。
+
+        改成 ``pop`` 之后,摘到 ``req`` 即等于**独占地领走**了这条审批;第二个线程
+        拿到 None,如实返回"没有这条待审批",不会重复记账。
         """
         with self._lock:
-            req = self._pending.get(request_id)
+            req = self._pending.pop(request_id, None)
 
         if req is None:
             logger.warning("HITLPolicy.decide: unknown request_id=%s", request_id)
@@ -377,7 +389,7 @@ class HITLPolicy:
         req.decision = decision
 
         with self._lock:
-            self._pending.pop(request_id, None)
+            # 这条已在上面 pop 时领走,此处只需记账
             self._history.append(decision)
             if len(self._history) > 500:
                 self._history = self._history[-500:]

--- a/core/routes/perception.py
+++ b/core/routes/perception.py
@@ -58,6 +58,18 @@ class DesktopListen(BaseModel):
     prompt: str = ""
 
 
+def _internal_error(where: str, exc: Exception) -> Dict[str, Any]:
+    """内部错误的统一回法:细节只进服务端日志,不回给调用方。
+
+    直接把 ``str(exc)`` 回出去会泄露文件路径、模块名等实现细节(CodeQL 的
+    "Information exposure through an exception")。这里回一个稳定的 ``error_code``
+    让客户端能分支处理,真正的堆栈用 ``exc_info=True`` 留在日志里 —— 排查能力不打折,
+    但不经由 HTTP 响应外泄。
+    """
+    logger.error("桌面感知接口内部错误 [%s]: %s", where, exc, exc_info=True)
+    return {"success": False, "error": "内部错误,请查看服务端日志", "error_code": where}
+
+
 def create_router(service_manager=None, config=None) -> APIRouter:
     """Create desktop perception ingest routes."""
     router = APIRouter(prefix="/api/perception/desktop", tags=["perception"])
@@ -132,8 +144,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
             store.update_system_audio(audio.audio_base64, mime=audio.mime)
             return {"success": True, "stored": "system_audio"}
         except Exception as exc:  # noqa: BLE001
-            logger.debug("system audio ingest failed: %s", exc)
-            return {"success": False, "error": str(exc)}
+            return _internal_error("system_audio_ingest", exc)
 
     @router.get("/system_audio/probe")
     async def probe_system_audio():
@@ -147,8 +158,7 @@ def create_router(service_manager=None, config=None) -> APIRouter:
 
             return {"success": True, **probe()}
         except Exception as exc:  # noqa: BLE001
-            logger.warning("系统播放声采集探测失败: %s", exc)
-            return {"success": False, "available": False, "error": str(exc)}
+            return {**_internal_error("system_audio_probe", exc), "available": False}
 
     @router.get("/status")
     async def perception_status():

--- a/core/routes/perception.py
+++ b/core/routes/perception.py
@@ -1,13 +1,20 @@
 """
 core/routes/perception.py
 =========================
-桌面端连续感知接收路由（摄像头 / 麦克风 / 屏幕）。
+桌面端连续感知接收路由（摄像头 / 麦克风 / 屏幕 / 系统播放声）。
 
 电脑端 Electron 壳用 getUserMedia 采集帧后 POST 到这里：
 - POST /api/perception/desktop/frame    —— 存最新摄像头/屏幕帧（隐蔽上下文）
 - POST /api/perception/desktop/audio    —— 存最新麦克风音频片段
+- POST /api/perception/desktop/system_audio      —— 存最新系统播放声片段
+- GET  /api/perception/desktop/system_audio/probe —— 本机能否回环采集 + 不能的原因
 - POST /api/perception/desktop/analyze  —— 「现在看一下」：把帧原生送模型分析
 - GET  /api/perception/desktop/status   —— 存储/新鲜度诊断
+
+系统播放声这一路**只能在电脑端本机采集**：getUserMedia 只给输入设备，拿不到系统
+输出；getDisplayMedia 要每次手动选窗口、跨浏览器支持残缺，做不成常驻感知。所以它
+走 WASAPI loopback（Windows）/ PulseAudio .monitor（Linux），见
+``core/multimodal/system_audio_ingest.py``。这是能力差异，不是性能优化。
 
 frame/audio 只更新进程内 DesktopPerceptionStore，由 OpenClawd.process() 在下一次
 真实请求时按 TTL 取用、作为原生多模态上下文注入（模型真正「看到」摄像头）。
@@ -102,6 +109,46 @@ def create_router(service_manager=None, config=None) -> APIRouter:
         except Exception as exc:  # noqa: BLE001
             logger.debug("audio ingest failed: %s", exc)
             return {"success": False, "error": str(exc)}
+
+    @router.post("/system_audio")
+    async def ingest_system_audio(audio: DesktopAudio):
+        """接收最新【系统播放声】片段(扬声器输出的回环采集)→ 存入独立槽位。
+
+        与 /audio 分开是因为语义不同:麦克风是"用户说了什么",系统声是"用户此刻在
+        听什么"。混进同一槽会互相覆盖,而且模型再也分不出这段声音是人说的还是屏幕
+        里放的 —— 那恰恰是它最需要区分的一件事。
+        """
+        try:
+            from core.perception.desktop_perception_store import get_desktop_perception_store
+
+            store = get_desktop_perception_store()
+            if store.paused:  # 同 /frame:拒收要如实上报,不能假装存了
+                return {
+                    "success": False,
+                    "stored": None,
+                    "privacy_paused": True,
+                    "reason": "感知已被隐私暂停,本段系统播放声未被接收",
+                }
+            store.update_system_audio(audio.audio_base64, mime=audio.mime)
+            return {"success": True, "stored": "system_audio"}
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("system audio ingest failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    @router.get("/system_audio/probe")
+    async def probe_system_audio():
+        """本机能否做系统播放声采集,以及不能的话**为什么**。
+
+        采集端(电脑端壳)先问这里再决定是否启动回环采集线程;不可用时 reason_text
+        是一句可直接展示给用户的修复指引,而不是静默的 false。
+        """
+        try:
+            from core.multimodal.system_audio_ingest import probe
+
+            return {"success": True, **probe()}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("系统播放声采集探测失败: %s", exc)
+            return {"success": False, "available": False, "error": str(exc)}
 
     @router.get("/status")
     async def perception_status():

--- a/core/routes/perception.py
+++ b/core/routes/perception.py
@@ -160,6 +160,37 @@ def create_router(service_manager=None, config=None) -> APIRouter:
         except Exception as exc:  # noqa: BLE001
             return {**_internal_error("system_audio_probe", exc), "available": False}
 
+    @router.get("/audio/echo_cancellation")
+    async def echo_cancellation_status():
+        """回声消除与回环采集的实时状态。
+
+        这条接口存在的理由是**可观测性**:AEC 在没有参考信号时会静默走旁通 ——
+        不报错、不打日志、回声照旧。光看现象根本分不清"AEC 没装上"、"回环采集没起来"、
+        还是"装上了但还没收敛"。这里把三者分开摊出来:
+
+        - ``capture.running`` / ``capture.unavailable_reason`` —— 参考信号有没有源头;
+        - ``aec.blocks_bypassed`` + ``last_bypass_reason`` —— 有没有在旁通,为什么;
+        - ``aec.erle_db`` —— 真实抑制了多少 dB。这是唯一的硬指标,>6dB 才算在起作用。
+        """
+        out: Dict[str, Any] = {"success": True}
+        try:
+            from core.multimodal.acoustic_echo_canceller import get_echo_canceller
+
+            out["aec"] = get_echo_canceller().snapshot()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("读取 AEC 状态失败: %s", exc)
+            out["aec"] = {"available": False}
+        try:
+            from core.multimodal.system_audio_capture_service import (
+                get_system_audio_capture,
+            )
+
+            out["capture"] = get_system_audio_capture().status()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("读取回环采集状态失败: %s", exc)
+            out["capture"] = {"running": False}
+        return out
+
     @router.get("/status")
     async def perception_status():
         """返回桌面感知存储的新鲜度/计数诊断。"""

--- a/core/speech_output.py
+++ b/core/speech_output.py
@@ -469,6 +469,17 @@ def speak_response(text: str, *, source: str = "") -> None:
 
     spoken = text[: _max_chars()]
 
+    # 反自激励:登记"这段话即将从扬声器出去"。麦克风必然把它采回来、被 VAD 判成
+    # "有人说话"、被 Whisper 转写成文字送进语音闭环;登记在此处(而不是某条具体
+    # 发声路径里)是因为下面三条路——原生发声 / 整段批处理 / 分句流式——都从这里
+    # 分叉,登记一次就三条全覆盖。判定见 core.voice_echo_guard。
+    try:
+        from core.voice_echo_guard import note_utterance as _note_utterance
+
+        _note_utterance(spoken)
+    except Exception as _exc:  # noqa: BLE001 — 登记失败最多漏挡一句回声,不能影响朗读
+        logger.debug("反自激励登记跳过(非致命): %s", _exc)
+
     # 说的通路按【当前档位】自适配:B 档(说=原生)且原生后端已注册 → 原生发声,跳过
     # TTS;A 档 / 原生后端未就绪 → 落到下面的 TTS 引擎链。原生后端未注册时(当前默认)
     # 本调用恒 False,与既有行为完全一致。

--- a/core/streaming_speech.py
+++ b/core/streaming_speech.py
@@ -33,6 +33,17 @@ _SENTENCE_END = "。！？；…!?;\n"
 _MIN_CHUNK_CHARS = 6  # 太短的碎片（如单独一个"好。"）并入邻句，避免频繁启停播放器
 
 
+def _note_spoken(text: str) -> None:
+    """把"这句已经变成声音"登记到反自激励门。懒导入 + 全吞异常:本模块是纯播放层,
+    不能因为门不可用就影响朗读。"""
+    try:
+        from core.voice_echo_guard import note_utterance
+
+        note_utterance(text)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("反自激励登记跳过(非致命): %s", exc)
+
+
 def split_into_speakable_chunks(text: str, *, min_chars: int = _MIN_CHUNK_CHARS) -> List[str]:
     """把一段文字切成"可朗读的句子块"。
 
@@ -429,6 +440,10 @@ class IncrementalSpeaker:
                     continue
                 if not self._speaking:
                     self._mark_speaking(True)
+                # 反自激励:这句【此刻】开始变成声音,登记它。边生成边念这条路不经
+                # speak_response(文本是逐 token 喂进来的),故必须在这里单独登记,
+                # 否则 /chat/stream 的朗读会被麦克风采回、转写成"用户输入"喂回大脑。
+                _note_spoken(text)
                 # 恰在这句开始播放的此刻回调其文本(锁步:文字与语音同刻上屏)。
                 if self._on_sentence_start is not None:
                     try:

--- a/core/voice_dialog_policy.py
+++ b/core/voice_dialog_policy.py
@@ -316,12 +316,22 @@ class DialogPolicy:
         注意本方法**只回答分类**,不关心 AI 此刻是否真在朗读。调用方要先确认在朗读
         中再问 —— AI 没在说话时,"嗯"是一个(弱)用户回合,不是应答。
         """
+        # hold / stop 类模式要拿【原始小写文本】去比对,不能用归一化后的文本:
+        # _HOLD_PATTERNS 里有 6 个含空格的多词模式("hold on"/"let me think"/"be quiet"…),
+        # 而归一化会把空格去掉,那些模式于是永远匹配不到 —— 一个恒为假的 any()。
+        # 目前它还不构成行为缺陷(那些句子都会因"含实义内容"落到 interrupt),但只要将来
+        # 加进一个短的、恰好全由应答词组成的多词 hold 口令,这道闸门就会静默失效。
+        raw = (text or "").strip().lower()
+        if any(p in raw for p in _HOLD_PATTERNS) or any(p in raw for p in _STOP_WORDS):
+            return BARGE_IN_INTERRUPT
+
         t = normalize_for_backchannel(text)
         if not t:
             return BARGE_IN_INTERRUPT
         if len(t) > _MAX_BACKCHANNEL_CHARS:
             return BARGE_IN_INTERRUPT
-        if any(p in t for p in _HOLD_PATTERNS) or any(p in t for p in _STOP_WORDS):
+        # 归一化后的文本也过一遍 stop 词:ASR 可能把"别 说 了"断开,去空格后才连成词
+        if any(p in t for p in _STOP_WORDS):
             return BARGE_IN_INTERRUPT
         rest = t
         for token in _BACKCHANNEL_TOKENS:

--- a/core/voice_dialog_policy.py
+++ b/core/voice_dialog_policy.py
@@ -16,10 +16,22 @@
    ("我去查,稍等")并把重活丢后台,结果回来再说——对话不被推理堵死。
 5. **捧哏节奏**:后台任务跑着时,按节奏给一两声短填充("嗯,我在看"),
    不让对话死寂;有 hold 时不出声。
+6. **barge-in 分类**(``classify_barge_in``):朗读期间用户出声,分"应答"与"真打断"。
+   人在听别人说话时会一直出声("嗯""对""好""哦")—— 那是积极倾听,不是抢话。原先
+   "一出词就掐断"的行为让 AI 每讲两句就被"嗯"一声打断,对话进行不下去。
 
-纯逻辑、零重依赖、全部可单测。诚实边界:真·全双工(同一时刻边说边听)需要
-回声消除+双工模型,本政策做的是"委托+语义回合+填充"三件套——编排层能拿到的
-全双工体感,不假装是模型级全双工。
+诚实边界(逐条,不含糊)
+------------------------
+* **回声消除已经有了。** ``core/multimodal/acoustic_echo_canceller.py`` 在信号层做
+  AEC(实测合成路径 27 dB ERLE),参考信号来自系统播放声回环采集。所以"同一时刻边说
+  边听"的**听**这一半现在是通的:麦克风可以在朗读期间一直开着,而且能分清谁在说。
+* **说的那一半仍是半双工。** 用户真打断时 AI 的反应是**停下来**,不是边说边接话。
+  再往前需要双工模型通路(持续上行 + 持续下行的连接),那不是政策层的事。
+* **"压低音量继续说"(ducking)做不了。** 现有播放层没有运行期音量控制:edge-tts 的
+  ``volume`` 是**合成时**参数(烤进生成的音频里),``_play_audio(path)`` 只是播一个
+  文件,``engine.stop()` 只能整段掐断。要做 ducking 得先把播放层换成能在播放中调音量
+  的实现 —— 那是另一件事,这里不假装支持,``classify_barge_in`` 只返回"应答/打断"两
+  种,不返回一个没人能兑现的 duck。
 """
 
 from __future__ import annotations
@@ -179,8 +191,80 @@ _RESUME_PATTERNS = (
 _DEFAULT_HOLD_S = 90.0
 
 
+# ── barge-in 分类 ─────────────────────────────────────────────────────────────
+#: 用户在 AI 朗读期间出声的两种性质
+BARGE_IN_BACKCHANNEL = "backchannel"  # 应答/积极倾听 —— 不该打断
+BARGE_IN_INTERRUPT = "interrupt"  # 真的要抢话 —— 立刻掐断
+
+#: 纯应答词。必须是**语义空**的:含任何实义内容都不算应答。
+#: 刻意不含"继续"—— 它是 hold 的恢复口令,归 check_resume_command 管。
+#:
+#: 顺序**无关**:下面会按长度降序排一次再用。剥离时短词先匹配会咬掉长词的前缀 ——
+#: 例如先剥 "ok" 会把 "okay" 变成 "ay",于是 "okay" 被误判成打断(实测踩到)。
+#: 靠手工把长词写在前面太脆,新增一个词就可能悄悄破功,故程序化排序。
+_BACKCHANNEL_TOKENS_RAW = (
+    "嗯嗯",
+    "嗯",
+    "呃",
+    "哦",
+    "噢",
+    "喔",
+    "唔",
+    "啊",
+    "对对",
+    "对",
+    "是的",
+    "是",
+    "好的",
+    "好",
+    "行",
+    "可以",
+    "没错",
+    "明白",
+    "懂了",
+    "知道了",
+    "了解",
+    "ok",
+    "okay",
+    "yeah",
+    "yep",
+    "yes",
+    "uhhuh",
+    "mhm",
+    "right",
+    "sure",
+    "gotit",
+    "isee",
+)
+
+#: 按长度降序:剥离时长词先匹配,避免短词咬掉长词的前缀。
+_BACKCHANNEL_TOKENS = tuple(sorted(_BACKCHANNEL_TOKENS_RAW, key=len, reverse=True))
+
+#: 永远算打断的词(与 _HOLD_PATTERNS 一起用)
+_STOP_WORDS = ("停", "别念", "别说", "闭嘴", "打住", "stop", "shutup", "waitwait")
+
+#: 超过这个长度就不可能是纯应答了
+_MAX_BACKCHANNEL_CHARS = 6
+
+_BACKCHANNEL_STRIP = re.compile(r"[\s,。、;:!?…—~·\"'“”‘’()()《》【】\[\]{}<>/\\|+*=&%$#@^_`,.;:!?~-]+")
+
+
+def normalize_for_backchannel(text: str) -> str:
+    """归一化:去标点空白、英文转小写。ASR 的标点极不稳定,不能参与判断。"""
+    return _BACKCHANNEL_STRIP.sub("", (text or "")).lower()
+
+
+def backchannel_tolerance_enabled() -> bool:
+    """是否启用"应答不打断"(默认开启)。
+
+    默认开启是因为反面明显更糟:用户说一声"嗯"就把 AI 的话掐断,是个谁都能立刻察觉的
+    毛病。设 ``GALAXY_VOICE_BACKCHANNEL_TOLERANCE=0`` 可退回"一出词就打断"的旧行为。
+    """
+    return _flag("GALAXY_VOICE_BACKCHANNEL_TOLERANCE", "1")
+
+
 class DialogPolicy:
-    """会话级政策状态(hold 窗口 + 捧哏/致谢轮换)。"""
+    """会话级政策状态(hold 窗口 + 捧哏/致谢轮换 + barge-in 分类)。"""
 
     def __init__(self) -> None:
         self._hold_until: float = 0.0
@@ -210,6 +294,39 @@ class DialogPolicy:
 
     def is_holding(self) -> bool:
         return time.monotonic() < self._hold_until
+
+    # barge-in 语义 ----------------------------------------------------------
+
+    def classify_barge_in(self, text: str) -> str:
+        """AI 正在朗读时用户出声了 —— 这是"打断"还是"应答"?返回
+        ``BARGE_IN_BACKCHANNEL`` 或 ``BARGE_IN_INTERRUPT``。
+
+        为什么需要分开
+        --------------
+        原先的 barge-in 是"ASR 一出词就掐断朗读"。但人在听别人说话时会一直出声
+        ——"嗯""对""好""哦" —— 那是**积极倾听**,不是要抢话。把这些当打断,结果是
+        AI 每讲两句就被"嗯"一声打断,对话根本进行不下去。这是"边说边听"体验里最刺眼
+        的一处,也是纯政策层就能修的一处。
+
+        判据(刻意保守,宁可判成打断也不要吃掉用户真的要说的话):
+        - 归一化后必须**完全由**应答词构成 —— 含任何实义内容即判打断;
+        - 且长度不超过 ``_MAX_BACKCHANNEL_CHARS``;
+        - 且不含任何停止/hold 类词("停""别说了")—— 那些永远是打断。
+
+        注意本方法**只回答分类**,不关心 AI 此刻是否真在朗读。调用方要先确认在朗读
+        中再问 —— AI 没在说话时,"嗯"是一个(弱)用户回合,不是应答。
+        """
+        t = normalize_for_backchannel(text)
+        if not t:
+            return BARGE_IN_INTERRUPT
+        if len(t) > _MAX_BACKCHANNEL_CHARS:
+            return BARGE_IN_INTERRUPT
+        if any(p in t for p in _HOLD_PATTERNS) or any(p in t for p in _STOP_WORDS):
+            return BARGE_IN_INTERRUPT
+        rest = t
+        for token in _BACKCHANNEL_TOKENS:
+            rest = rest.replace(token, "")
+        return BARGE_IN_BACKCHANNEL if not rest.strip() else BARGE_IN_INTERRUPT
 
     # 委托分类 ----------------------------------------------------------------
     # heavy = 需要搜索/工具/多步执行的任务型回合;quick = 闲聊/短问答。

--- a/core/voice_duplex_session.py
+++ b/core/voice_duplex_session.py
@@ -450,6 +450,23 @@ class DuplexSession:
                 logger.warning("双工下行读循环异常结束: %s", exc)
         finally:
             self._connected = False
+            if not self._closing:
+                # 服务端**正常**关闭连接时,上面的 async for 会安静地结束、不抛异常。
+                # 若这里什么都不做,后果是完全静默的:上行的 send_audio 从此每次返回
+                # False(没人看返回值),用户的声音再也传不上去;而下行消费方还在
+                # await 一个永远不会再有事件的队列上,任务就此挂死。症状是"助手突然
+                # 不理人了",日志里一点线索都没有。
+                #
+                # 所以:升 WARNING,并**补发** SESSION_CLOSED —— 消费方靠它退出循环。
+                self.last_error = self.last_error or "server_closed_connection"
+                logger.warning(
+                    "双工会话已断开(服务端关闭连接),语音上行已失效。"
+                    "已发出 SESSION_CLOSED;调用方应重建会话或退回回合制。"
+                )
+                try:
+                    await self._emit(DuplexEvent(DuplexEventType.SESSION_CLOSED))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("补发 SESSION_CLOSED 失败(忽略): %s", exc)
 
     @staticmethod
     def _note_spoken(text: str) -> None:

--- a/core/voice_duplex_session.py
+++ b/core/voice_duplex_session.py
@@ -1,0 +1,610 @@
+"""core/voice_duplex_session.py —— 双工语音会话(持续上行 + 持续下行)。
+
+这一层解决什么
+--------------
+现有语音链路是**回合制**的:麦克风攒够一段 → Whisper 整段转写 → 大脑生成整段回复 →
+TTS 整段合成播放。每一步都要等上一步结束,所以"同一时刻边说边听"在架构上就不可能 ——
+不是调参问题,是拓扑问题。
+
+双工会话把这条链路换成**一条持续开着的连接**:音频不断往上走,音频/文字不断往下来,
+两个方向互不阻塞。用户说到一半模型就能开始应答,模型说到一半用户插话也能立刻被听见。
+
+三层的分工(与已落地的两层是叠加关系,不是替代)
+------------------------------------------------
+* ``acoustic_echo_canceller`` —— 信号层:把扬声器的声音从麦克风里减掉。**双工比回合制
+  更需要它**:回合制下 AI 说话时麦克风的内容最终会被丢掉,双工下那些字节会实时上行进
+  模型,不做 AEC 等于让模型一直听见自己在说话。
+* ``voice_echo_guard`` —— 文本层:兜住 AEC 消不掉的非线性残余回声。
+* 本模块 —— 传输/编排层:让"同时"这件事在拓扑上成为可能。
+
+诚实边界
+--------
+* **默认关闭**(``GALAXY_VOICE_DUPLEX=0``)。它需要一个支持 realtime 的 provider 与
+  对应的 key;默认打开会让所有没配 key 的部署直接失去语音功能。这是刻意的保守默认,
+  不是"没接上"—— 接线在 ``VoiceLoop.start()`` 里,开关一开就走这条路(见
+  ``tests/test_voice_duplex_session.py::TestVoiceLoopWiring``)。
+* **真实 provider 连接在本仓库的测试环境里无法验证**(没有 key、没有出网)。可验证的是
+  协议编解码(抽成纯函数)、会话状态机、以及跑在**本地真 WebSocket 服务端**上的完整
+  会话流程 —— 那不是 mock,是真的建连、真的收发帧。
+* 只实现了 OpenAI Realtime 的帧格式适配器。Gemini Live 的 ``bidiGenerateContent`` 帧形状
+  不同,留了 ``ProtocolAdapter`` 接口但**没有**实现 —— 没实现就不假装支持。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Galaxy.VoiceDuplex")
+
+_BACKGROUND_TASKS: set = set()
+
+#: 下行事件队列上限。满了丢**最旧**的:双工场景里过期的音频块没有价值,
+#: 而阻塞上行会直接毁掉实时性。
+_EVENT_QUEUE_MAX = 256
+
+
+def _flag(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default).strip().lower() not in ("0", "false", "no", "off")
+
+
+def duplex_enabled() -> bool:
+    """双工语音是否启用。**默认关闭** —— 它需要 realtime provider 与 key。"""
+    return _flag("GALAXY_VOICE_DUPLEX", "0")
+
+
+class DuplexEventType(str, Enum):
+    """下行事件类型(provider 无关)。"""
+
+    SESSION_OPEN = "session_open"
+    USER_SPEECH_STARTED = "user_speech_started"  # 服务端 VAD 判定用户开口
+    USER_SPEECH_STOPPED = "user_speech_stopped"
+    PARTIAL_TRANSCRIPT = "partial_transcript"
+    FINAL_TRANSCRIPT = "final_transcript"
+    ASSISTANT_TEXT_DELTA = "assistant_text_delta"
+    ASSISTANT_AUDIO_DELTA = "assistant_audio_delta"
+    RESPONSE_DONE = "response_done"
+    ERROR = "error"
+    SESSION_CLOSED = "session_closed"
+
+
+@dataclass
+class DuplexEvent:
+    """一条下行事件。``raw`` 保留原始帧,便于排查 provider 侧的意外字段。"""
+
+    type: DuplexEventType
+    text: str = ""
+    audio_b64: str = ""
+    error: str = ""
+    ts: float = field(default_factory=time.time)
+    raw: Optional[Dict[str, Any]] = field(default=None, repr=False)
+
+
+@dataclass
+class DuplexSessionConfig:
+    """双工会话参数。
+
+    ``api_key`` 刻意**不**带默认值也不从这里读环境变量 —— 由 ``from_env`` 统一负责,
+    避免出现"某处忘了传 key 就静默用了空字符串去建连"。
+    """
+
+    url: str
+    api_key: str
+    model: str = "gpt-4o-realtime-preview"
+    voice: str = "alloy"
+    sample_rate: int = 16000
+    instructions: str = ""
+    #: 服务端 VAD 的静音判定阈值(毫秒)。双工下回合边界由服务端判,不再靠本地攒够时长。
+    silence_ms: int = 500
+
+    @classmethod
+    def from_env(cls) -> Optional["DuplexSessionConfig"]:
+        """从环境变量构造;缺 key 或缺 url 时返回 None 并**说明缺什么**。
+
+        返回 None 而不是抛异常:双工默认关闭,缺配置是预期情形而非错误。但原因要能
+        从日志里看到 —— 否则"开了开关却没生效"完全无从排查。
+        """
+        key = (os.getenv("GALAXY_REALTIME_API_KEY") or os.getenv("OPENAI_API_KEY") or "").strip()
+        url = (os.getenv("GALAXY_REALTIME_URL") or "").strip()
+        model = (os.getenv("GALAXY_REALTIME_MODEL") or "gpt-4o-realtime-preview").strip()
+        if not url:
+            url = f"wss://api.openai.com/v1/realtime?model={model}"
+        if not key:
+            logger.warning(
+                "双工语音已开启但缺少 API key(GALAXY_REALTIME_API_KEY 或 OPENAI_API_KEY)," "本次退回回合制语音链路。"
+            )
+            return None
+        return cls(url=url, api_key=key, model=model)
+
+
+# ── 协议适配:全部是纯函数,不碰网络,可完整单测 ────────────────────────────
+
+
+class ProtocolAdapter:
+    """provider 帧格式适配器。
+
+    只有 OpenAI Realtime 一个实现。Gemini Live 的 ``bidiGenerateContent`` 帧形状不同,
+    接口留在这里,但**没有实现** —— 没实现就不假装支持。
+    """
+
+    name = "abstract"
+
+    def session_update(self, cfg: DuplexSessionConfig) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def audio_frame(self, pcm16: bytes) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def text_frame(self, text: str) -> List[Dict[str, Any]]:
+        raise NotImplementedError
+
+    def interrupt_frame(self) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def decode(self, msg: Dict[str, Any]) -> Optional[DuplexEvent]:
+        raise NotImplementedError
+
+    def headers(self, cfg: DuplexSessionConfig) -> Dict[str, str]:
+        raise NotImplementedError
+
+
+class OpenAIRealtimeAdapter(ProtocolAdapter):
+    """OpenAI Realtime(``wss://api.openai.com/v1/realtime``)的帧格式。"""
+
+    name = "openai_realtime"
+
+    def headers(self, cfg: DuplexSessionConfig) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {cfg.api_key}",
+            "OpenAI-Beta": "realtime=v1",
+        }
+
+    def session_update(self, cfg: DuplexSessionConfig) -> Dict[str, Any]:
+        session: Dict[str, Any] = {
+            "modalities": ["text", "audio"],
+            "voice": cfg.voice,
+            "input_audio_format": "pcm16",
+            "output_audio_format": "pcm16",
+            "input_audio_transcription": {"model": "whisper-1"},
+            # 服务端 VAD:双工下回合边界由服务端判。本地不再"攒够 3 秒再转写"——
+            # 那正是回合制延迟的来源。
+            "turn_detection": {
+                "type": "server_vad",
+                "silence_duration_ms": int(cfg.silence_ms),
+            },
+        }
+        if cfg.instructions:
+            session["instructions"] = cfg.instructions
+        return {"type": "session.update", "session": session}
+
+    def audio_frame(self, pcm16: bytes) -> Dict[str, Any]:
+        return {
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(pcm16).decode("ascii"),
+        }
+
+    def text_frame(self, text: str) -> List[Dict[str, Any]]:
+        return [
+            {
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": text}],
+                },
+            },
+            {"type": "response.create"},
+        ]
+
+    def interrupt_frame(self) -> Dict[str, Any]:
+        """双工下的 barge-in:让服务端**停止当前回复**,而不是本地掐断播放。
+
+        回合制的 ``interrupt_speech()`` 只是停掉本地播放器,模型那边还在继续生成
+        (token 照烧、上下文照涨)。双工下必须让服务端也停。
+        """
+        return {"type": "response.cancel"}
+
+    _MAP = {
+        "session.created": DuplexEventType.SESSION_OPEN,
+        "session.updated": DuplexEventType.SESSION_OPEN,
+        "input_audio_buffer.speech_started": DuplexEventType.USER_SPEECH_STARTED,
+        "input_audio_buffer.speech_stopped": DuplexEventType.USER_SPEECH_STOPPED,
+        "response.done": DuplexEventType.RESPONSE_DONE,
+        "error": DuplexEventType.ERROR,
+    }
+
+    def decode(self, msg: Dict[str, Any]) -> Optional[DuplexEvent]:
+        """把一帧服务端消息翻成 ``DuplexEvent``;不认识的帧返回 None(而不是报错)。
+
+        provider 会不断加新事件类型,对未知帧报错会让会话动不动就断。未知帧只在
+        debug 级别记一笔。
+        """
+        t = str(msg.get("type") or "")
+        if not t:
+            return None
+
+        if t == "response.audio.delta":
+            return DuplexEvent(DuplexEventType.ASSISTANT_AUDIO_DELTA, audio_b64=str(msg.get("delta") or ""), raw=msg)
+        if t in ("response.text.delta", "response.audio_transcript.delta"):
+            return DuplexEvent(DuplexEventType.ASSISTANT_TEXT_DELTA, text=str(msg.get("delta") or ""), raw=msg)
+        if t == "conversation.item.input_audio_transcription.delta":
+            return DuplexEvent(DuplexEventType.PARTIAL_TRANSCRIPT, text=str(msg.get("delta") or ""), raw=msg)
+        if t == "conversation.item.input_audio_transcription.completed":
+            return DuplexEvent(DuplexEventType.FINAL_TRANSCRIPT, text=str(msg.get("transcript") or ""), raw=msg)
+        if t == "error":
+            err = msg.get("error") or {}
+            detail = err.get("message") if isinstance(err, dict) else str(err)
+            return DuplexEvent(DuplexEventType.ERROR, error=str(detail or "unknown"), raw=msg)
+
+        mapped = self._MAP.get(t)
+        if mapped is not None:
+            return DuplexEvent(mapped, raw=msg)
+        logger.debug("双工会话:未识别的服务端帧类型 %s(已忽略)", t)
+        return None
+
+
+def get_adapter(name: str = "openai_realtime") -> ProtocolAdapter:
+    if name == "openai_realtime":
+        return OpenAIRealtimeAdapter()
+    raise ValueError(f"未实现的双工 provider 适配器: {name}(目前只有 openai_realtime)")
+
+
+# ── 会话 ─────────────────────────────────────────────────────────────────────
+
+
+class DuplexSession:
+    """一条持续开着的双工语音会话。
+
+    用法::
+
+        sess = DuplexSession(cfg)
+        await sess.connect()
+        await sess.send_audio(pcm16_bytes)      # 可以一直调,不阻塞下行
+        async for ev in sess.events():
+            ...
+        await sess.close()
+
+    上行与下行是**两个独立的协程**:下行有一个常驻读循环把帧解码后塞进队列,上行直接
+    发送。这样"边说边听"在实现上才真的成立 —— 如果上行要等下行读完一帧,那还是回合制。
+    """
+
+    def __init__(self, config: DuplexSessionConfig, adapter: Optional[ProtocolAdapter] = None) -> None:
+        self.config = config
+        self.adapter = adapter or get_adapter()
+        self._ws: Any = None
+        self._reader: Optional[asyncio.Task] = None
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=_EVENT_QUEUE_MAX)
+        self._connected = False
+        self._closing = False
+        # 观测
+        self.frames_sent = 0
+        self.frames_received = 0
+        self.events_emitted = 0
+        self.events_dropped = 0
+        self.bytes_uplinked = 0
+        self.last_error = ""
+
+    # ── 生命周期 ──────────────────────────────────────────────────────────
+
+    async def connect(self) -> bool:
+        """建连并下发会话配置。返回是否成功;失败时如实记录原因,不抛出。"""
+        if self._connected:
+            return True
+        try:
+            import websockets
+        except Exception as exc:  # noqa: BLE001
+            self.last_error = f"websockets_missing: {exc}"
+            logger.warning("双工会话不可用(缺 websockets): %s", exc)
+            return False
+        try:
+            self._ws = await websockets.connect(
+                self.config.url,
+                additional_headers=self.adapter.headers(self.config),
+                max_size=16 * 1024 * 1024,
+            )
+            await self._send_json(self.adapter.session_update(self.config))
+        except Exception as exc:  # noqa: BLE001
+            self.last_error = f"connect_failed: {exc}"
+            logger.warning("双工会话建连失败,退回回合制语音: %s", exc)
+            await self._hard_close()
+            return False
+
+        self._connected = True
+        self._closing = False
+        self._reader = asyncio.ensure_future(self._read_loop())
+        _BACKGROUND_TASKS.add(self._reader)
+        self._reader.add_done_callback(_BACKGROUND_TASKS.discard)
+        logger.info("双工语音会话已建立(%s, model=%s)", self.adapter.name, self.config.model)
+        return True
+
+    async def close(self) -> None:
+        """关闭会话。幂等、永不抛出。"""
+        self._closing = True
+        self._connected = False
+        reader, self._reader = self._reader, None
+        if reader is not None:
+            reader.cancel()
+            try:
+                await reader
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        await self._hard_close()
+        await self._emit(DuplexEvent(DuplexEventType.SESSION_CLOSED))
+
+    async def _hard_close(self) -> None:
+        ws, self._ws = self._ws, None
+        if ws is None:
+            return
+        try:
+            await ws.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("关闭双工连接失败(忽略): %s", exc)
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    # ── 上行 ──────────────────────────────────────────────────────────────
+
+    async def _send_json(self, payload: Dict[str, Any]) -> bool:
+        ws = self._ws
+        if ws is None:
+            return False
+        try:
+            await ws.send(json.dumps(payload, ensure_ascii=False))
+            self.frames_sent += 1
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self.last_error = f"send_failed: {exc}"
+            logger.debug("双工上行发送失败: %s", exc)
+            return False
+
+    async def send_audio(self, pcm16: bytes) -> bool:
+        """上行一块 16-bit PCM。
+
+        调用方**应当**送已经过 AEC 的音频:双工下这些字节会实时进模型,不做回声消除
+        等于让模型一直听见自己在说话(比回合制更严重 —— 回合制下那段音频最终会被丢掉)。
+        """
+        if not pcm16 or not self._connected:
+            return False
+        ok = await self._send_json(self.adapter.audio_frame(pcm16))
+        if ok:
+            self.bytes_uplinked += len(pcm16)
+        return ok
+
+    async def send_text(self, text: str) -> bool:
+        """上行一段文字(供面板/键盘输入与语音共用同一条会话)。"""
+        if not text or not self._connected:
+            return False
+        ok = True
+        for frame in self.adapter.text_frame(text):
+            ok = await self._send_json(frame) and ok
+        return ok
+
+    async def interrupt(self) -> bool:
+        """barge-in:让**服务端**停止当前回复。
+
+        与回合制的 ``interrupt_speech()`` 有本质区别:那个只停本地播放器,模型那边还在
+        继续生成(token 照烧、上下文照涨)。双工下必须让服务端也停。
+        """
+        if not self._connected:
+            return False
+        return await self._send_json(self.adapter.interrupt_frame())
+
+    # ── 下行 ──────────────────────────────────────────────────────────────
+
+    async def _emit(self, ev: DuplexEvent) -> None:
+        """把事件塞进队列。满了丢**最旧**的 —— 过期音频块没有价值,而阻塞上行会毁掉
+        实时性。丢弃有计数,不静默。"""
+        try:
+            self._queue.put_nowait(ev)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+                self.events_dropped += 1
+                self._queue.put_nowait(ev)
+            except Exception:  # noqa: BLE001
+                self.events_dropped += 1
+                return
+        self.events_emitted += 1
+
+    async def _read_loop(self) -> None:
+        """常驻下行读循环:收帧 → 解码 → 入队。与上行完全解耦。"""
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            async for raw in ws:
+                self.frames_received += 1
+                try:
+                    msg = json.loads(raw)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("双工下行帧不是合法 JSON(忽略): %s", exc)
+                    continue
+                if not isinstance(msg, dict):
+                    continue
+                ev = self.adapter.decode(msg)
+                if ev is None:
+                    continue
+                if ev.type is DuplexEventType.ERROR:
+                    self.last_error = ev.error
+                    logger.warning("双工会话服务端报错: %s", ev.error)
+                # 把 AI 说出口的文字登记进反自激励门 —— 双工下同样需要:AEC 消不掉
+                # 非线性残余回声,残余转写出来后仍要能判出"这是我自己说的"。
+                if ev.type is DuplexEventType.ASSISTANT_TEXT_DELTA and ev.text:
+                    self._note_spoken(ev.text)
+                await self._emit(ev)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            if not self._closing:
+                self.last_error = f"read_loop: {exc}"
+                logger.warning("双工下行读循环异常结束: %s", exc)
+        finally:
+            self._connected = False
+
+    @staticmethod
+    def _note_spoken(text: str) -> None:
+        try:
+            from core.voice_echo_guard import note_utterance
+
+            note_utterance(text)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("双工:登记已说出口文本失败(非致命): %s", exc)
+
+    async def events(self) -> AsyncIterator[DuplexEvent]:
+        """异步迭代下行事件,直到会话关闭。"""
+        while True:
+            ev = await self._queue.get()
+            yield ev
+            if ev.type is DuplexEventType.SESSION_CLOSED:
+                return
+
+    async def next_event(self, timeout: Optional[float] = None) -> Optional[DuplexEvent]:
+        """取一条事件;超时返回 None。供不想用异步迭代的调用方。"""
+        try:
+            if timeout is None:
+                return await self._queue.get()
+            return await asyncio.wait_for(self._queue.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    # ── 观测 ──────────────────────────────────────────────────────────────
+
+    def status(self) -> Dict[str, Any]:
+        return {
+            "connected": self._connected,
+            "adapter": self.adapter.name,
+            "model": self.config.model,
+            "frames_sent": self.frames_sent,
+            "frames_received": self.frames_received,
+            "events_emitted": self.events_emitted,
+            "events_dropped": self.events_dropped,
+            "bytes_uplinked": self.bytes_uplinked,
+            "queue_depth": self._queue.qsize(),
+            "last_error": self.last_error or None,
+        }
+
+
+async def open_duplex_session(
+    config: Optional[DuplexSessionConfig] = None,
+    adapter: Optional[ProtocolAdapter] = None,
+) -> Optional[DuplexSession]:
+    """按环境配置建立一条双工会话;不可用时返回 None(调用方退回回合制)。
+
+    返回 None 的每种情形都有日志:开关没开、缺 key、建连失败 —— 否则"开了开关却没生效"
+    完全无从排查。
+    """
+    if config is None:
+        if not duplex_enabled():
+            logger.debug("双工语音未启用(GALAXY_VOICE_DUPLEX 未开),走回合制链路")
+            return None
+        config = DuplexSessionConfig.from_env()
+        if config is None:
+            return None
+    sess = DuplexSession(config, adapter=adapter)
+    if not await sess.connect():
+        return None
+    return sess
+
+
+def pcm16_from_float(samples: Any) -> bytes:
+    """float32/float64 [-1,1] → 16-bit PCM 字节(上行格式)。
+
+    限幅后再转,不做自动增益:溢出翻转会变成刺耳爆音,而且会污染模型的听觉输入。
+    """
+    import numpy as np
+
+    arr = np.asarray(samples, dtype=np.float64).reshape(-1)
+    if arr.size == 0:
+        return b""
+    return (np.clip(arr, -1.0, 1.0) * 32767.0).astype("<i2").tobytes()
+
+
+def float_from_pcm16(data: bytes) -> Any:
+    """16-bit PCM 字节 → float32 [-1,1](下行播放/分析用)。"""
+    import numpy as np
+
+    if not data:
+        return np.zeros(0, dtype=np.float32)
+    return (np.frombuffer(data, dtype="<i2").astype(np.float32) / 32767.0).astype(np.float32)
+
+
+#: 供 VoiceLoop 在双工模式下把上行音频接过去的回调类型
+UplinkHook = Callable[[bytes], Any]
+
+
+class PcmPlayer:
+    """下行原始 PCM 的播放器。
+
+    双工下行是**连续的 PCM 流**,不是一个个音频文件,所以现有 TTS 引擎那套
+    ``_play_audio(path)`` 用不上 —— 为每个 20ms 的音频块写一个临时文件再播,延迟和
+    IO 开销都不可接受。这里直接开一条 ``sounddevice`` 输出流往里写。
+
+    没有 sounddevice / 没有输出设备时**如实不可用**并记一次 WARNING,不静默假装在播 ——
+    "以为在说话其实一点声音都没有"是最难排查的一类症状。
+    """
+
+    def __init__(self, sample_rate: int = 16000) -> None:
+        self.sample_rate = int(sample_rate)
+        self._stream: Any = None
+        self._unavailable_reason = ""
+        self.blocks_played = 0
+        self.blocks_dropped = 0
+
+    def start(self) -> bool:
+        if self._stream is not None:
+            return True
+        try:
+            import sounddevice as sd
+
+            self._stream = sd.OutputStream(samplerate=self.sample_rate, channels=1, dtype="float32")
+            self._stream.start()
+            logger.info("双工下行播放器已启动(sr=%d)", self.sample_rate)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self._unavailable_reason = str(exc)
+            logger.warning("双工下行播放器不可用(模型的回复将听不到): %s", exc)
+            self._stream = None
+            return False
+
+    def play(self, pcm16: bytes) -> bool:
+        """播一块 PCM。永不抛出;不可用时计数丢弃。"""
+        if not pcm16:
+            return False
+        if self._stream is None:
+            self.blocks_dropped += 1
+            return False
+        try:
+            self._stream.write(float_from_pcm16(pcm16).reshape(-1, 1))
+            self.blocks_played += 1
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self.blocks_dropped += 1
+            logger.debug("双工下行播放失败(丢弃本块): %s", exc)
+            return False
+
+    def stop(self) -> None:
+        stream, self._stream = self._stream, None
+        if stream is None:
+            return
+        try:
+            stream.stop()
+            stream.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("关闭双工播放器失败(忽略): %s", exc)
+
+    def status(self) -> Dict[str, Any]:
+        return {
+            "available": self._stream is not None,
+            "unavailable_reason": self._unavailable_reason or None,
+            "blocks_played": self.blocks_played,
+            "blocks_dropped": self.blocks_dropped,
+        }

--- a/core/voice_duplex_session.py
+++ b/core/voice_duplex_session.py
@@ -37,6 +37,7 @@ import base64
 import json
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -541,12 +542,27 @@ def float_from_pcm16(data: bytes) -> Any:
 UplinkHook = Callable[[bytes], Any]
 
 
-class PcmPlayer:
-    """下行原始 PCM 的播放器。
+#: 下行播放缓冲上限(秒)。满了丢**最旧**的:过期音频没有价值,而让 play() 等待
+#: 会把事件循环连带上行一起卡住。
+_PLAYER_BUFFER_SEC = 2.0
 
+
+class PcmPlayer:
+    """下行原始 PCM 的播放器(回调驱动,``play()`` 绝不阻塞)。
+
+    为什么不能用 ``OutputStream.write()``
+    -------------------------------------
     双工下行是**连续的 PCM 流**,不是一个个音频文件,所以现有 TTS 引擎那套
     ``_play_audio(path)`` 用不上 —— 为每个 20ms 的音频块写一个临时文件再播,延迟和
-    IO 开销都不可接受。这里直接开一条 ``sounddevice`` 输出流往里写。
+    IO 开销都不可接受。
+
+    但直接用 ``stream.write()`` 也不行:按 sounddevice 的契约它**会阻塞**到所有帧都写进
+    设备缓冲为止。而 ``play()`` 是从 ``_duplex_downlink`` 里调的,跑在事件循环上 ——
+    一阻塞,同一个循环上的**上行**也跟着停。那就等于用一个"实时"播放器把双工性质亲手
+    毁掉:模型说话时用户的声音传不上去,退化成半双工。
+
+    所以改成**回调驱动**:``sounddevice`` 的音频线程主动来取,``play()`` 只是往一个有界
+    环形缓冲里追加,纯内存操作、不等待任何人。这也是音频输出的标准做法。
 
     没有 sounddevice / 没有输出设备时**如实不可用**并记一次 WARNING,不静默假装在播 ——
     "以为在说话其实一点声音都没有"是最难排查的一类症状。
@@ -556,18 +572,48 @@ class PcmPlayer:
         self.sample_rate = int(sample_rate)
         self._stream: Any = None
         self._unavailable_reason = ""
+        self._lock = threading.Lock()
+        self._buf: Any = None  # numpy 1-D 待播样本
+        self._np: Any = None
         self.blocks_played = 0
         self.blocks_dropped = 0
+        self.samples_underrun = 0  # 缓冲空、只能输出静音的样本数(可听为卡顿)
+
+    @property
+    def _max_samples(self) -> int:
+        return int(_PLAYER_BUFFER_SEC * self.sample_rate)
 
     def start(self) -> bool:
         if self._stream is not None:
             return True
         try:
+            import numpy as np
             import sounddevice as sd
 
-            self._stream = sd.OutputStream(samplerate=self.sample_rate, channels=1, dtype="float32")
+            self._np = np
+            self._buf = np.zeros(0, dtype=np.float32)
+
+            def _cb(outdata, frames, _time_info, status) -> None:  # noqa: ANN001
+                # 音频线程:只做取数与补静音,绝不做 IO / 日志 / 加重锁
+                if status:
+                    pass
+                with self._lock:
+                    have = min(frames, self._buf.size)
+                    if have:
+                        outdata[:have, 0] = self._buf[:have]
+                        self._buf = self._buf[have:]
+                    if have < frames:
+                        outdata[have:, 0] = 0.0
+                        self.samples_underrun += frames - have
+
+            self._stream = sd.OutputStream(
+                samplerate=self.sample_rate,
+                channels=1,
+                dtype="float32",
+                callback=_cb,
+            )
             self._stream.start()
-            logger.info("双工下行播放器已启动(sr=%d)", self.sample_rate)
+            logger.info("双工下行播放器已启动(回调驱动, sr=%d)", self.sample_rate)
             return True
         except Exception as exc:  # noqa: BLE001
             self._unavailable_reason = str(exc)
@@ -576,23 +622,34 @@ class PcmPlayer:
             return False
 
     def play(self, pcm16: bytes) -> bool:
-        """播一块 PCM。永不抛出;不可用时计数丢弃。"""
+        """把一块 PCM 追加到播放缓冲。**不阻塞**、永不抛出。"""
         if not pcm16:
             return False
-        if self._stream is None:
+        if self._stream is None or self._np is None:
             self.blocks_dropped += 1
             return False
         try:
-            self._stream.write(float_from_pcm16(pcm16).reshape(-1, 1))
+            np = self._np
+            samples = float_from_pcm16(pcm16)
+            with self._lock:
+                self._buf = np.concatenate((self._buf, samples))
+                # 有界:生产快于消费时丢最旧的,而不是让 play() 等下去
+                extra = self._buf.size - self._max_samples
+                if extra > 0:
+                    self._buf = self._buf[extra:]
+                    self.blocks_dropped += 1
             self.blocks_played += 1
             return True
         except Exception as exc:  # noqa: BLE001
             self.blocks_dropped += 1
-            logger.debug("双工下行播放失败(丢弃本块): %s", exc)
+            logger.debug("双工下行入缓冲失败(丢弃本块): %s", exc)
             return False
 
     def stop(self) -> None:
         stream, self._stream = self._stream, None
+        with self._lock:
+            if self._np is not None:
+                self._buf = self._np.zeros(0, dtype=self._np.float32)
         if stream is None:
             return
         try:
@@ -602,9 +659,13 @@ class PcmPlayer:
             logger.debug("关闭双工播放器失败(忽略): %s", exc)
 
     def status(self) -> Dict[str, Any]:
+        with self._lock:
+            buffered = int(self._buf.size) if self._buf is not None else 0
         return {
             "available": self._stream is not None,
             "unavailable_reason": self._unavailable_reason or None,
             "blocks_played": self.blocks_played,
             "blocks_dropped": self.blocks_dropped,
+            "buffered_samples": buffered,
+            "samples_underrun": self.samples_underrun,
         }

--- a/core/voice_echo_guard.py
+++ b/core/voice_echo_guard.py
@@ -1,0 +1,364 @@
+"""core.voice_echo_guard — 反自激励门:分辨"麦克风听到的是用户,还是 AI 自己"。
+
+要解决的真实缺陷
+----------------
+本地语音闭环是 ``麦克风 → VAD → Whisper → VoiceLoop._on_voice_input``。AI 用
+TTS 从扬声器把回复念出来时,同一间屋子里的麦克风必然把这段声音重新采回去,VAD
+判"有人在说话",Whisper 把 AI 自己的话转写成文字,再当作用户输入送进
+``_on_voice_input``。后果有两条,而且都不是理论风险:
+
+1. **AI 打断自己。** ``_on_voice_input`` 开头把"出词"当作用户开口的证据,
+   ``is_speaking()`` 为真就调 ``interrupt_speech()``。而此刻正在说话的就是它
+   自己 —— 于是每念一两句就被自己的回声掐断一次。
+2. **AI 对自己说的话作答。** 转写出的文字继续往下走,进大脑,生成回复,再念出
+   来,再被采回去 —— 自言自语的闭环。
+
+``core/ambient_attention_loop.py`` 里对**它自己那条**感知通路写明并挡住了同一
+个危险(见其"反自激励(anti-echo)"注释),但语音主闭环这条 —— 默认开启、真正
+驱动对话的那条 —— 一直没有任何防护。本模块补上。
+
+为什么不能简单地"朗读期间丢掉所有音频"
+--------------------------------------
+那会连真正的 barge-in 一起杀掉。"你一说话它就闭嘴"是本仓库明确提供的能力,不能
+为了挡回声把它换掉。所以这里判的不是"此刻是否在朗读",而是**这段文字是不是我刚
+刚说过的话**:
+
+- 内容与刚说出口的话高度重合 → 自己的回声 → 丢弃,且**不触发 barge-in**。
+- 内容是别的 → 用户真的开口了 → 照常打断、照常处理。
+
+为什么按"文字"判而不按"是否在朗读"判
+------------------------------------
+``speech_output.is_speaking()`` 只反映 ``_active_speaker``,而 ``_active_speaker``
+只在**流式**朗读路径上被设置。整段批处理路径(``GALAXY_TTS_STREAMING=0``)和原生
+发声路径都不设它 —— 那两种模式下 ``is_speaking()`` 恒为 False,任何建立在它之上
+的门(包括 ambient 那条)都是失效的。本模块挂在"文字真的变成声音"的那一刻,三条
+发声路径一视同仁,因此比 ``is_speaking()`` 严格更可靠。
+
+留存窗口
+--------
+麦克风侧有缓冲:``AudioCaptureService`` 攒够 ``asr_buffer_duration_s``(默认 3 秒)
+才转写,加上 Whisper 本身的耗时,一段转写可能比它对应的声音晚好几秒才到。所以
+"刚说过的话"必须在**说完之后**继续留存一段尾巴时间。又因为流式朗读是整段登记、
+逐句播出的,一段长回复登记时刻很早、播完很晚,固定尾巴会让它在还没念完时就过期。
+故留存时长按文本长度估算朗读耗时后再加尾巴。
+
+不做的事(说明白,不含糊)
+--------------------------
+- 这不是回声消除(AEC)。没有做参考信号对齐,不处理"用户和 AI 同时说话"
+  (double-talk)——那需要声学层的 AEC,不是文本层能解决的。
+- barge-in 被打断时,尚未播出的后半段仍留在窗口里。清掉它会给**已经播出**的前半
+  段重新打开回声口子,权衡之下选择留着;代价是打断后数秒内,用户若正好说出与那段
+  未播出文字高度重合的话,会被误判一次。
+
+默认开启(``GALAXY_VOICE_ECHO_GUARD=0`` 可关)。任何内部异常都判为"用户",绝不因
+本模块失灵而让助手变聋。
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import os
+import re
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, Optional, Tuple
+
+logger = logging.getLogger("Galaxy.VoiceEchoGuard")
+
+# 判定结果
+VERDICT_USER = "user"
+VERDICT_SELF_ECHO = "self_echo"
+
+# 最多留存多少条已说出口的话(防无界增长;远超任何真实对话所需)
+_MAX_UTTERANCES = 32
+
+# 朗读速度估算(中文 TTS 约每秒 5 字),用于推算一段文本要念多久
+_CHARS_PER_SEC = 5.0
+
+# 连续压制多少条后升一次 WARNING —— 万一相似度误判,要看得见,不能静默变聋
+_SUPPRESS_STREAK_WARN = 5
+
+_PUNCT_RE = re.compile(r"[\s,。、;:!?…—~·\"'“”‘’()()《》【】\[\]{}<>/\\|+*=&%$#@^_`,.;:!?~-]+")
+
+
+def _flag(name: str, default: str = "1") -> bool:
+    return os.getenv(name, default).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _num(name: str, default: float) -> float:
+    """读数值型环境变量;非法值退回默认并告警(不静默吞掉配置错误)。"""
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("%s=%r 不是合法数值,已退回默认值 %s", name, raw, default)
+        return default
+
+
+def enabled() -> bool:
+    """反自激励门是否启用(默认开启)。"""
+    return _flag("GALAXY_VOICE_ECHO_GUARD", "1")
+
+
+def tail_seconds() -> float:
+    """说完之后仍把这段话算作"刚说过"的尾巴时长(秒)。"""
+    return max(0.0, _num("GALAXY_VOICE_ECHO_TAIL_S", 6.0))
+
+
+def similarity_threshold() -> float:
+    """判为自己回声所需的最低重合度(0~1)。"""
+    return min(1.0, max(0.0, _num("GALAXY_VOICE_ECHO_SIM", 0.62)))
+
+
+def min_chars() -> int:
+    """短于此长度的转写一律判"用户"——"停"/"别说了" 这类打断口令必须永远通得过。"""
+    return max(1, int(_num("GALAXY_VOICE_ECHO_MIN_CHARS", 4)))
+
+
+def min_block() -> int:
+    """至少要有这么长的一段【连续】重合,才可能是回声。
+
+    只看总重合比例会误判:中文常用字少,一句短话("好的""可以吧")的每个字几乎
+    必然散落在长回复的某处,总重合能凑到 1.0。要求一段足够长的连续命中,散落的
+    单字重合就构不成证据了。
+    """
+    return max(2, int(_num("GALAXY_VOICE_ECHO_MIN_BLOCK", 4)))
+
+
+def normalize(text: str) -> str:
+    """归一化:去标点空白、英文转小写。ASR 的标点很不稳定,不能参与比对。"""
+    return _PUNCT_RE.sub("", (text or "")).lower()
+
+
+def _speech_duration_estimate(norm_len: int) -> float:
+    """估算这段文本要念多久(秒)。"""
+    return norm_len / _CHARS_PER_SEC if norm_len > 0 else 0.0
+
+
+def overlap(asr_norm: str, utt_norm: str) -> Tuple[float, int]:
+    """返回 ``(重合比例, 最长连续重合长度)``。
+
+    重合比例是"转写文本中有多少比例能在已说出口的话里找到对应"——即 containment,
+    而不是对称的相似度:已说出口的话通常长得多(整段回复),对称相似度会被长度差
+    压到极小,根本判不出来。
+    """
+    if not asr_norm or not utt_norm:
+        return 0.0, 0
+    sm = difflib.SequenceMatcher(None, asr_norm, utt_norm, autojunk=False)
+    blocks = sm.get_matching_blocks()
+    matched = sum(b.size for b in blocks)
+    longest = max((b.size for b in blocks), default=0)
+    return min(1.0, matched / len(asr_norm)), longest
+
+
+@dataclass
+class _Utterance:
+    """一段【确实已经变成声音】的文本。"""
+
+    norm: str
+    ts: float
+    preview: str = field(default="", repr=False)
+
+    def expires_at(self, tail: float) -> float:
+        """过期时刻:登记时刻 + 估算朗读耗时 + 尾巴。"""
+        return self.ts + _speech_duration_estimate(len(self.norm)) + tail
+
+
+class EchoGuard:
+    """记录"AI 刚说出口的话",据此判断一段转写是不是它自己的回声。
+
+    线程安全:登记发生在朗读/播放协程里,判定发生在 ASR 线程池 worker 或事件循环
+    线程里,两侧都可能并发,故全部状态由一把锁守护。
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._utterances: Deque[_Utterance] = deque(maxlen=_MAX_UTTERANCES)
+        # 可观测计数
+        self.noted: int = 0
+        self.checked: int = 0
+        self.suppressed: int = 0
+        self.passed: int = 0
+        self._streak: int = 0
+
+    # ── 登记(由发声侧调用)─────────────────────────────────────────────────
+
+    def note_utterance(self, text: str) -> None:
+        """登记一段【已经/正在】变成声音的文本。降级安全,永不抛出。"""
+        try:
+            norm = normalize(text)
+            if not norm:
+                return
+            with self._lock:
+                self._utterances.append(_Utterance(norm=norm, ts=time.time(), preview=(text or "")[:40]))
+                self.noted += 1
+        except Exception as exc:  # noqa: BLE001 — 登记失败最多让门漏一句,不能影响朗读
+            logger.debug("登记已说出口的文本失败(非致命): %s", exc)
+
+    # ── 判定(由听侧调用)─────────────────────────────────────────────────
+
+    def _prune_unlocked(self, now: float, tail: float) -> None:
+        while self._utterances and self._utterances[0].expires_at(tail) < now:
+            self._utterances.popleft()
+
+    def recently_spoke(self) -> bool:
+        """当前是否还有"刚说过的话"在留存窗口内。
+
+        供不掌握文字、只能按时间挡的调用方(如 ambient 感知通路)使用;它比
+        ``speech_output.is_speaking()`` 覆盖更全 —— 整段批处理和原生发声这两条
+        路径不设 ``_active_speaker``,``is_speaking()`` 在那里恒为 False。
+        """
+        try:
+            if not enabled():
+                return False
+            now = time.time()
+            tail = tail_seconds()
+            with self._lock:
+                self._prune_unlocked(now, tail)
+                return bool(self._utterances)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("recently_spoke 判定失败,按「没说过」处理: %s", exc)
+            return False
+
+    def classify(self, asr_text: str) -> Tuple[str, float, str]:
+        """判定一段 ASR 文字的来源。返回 ``(verdict, score, reason)``。
+
+        任何异常、任何不确定 → 判 ``VERDICT_USER``。宁可漏挡一次回声,也不能把
+        用户真的说的话吃掉。
+        """
+        try:
+            return self._classify_inner(asr_text)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("反自激励判定失败,按「用户输入」放行: %s", exc)
+            return VERDICT_USER, 0.0, "guard_error"
+
+    def _classify_inner(self, asr_text: str) -> Tuple[str, float, str]:
+        if not enabled():
+            return VERDICT_USER, 0.0, "disabled"
+
+        norm = normalize(asr_text)
+        if not norm:
+            return VERDICT_USER, 0.0, "empty"
+        if len(norm) < min_chars():
+            # 太短判不准,而且"停/别念了"这类打断口令正是这个长度——必须放行。
+            return VERDICT_USER, 0.0, "too_short"
+
+        now = time.time()
+        tail = tail_seconds()
+        thr = similarity_threshold()
+        need_block = min_block()
+
+        with self._lock:
+            self._prune_unlocked(now, tail)
+            if not self._utterances:
+                self.checked += 1
+                self.passed += 1
+                self._streak = 0
+                return VERDICT_USER, 0.0, "nothing_recent"
+            candidates = list(self._utterances)
+
+        best_score = 0.0
+        best_block = 0
+        best_preview = ""
+        for utt in candidates:
+            score, longest = overlap(norm, utt.norm)
+            if longest < need_block:
+                continue  # 只有散落单字重合,不构成证据
+            if score > best_score:
+                best_score, best_block, best_preview = score, longest, utt.preview
+
+        with self._lock:
+            self.checked += 1
+            if best_score >= thr:
+                self.suppressed += 1
+                self._streak += 1
+                streak = self._streak
+            else:
+                self.passed += 1
+                self._streak = 0
+                streak = 0
+
+        if best_score >= thr:
+            if streak and streak % _SUPPRESS_STREAK_WARN == 0:
+                # 相似度门若误判,症状是"助手不理人"。必须看得见,不能静默变聋。
+                logger.warning(
+                    "反自激励门已连续压制 %d 条语音输入(最近一条=%r,重合=%.2f)。"
+                    "若用户其实在说话却没被响应,调高 GALAXY_VOICE_ECHO_SIM 或设 "
+                    "GALAXY_VOICE_ECHO_GUARD=0 复核。",
+                    streak,
+                    asr_text[:40],
+                    best_score,
+                )
+            return VERDICT_SELF_ECHO, best_score, f"matched:{best_preview}"
+        return VERDICT_USER, best_score, f"below_threshold:{best_block}"
+
+    # ── 观测 / 测试支持 ───────────────────────────────────────────────────
+
+    def stats(self) -> Dict[str, object]:
+        with self._lock:
+            now = time.time()
+            tail = tail_seconds()
+            self._prune_unlocked(now, tail)
+            return {
+                "enabled": enabled(),
+                "live_utterances": len(self._utterances),
+                "noted": self.noted,
+                "checked": self.checked,
+                "suppressed": self.suppressed,
+                "passed": self.passed,
+                "suppress_streak": self._streak,
+                "tail_s": tail,
+                "sim_threshold": similarity_threshold(),
+            }
+
+    def clear(self) -> None:
+        with self._lock:
+            self._utterances.clear()
+            self._streak = 0
+
+
+# ── 进程级单例 ───────────────────────────────────────────────────────────────
+
+_guard: Optional[EchoGuard] = None
+_guard_lock = threading.Lock()
+
+
+def get_echo_guard() -> EchoGuard:
+    global _guard
+    if _guard is None:
+        with _guard_lock:
+            if _guard is None:
+                _guard = EchoGuard()
+    return _guard
+
+
+def reset_echo_guard() -> None:
+    """重置单例(测试用)。"""
+    global _guard
+    with _guard_lock:
+        _guard = None
+
+
+def note_utterance(text: str) -> None:
+    """模块级快捷入口:登记一段已说出口的文本。"""
+    get_echo_guard().note_utterance(text)
+
+
+def classify_asr_text(text: str) -> Tuple[str, float, str]:
+    """模块级快捷入口:判定一段 ASR 文字的来源。"""
+    return get_echo_guard().classify(text)
+
+
+def is_self_echo(text: str) -> bool:
+    """便捷判定:这段转写是不是 AI 自己的回声。"""
+    return classify_asr_text(text)[0] == VERDICT_SELF_ECHO
+
+
+def recently_spoke() -> bool:
+    """模块级快捷入口:留存窗口内是否还有刚说过的话。"""
+    return get_echo_guard().recently_spoke()

--- a/core/voice_loop.py
+++ b/core/voice_loop.py
@@ -87,6 +87,10 @@ class VoiceLoop:
         self._turn_seq: int = 0
         # 委托模式:后台任务句柄(防 GC;stop 时取消)。
         self._bg_tasks: set = set()
+        # 双工模式状态(未启用时全为 None)
+        self._duplex: Optional[Any] = None
+        self._duplex_player: Optional[Any] = None
+        self._duplex_loop: Optional[asyncio.AbstractEventLoop] = None
 
     async def start(self) -> None:
         """启动语音闭环。
@@ -120,6 +124,12 @@ class VoiceLoop:
 
         logger.info("Starting VoiceLoop...")
 
+        # 0. 双工优先:开关打开且会话建得起来 → 走持续上下行链路,不再初始化
+        #    ASR/TTS(那是回合制的部件)。建不起来则如实退回回合制,原因已在
+        #    open_duplex_session 里记过日志。
+        if await self._try_start_duplex(AudioCaptureConfig, AudioCaptureService):
+            return
+
         # 1. 初始化 ASR
         self.asr = WhisperASR(model_size=self.model_size)
         logger.info("ASR initialized: %s", self.asr)
@@ -145,6 +155,107 @@ class VoiceLoop:
         await self.capture.start()
         self._running = True
         logger.info("VoiceLoop started — listening for voice input")
+
+    # ── 双工路径 ──────────────────────────────────────────────────────────
+
+    async def _try_start_duplex(self, AudioCaptureConfig, AudioCaptureService) -> bool:  # noqa: N803
+        """尝试用双工会话取代回合制链路。返回是否真的启动了双工。
+
+        为什么是"取代"而不是"并存":同一个麦克风的音频不能既攒着等 Whisper 整段转写、
+        又实时流给 realtime 服务端 —— 两条路都要独占回合边界的判定权。所以这里二选一。
+
+        上行刻意复用 ``AudioCaptureService``:AEC 挂在 ``AudioIngestPipeline._process_chunk``
+        里,走这条路上行的音频**已经过回声消除**。双工比回合制更需要这一点 —— 回合制下
+        AI 说话时采到的回声最终会被丢掉,双工下那些字节会实时进模型,不消回声等于让模型
+        一直听见自己在说话。
+        """
+        try:
+            from core.voice_duplex_session import (
+                DuplexEventType,
+                PcmPlayer,
+                duplex_enabled,
+                open_duplex_session,
+                pcm16_from_float,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("双工模块不可用,走回合制: %s", exc)
+            return False
+
+        if not duplex_enabled():
+            return False
+        session = await open_duplex_session()
+        if session is None:
+            return False
+
+        self._duplex = session
+        self._duplex_player = PcmPlayer(sample_rate=self.sample_rate)
+        self._duplex_player.start()
+
+        # 上行:复用采集服务(因此复用 AEC),把每块样本转成 PCM16 发上去
+        capture = AudioCaptureService(
+            config=AudioCaptureConfig(
+                sample_rate=self.sample_rate,
+                chunk_duration_ms=self.chunk_duration_ms,
+            )
+        )
+
+        def _uplink(state, _quality) -> None:
+            try:
+                pcm = pcm16_from_float(state.samples)
+                if not pcm:
+                    return
+                loop = self._duplex_loop
+                if loop is None:
+                    return
+                # 采集回调跑在采集线程/事件循环回调里,发送是 async → 跨线程安全调度
+                asyncio.run_coroutine_threadsafe(session.send_audio(pcm), loop)
+            except Exception as exc:  # noqa: BLE001 — 上行单块失败不能影响采集
+                logger.debug("双工上行单块失败(跳过): %s", exc)
+
+        self._duplex_loop = asyncio.get_running_loop()
+        capture.add_asr_callback(_uplink)
+        self.capture = capture
+        await capture.start()
+
+        task = asyncio.ensure_future(self._duplex_downlink(session, DuplexEventType))
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
+
+        self._running = True
+        logger.info("VoiceLoop 已以【双工】模式启动(持续上行 + 持续下行)")
+        return True
+
+    async def _duplex_downlink(self, session, DuplexEventType) -> None:  # noqa: N803
+        """消费下行事件:播音频、推面板、用户开口即让服务端停当前回复。"""
+        try:
+            async for ev in session.events():
+                if ev.type is DuplexEventType.ASSISTANT_AUDIO_DELTA and ev.audio_b64:
+                    import base64
+
+                    self._duplex_player.play(base64.b64decode(ev.audio_b64))
+                elif ev.type is DuplexEventType.USER_SPEECH_STARTED:
+                    # 双工下的 barge-in:让【服务端】停止当前回复。只停本地播放没用 ——
+                    # 模型那边还在继续生成,token 照烧、上下文照涨。
+                    await session.interrupt()
+                elif ev.type is DuplexEventType.FINAL_TRANSCRIPT and ev.text:
+                    self._emit_panel("user", ev.text)
+                elif ev.type is DuplexEventType.RESPONSE_DONE:
+                    logger.debug("双工:一个回复回合结束")
+                elif ev.type is DuplexEventType.SESSION_CLOSED:
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("双工下行消费异常结束: %s", exc)
+
+    @staticmethod
+    def _emit_panel(role: str, text: str) -> None:
+        try:
+            from core.lumiv_websocket_bridge import emit_conversation
+
+            emit_conversation(role, text, source="voice")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("emit_conversation 跳过(非致命): %s", exc)
 
     async def _on_voice_input(self, text: str) -> None:
         """处理语音识别结果。
@@ -388,6 +499,23 @@ class VoiceLoop:
             except Exception as exc:
                 logger.debug("Error stopping capture: %s", exc)
 
+        # 双工资源的生命周期必须与回路对称:漏掉这里会留一条活着的 WebSocket 连接和
+        # 一条打开的音频输出流 —— 前者继续计费/占额度,后者占着音频设备不放。
+        player, self._duplex_player = self._duplex_player, None
+        if player is not None:
+            try:
+                player.stop()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("关闭双工播放器失败(忽略): %s", exc)
+
+        session, self._duplex = self._duplex, None
+        if session is not None:
+            try:
+                await session.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("关闭双工会话失败(忽略): %s", exc)
+
+        self._duplex_loop = None
         logger.info("VoiceLoop stopped")
 
     async def say(self, text: str) -> None:

--- a/core/voice_loop.py
+++ b/core/voice_loop.py
@@ -183,12 +183,26 @@ class VoiceLoop:
         except Exception as _exc:  # noqa: BLE001 — 门失灵绝不能让助手变聋
             logger.warning("反自激励门不可用,按用户输入继续处理: %s", _exc)
 
-        # barge-in：用户开口时若 AI 正在朗读，立刻掐断——"你一说话它就闭嘴"。
-        # ASR 出词即视为用户已开口（句级打断）；集中式朗读走 speech_output。
+        # ── barge-in:朗读期间用户出声,分"应答"与"真打断"两种处理 ──────────
+        # 原先是"ASR 一出词就掐断"。但人在听别人说话时会一直出声("嗯""对""好""哦")
+        # —— 那是积极倾听,不是抢话。全当打断的结果是 AI 每讲两句就被"嗯"一声掐断,
+        # 对话根本进行不下去。所以:应答 → 继续说、且不送大脑;真打断 → 立刻掐断。
         try:
             from core.speech_output import interrupt_speech, is_speaking
+            from core.voice_dialog_policy import (
+                BARGE_IN_BACKCHANNEL,
+                backchannel_tolerance_enabled,
+            )
 
             if is_speaking():
+                from core.voice_dialog_policy import get_dialog_policy as _gp
+
+                kind = _gp().classify_barge_in(text) if backchannel_tolerance_enabled() else "interrupt"
+                if kind == BARGE_IN_BACKCHANNEL:
+                    # 继续说下去,也不把这声"嗯"当成一个用户回合送进大脑 ——
+                    # 那会让 AI 对一句语义空的应答另起一段回复。
+                    logger.info("应答(非打断),继续朗读: %s", text[:20])
+                    return
                 interrupt_speech()
                 logger.info("Barge-in: 用户开口，打断 AI 朗读")
         except Exception as _exc:  # noqa: BLE001

--- a/core/voice_loop.py
+++ b/core/voice_loop.py
@@ -161,6 +161,28 @@ class VoiceLoop:
 
         logger.info("Voice input: %s", text)
 
+        # ── 反自激励门(必须在 barge-in 之前)──────────────────────────────
+        # 扬声器放出去的 TTS 会被同一间屋子的麦克风重新采回来、被 VAD 判成"有人在
+        # 说话"、被 Whisper 转写成文字流到这里。若不在此拦住,下面两件事都会发生:
+        #   1. barge-in 把 AI 自己的朗读掐断(它把自己的回声当成"用户开口了");
+        #   2. AI 自己说的话被当作用户输入送进大脑 → 对自己作答 → 自言自语闭环。
+        # 判的是"这段文字是不是我刚说过的话"而不是"此刻是否在朗读",所以真正的
+        # barge-in(用户说的是别的内容)完全不受影响。见 core.voice_echo_guard。
+        try:
+            from core.voice_echo_guard import VERDICT_SELF_ECHO, classify_asr_text
+
+            verdict, score, reason = classify_asr_text(text)
+            if verdict == VERDICT_SELF_ECHO:
+                logger.info(
+                    "反自激励:丢弃 AI 自己的回声(重合=%.2f, %s): %s",
+                    score,
+                    reason,
+                    text[:40],
+                )
+                return  # 不打断、不处理——它本来就是我们自己在说话
+        except Exception as _exc:  # noqa: BLE001 — 门失灵绝不能让助手变聋
+            logger.warning("反自激励门不可用,按用户输入继续处理: %s", _exc)
+
         # barge-in：用户开口时若 AI 正在朗读，立刻掐断——"你一说话它就闭嘴"。
         # ASR 出词即视为用户已开口（句级打断）；集中式朗读走 speech_output。
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,20 @@ def _reset_session_registry():
     except ImportError:
         pass
     yield
+
+
+# 反自激励门是带【时间状态】的进程单例:任何测试只要走过一次朗读路径
+# (speak_response / IncrementalSpeaker),就会往门里登记一段"刚说过的话",而它在留存
+# 窗口内(默认 6 秒 + 按文本长度估算的朗读耗时)会让所有以 recently_spoke() 为条件的
+# 门判定为"AI 正在说话"。于是后续测试里 ambient 感知的音频通路会被静默跳过 —— 单文件
+# 跑全绿、整套跑失败,而且失败点离真正的污染源很远。这里逐测试清零,消除顺序依赖。
+@pytest.fixture(autouse=True)
+def _reset_voice_echo_guard():
+    """Auto-use: 每个测试前清空反自激励门的"刚说过的话",避免跨测试污染。"""
+    try:
+        from core.voice_echo_guard import reset_echo_guard
+
+        reset_echo_guard()
+    except ImportError:
+        pass
+    yield

--- a/tests/test_acoustic_echo_cancellation.py
+++ b/tests/test_acoustic_echo_cancellation.py
@@ -1,0 +1,309 @@
+"""声学回声消除(AEC)的行为测试。
+
+为什么可以在没有麦克风、没有 Windows 机器的环境里严肃地测
+------------------------------------------------------------
+AEC 的效果有一个**客观的标量指标**:ERLE(Echo Return Loss Enhancement,回声抑制量,
+dB)—— 麦克风信号能量与残差能量之比。只要用**已知的**回声路径合成信号,就能算出真值:
+
+    参考信号(远端) → 卷积一个已知的房间冲激响应 → 回声 → 加已知整体时延 → 麦克风信号
+
+于是"AEC 到底消掉了多少回声"不是主观判断,而是一个可以断言的数字。真机上不确定的是
+**回声路径长什么样**,而不是**算法对给定路径有没有效**;后者正是这里钉住的东西。
+
+本文件钉的四件事
+----------------
+1. **纯回声时 ERLE 必须达标。** 这是 AEC 存在的理由。阈值取得比实测水平低一截,
+   给数值抖动留余量,但足以在算法退化时立刻失败。
+2. **双讲时必须保住用户的语音。** 这条比第 1 条更要紧:一个把回声消得很干净、却把
+   用户说的话也削掉的 AEC 是负资产 —— 它会让 ASR 什么也听不清,而症状极难归因。
+3. **绝不放大。** 任何情况下都不能出现"残差比麦克风信号还大"(ERLE 显著为负)。
+   开发过程中两次实现错误恰好都表现为这个:时域版归一化写错 → −2274 dB;频域版
+   功率估计从零平滑 → 开头 −20 dB。所以这条单独立一个用例。
+4. **降级永不断链。** 参考信号缺失/安静、块长突变、numpy 缺失 —— 一律原样返回麦克风
+   信号。上行语音通路不能因为 AEC 出问题就断掉。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from core.multimodal.acoustic_echo_canceller import (  # noqa: E402
+    AcousticEchoCanceller,
+    AECConfig,
+)
+
+SR = 16000
+BLK = 1600  # 100ms,与 AudioIngestConfig.chunk_duration_ms 默认值一致
+NB = 120  # 12 秒
+TRUE_DELAY = 800  # 50ms:两条流之间的整体偏移
+
+
+# ── 合成信号(确定性:固定种子,所有断言可复现)────────────────────────────
+
+
+def _rir(seed: int = 7, n: int = 400, decay: float = 60.0):
+    """合成房间冲激响应:指数衰减的随机脉冲串,总增益 0.8。"""
+    rng = np.random.default_rng(seed)
+    h = rng.standard_normal(n) * np.exp(-np.arange(n) / decay)
+    return h / (np.abs(h).sum() + 1e-9) * 0.8
+
+
+def _speechlike(seed: int, n: int, env_period_s: float = 0.7):
+    """类语音信号:带限噪声 + 慢变幅度包络。
+
+    刻意用**带限**(相关)信号而不是白噪声:白噪声对自适应滤波器是最容易的输入,
+    用它测等于放水。语音的强相关性正是时域 NLMS 收敛不下去的原因。
+    """
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal(n)
+    win = np.hanning(64) / np.hanning(64).sum()
+    b = np.convolve(x, win, "same")
+    env = 0.5 + 0.5 * np.sin(2 * np.pi * np.arange(b.size) / (SR * env_period_s))
+    return (b * env).astype(np.float64)
+
+
+def _erle_db(mic, err) -> float:
+    return float(10 * np.log10((mic @ mic + 1e-12) / (err @ err + 1e-12)))
+
+
+def _run(mic_all, ref, config=None, nb: int = NB):
+    """按块喂进 AEC,返回 (拼接后的麦克风信号, 拼接后的残差, aec)。"""
+    aec = AcousticEchoCanceller(config or AECConfig(sample_rate=SR))
+    mics, errs = [], []
+    for i in range(nb):
+        aec.push_reference(ref[i * BLK : (i + 1) * BLK])
+        m = mic_all[i * BLK : (i + 1) * BLK]
+        errs.append(np.asarray(aec.process(m)))
+        mics.append(m)
+    return np.concatenate(mics), np.concatenate(errs), aec
+
+
+def _echo_only_scenario():
+    """只有回声、没有近端语音。"""
+    h = _rir()
+    ref = _speechlike(7, NB * BLK)
+    echo = np.convolve(ref, h)[: ref.size]
+    mic = np.concatenate([np.zeros(TRUE_DELAY), echo])[: ref.size]
+    return mic, ref
+
+
+def _double_talk_scenario(dt_from_block: int = 80):
+    """前段纯回声,``dt_from_block`` 块之后叠加近端语音(用户开口)。"""
+    mic, ref = _echo_only_scenario()
+    near = np.zeros_like(mic)
+    tail = mic.size - dt_from_block * BLK
+    near[dt_from_block * BLK :] = _speechlike(99, tail, env_period_s=0.4)
+    return mic + near, ref, near
+
+
+# ── 1. 纯回声:ERLE 达标 ────────────────────────────────────────────────────
+
+
+class TestEchoSuppression:
+    def test_converges_to_useful_erle_on_echo_only(self):
+        """收敛后的 ERLE 必须达标。实测 ≈27 dB;阈值 18 dB 留足抖动余量。"""
+        mic, ref = _echo_only_scenario()
+        m, e, aec = _run(mic, ref)
+        q = m.size * 3 // 4
+        erle = _erle_db(m[q:], e[q:])
+        assert erle >= 18.0, f"收敛后 ERLE 仅 {erle:.2f} dB —— AEC 基本没起作用"
+
+    def test_delay_is_estimated_close_to_truth(self):
+        """整体时延估计错了,滤波器就得拿抽头去表示延迟,尾长被白白吃掉。"""
+        mic, ref = _echo_only_scenario()
+        _m, _e, aec = _run(mic, ref)
+        est = aec.snapshot()["delay_samples"]
+        assert abs(est - TRUE_DELAY) <= 64, f"时延估计 {est} 偏离真值 {TRUE_DELAY} 太多"
+
+    def test_erle_improves_over_time(self):
+        """自适应必须真的在收敛 —— 后段要显著好于前段,而不是一条平线。"""
+        mic, ref = _echo_only_scenario()
+        m, e, _ = _run(mic, ref)
+        third = m.size // 3
+        early = _erle_db(m[:third], e[:third])
+        late = _erle_db(m[2 * third :], e[2 * third :])
+        assert late > early + 5.0, f"没有收敛趋势:前段 {early:.1f} dB → 后段 {late:.1f} dB"
+
+
+# ── 2. 双讲:保住用户语音(比消回声更要紧)──────────────────────────────
+
+
+class TestDoubleTalkPreservesNearEndSpeech:
+    """一个把回声消干净、却把用户的话削掉的 AEC 是负资产:ASR 什么都听不清,而症状
+    极难归因到 AEC。所以这一组的断言比 ERLE 那一组更严格。"""
+
+    def test_near_end_speech_survives(self):
+        mic, ref, near = _double_talk_scenario()
+        _m, e, _aec = _run(mic, ref)
+        dt = slice(80 * BLK, None)
+        ne, res = near[dt], e[dt]
+        corr = float(np.dot(ne, res) / (np.linalg.norm(ne) * np.linalg.norm(res) + 1e-12))
+        assert corr > 0.9, f"残差与用户真实语音的相关只有 {corr:.3f} —— 用户的话被削掉了"
+
+    def test_near_end_energy_is_not_eaten(self):
+        """残差能量应与近端语音能量相当(±3 dB):既没被当成回声减掉,也没被放大。"""
+        mic, ref, near = _double_talk_scenario()
+        _m, e, _aec = _run(mic, ref)
+        dt = slice(80 * BLK, None)
+        ratio = _erle_db(e[dt], near[dt])  # 残差/近端
+        assert -3.0 < ratio < 3.0, f"残差与近端能量差 {ratio:+.2f} dB,偏离太多"
+
+    def test_double_talk_is_actually_detected(self):
+        """DTD 必须真的开火。一次都不开火说明它形同虚设(而那正是最初实现的反面:
+        它反过来把一切都判成双讲、导致永不收敛)。"""
+        mic, ref, _near = _double_talk_scenario()
+        _m, _e, aec = _run(mic, ref)
+        assert aec.snapshot()["blocks_double_talk"] > 0, "DTD 从未开火"
+
+    def test_adaptation_still_happens_outside_double_talk(self):
+        """反面防线:DTD 不能把一切都判成双讲。最初的实现里 120 块只有 8 块真的更新过
+        权重,于是永远收敛不了 —— 这个用例就是为了让那种退化立刻可见。"""
+        mic, ref, _near = _double_talk_scenario()
+        _m, _e, aec = _run(mic, ref)
+        snap = aec.snapshot()
+        assert (
+            snap["blocks_adapted"] > snap["blocks_processed"] * 0.5
+        ), f"只有 {snap['blocks_adapted']}/{snap['blocks_processed']} 块自适应过 —— DTD 过于激进"
+
+
+# ── 3. 绝不放大 ────────────────────────────────────────────────────────────
+
+
+class TestNeverAmplifies:
+    """开发过程中两次实现错误都表现为"AEC 把回声放大了":时域版归一化写错到 −2274 dB;
+    频域版功率估计从零平滑导致开头 −20 dB。所以单独立一组守住这条底线。"""
+
+    def test_overall_erle_is_not_negative_on_echo_only(self):
+        mic, ref = _echo_only_scenario()
+        m, e, _ = _run(mic, ref)
+        erle = _erle_db(m, e)
+        assert erle > 0.0, f"整段 ERLE 为 {erle:.2f} dB —— AEC 净放大了回声"
+
+    def test_no_catastrophic_block(self):
+        """逐块检查:任何单块的残差都不该比该块麦克风信号大一个数量级以上。"""
+        mic, ref = _echo_only_scenario()
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        worst = 0.0
+        for i in range(NB):
+            aec.push_reference(ref[i * BLK : (i + 1) * BLK])
+            m = mic[i * BLK : (i + 1) * BLK]
+            e = np.asarray(aec.process(m))
+            worst = min(worst, _erle_db(m, e))
+        assert worst > -10.0, f"最差单块 ERLE 为 {worst:.2f} dB —— 出现过剧烈过冲"
+
+    def test_power_estimate_is_seeded_from_the_first_block(self):
+        """守住那处修复本身:功率估计若从全零平滑,首块步长会放大 1/(1-power_smooth) 倍。"""
+        mic, ref = _echo_only_scenario()
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        aec.push_reference(ref[:BLK])
+        aec.process(mic[:BLK])
+        assert aec._pow_init is True
+        assert float(np.max(aec._pow)) > 0.0, "首块之后功率估计仍为零"
+
+
+# ── 4. 降级永不断链 ────────────────────────────────────────────────────────
+
+
+class TestGracefulDegradation:
+    def test_bypasses_when_reference_is_silent(self):
+        """扬声器没在放 → 没有回声可消。此时也**不能**自适应:那等于让滤波器去拟合
+        噪声,把已经收敛的权重带跑偏。"""
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        mic = _speechlike(3, BLK)
+        out = aec.process(mic)
+        assert np.allclose(np.asarray(out), mic), "参考安静时应原样返回"
+        snap = aec.snapshot()
+        assert snap["last_bypass_reason"] == "reference_silent"
+        assert snap["blocks_adapted"] == 0
+
+    def test_bypasses_when_disabled_by_env(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_AEC", "0")
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        mic = _speechlike(3, BLK)
+        aec.push_reference(_speechlike(4, BLK))
+        out = aec.process(mic)
+        assert np.allclose(np.asarray(out), mic)
+        assert aec.snapshot()["last_bypass_reason"] == "disabled"
+
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("GALAXY_AEC", raising=False)
+        from core.multimodal.acoustic_echo_canceller import enabled
+
+        assert enabled() is True
+
+    def test_output_length_always_matches_input(self):
+        """长度不符会让下游 VAD/ASR 拿到错长度的块。宁可旁通也不能返回错长度。"""
+        mic, ref = _echo_only_scenario()
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        for i in range(10):
+            aec.push_reference(ref[i * BLK : (i + 1) * BLK])
+            block = mic[i * BLK : (i + 1) * BLK]
+            assert np.asarray(aec.process(block)).size == block.size
+
+    def test_block_size_change_rebuilds_instead_of_failing(self):
+        """块长由设备实际给的帧数决定,可能变。变了要重建,不能每块都"长度不符→旁通"
+        —— 那等于 AEC 没接。"""
+        mic, ref = _echo_only_scenario()
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        aec.push_reference(ref[:BLK])
+        aec.process(mic[:BLK])
+        assert aec._n == BLK
+        half = BLK // 2
+        aec.push_reference(ref[BLK : BLK + half])
+        out = aec.process(mic[BLK : BLK + half])
+        assert aec._n == half, "块长变化后应重建滤波器"
+        assert np.asarray(out).size == half
+
+    def test_empty_block_is_safe(self):
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        out = aec.process(np.zeros(0))
+        assert np.asarray(out).size == 0
+
+    def test_process_never_raises_on_garbage_reference(self):
+        """参考信号来自另一条采集线程,形状不可控。任何异常都必须被吞掉并旁通。"""
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        aec.push_reference("not an array")  # type: ignore[arg-type]
+        aec.push_reference(None)  # type: ignore[arg-type]
+        mic = _speechlike(3, BLK)
+        assert np.asarray(aec.process(mic)).size == BLK
+
+    def test_internal_error_falls_back_to_raw_mic(self, monkeypatch):
+        aec = AcousticEchoCanceller(AECConfig(sample_rate=SR))
+        aec.push_reference(_speechlike(4, BLK * 2))
+        mic = _speechlike(3, BLK)
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("injected")
+
+        monkeypatch.setattr(aec, "_process_inner", _boom)
+        out = aec.process(mic)
+        assert np.allclose(np.asarray(out), mic), "内部异常时必须原样返回麦克风信号"
+        assert aec.snapshot()["last_bypass_reason"] == "error"
+
+    def test_reset_clears_filter_state(self):
+        mic, ref = _echo_only_scenario()
+        _m, _e, aec = _run(mic, ref, nb=20)
+        assert aec.snapshot()["blocks_processed"] > 0
+        aec.reset()
+        snap = aec.snapshot()
+        assert snap["blocks_processed"] == 0
+        assert snap["delay_samples"] == 0
+
+
+class TestSingleton:
+    def test_singleton_is_rebuilt_when_sample_rate_changes(self):
+        """滤波器长度与采样率绑定,换采样率必须重建,否则尾长语义悄悄变了。"""
+        from core.multimodal.acoustic_echo_canceller import (
+            get_echo_canceller,
+            reset_echo_canceller,
+        )
+
+        reset_echo_canceller()
+        a = get_echo_canceller(16000)
+        assert get_echo_canceller(16000) is a
+        b = get_echo_canceller(48000)
+        assert b is not a
+        assert b.config.sample_rate == 48000
+        reset_echo_canceller()

--- a/tests/test_barge_in_backchannel_tolerance.py
+++ b/tests/test_barge_in_backchannel_tolerance.py
@@ -1,0 +1,197 @@
+"""barge-in 分类("应答"与"真打断")的行为测试。
+
+被修的问题
+----------
+原先的 barge-in 是"ASR 一出词就掐断朗读"。但人在听别人说话时会一直出声
+——"嗯""对""好""哦" —— 那是**积极倾听**,不是要抢话。全当打断的结果是 AI 每讲两句就
+被"嗯"一声掐断,对话根本进行不下去。这是"边说边听"体验里最刺眼、也是纯政策层就能修的
+一处。
+
+两个方向都要守住
+----------------
+这个改动有**两种**失败方式,而且第二种更危险:
+
+1. 应答被当成打断 → AI 老被"嗯"打断(改动前的现状);
+2. **真打断被当成应答 → 用户想插话却被无视**。这个更糟:用户会以为助手坏了,而且会
+   反复大声重复。
+
+所以分类刻意保守:含任何实义内容一律判打断,只有**完全由**语义空的应答词组成、且足够短
+的才算应答。``TestRealInterruptionsAlwaysWin`` 就是为第二种失败方式立的防线。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core.voice_dialog_policy import (
+    BARGE_IN_BACKCHANNEL,
+    BARGE_IN_INTERRUPT,
+    backchannel_tolerance_enabled,
+    get_dialog_policy,
+    normalize_for_backchannel,
+    reset_dialog_policy,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_policy():
+    reset_dialog_policy()
+    yield
+    reset_dialog_policy()
+
+
+# ── 分类语义 ─────────────────────────────────────────────────────────────────
+
+
+class TestBackchannelsAreRecognised:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "嗯",
+            "嗯嗯",
+            "哦",
+            "噢",
+            "唔",
+            "对",
+            "对对",
+            "是",
+            "是的",
+            "好",
+            "好的",
+            "行",
+            "可以",
+            "明白",
+            "懂了",
+            "知道了",
+            "了解",
+            "没错",
+        ],
+    )
+    def test_chinese_backchannels(self, text):
+        assert get_dialog_policy().classify_barge_in(text) == BARGE_IN_BACKCHANNEL
+
+    @pytest.mark.parametrize("text", ["ok", "OK", "okay", "yeah", "yep", "yes", "right", "sure", "got it", "I see"])
+    def test_english_backchannels(self, text):
+        assert get_dialog_policy().classify_barge_in(text) == BARGE_IN_BACKCHANNEL
+
+    @pytest.mark.parametrize("text", ["嗯,对", "嗯嗯好的", "哦,明白", "对对对"])
+    def test_stacked_backchannels(self, text):
+        """连着说几声应答词仍是应答。"""
+        assert get_dialog_policy().classify_barge_in(text) == BARGE_IN_BACKCHANNEL
+
+    def test_punctuation_is_ignored(self):
+        """ASR 的标点极不稳定,不能参与判断。"""
+        assert normalize_for_backchannel("嗯……,") == "嗯"
+        assert get_dialog_policy().classify_barge_in("嗯……,") == BARGE_IN_BACKCHANNEL
+
+
+class TestRealInterruptionsAlwaysWin:
+    """最重要的一组:真打断被当成应答的话,用户想插话却被无视 —— 那比"老被嗯打断"更糟。"""
+
+    @pytest.mark.parametrize("text", ["停", "别说了", "别念了", "闭嘴", "打住", "stop", "shut up"])
+    def test_stop_commands_are_never_backchannels(self, text):
+        assert get_dialog_policy().classify_barge_in(text) == BARGE_IN_INTERRUPT
+
+    @pytest.mark.parametrize("text", ["等一下", "等等", "让我想想"])
+    def test_hold_commands_are_never_backchannels(self, text):
+        assert get_dialog_policy().classify_barge_in(text) == BARGE_IN_INTERRUPT
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "不是这个",
+            "帮我订一张去上海的机票",
+            "那明天呢",
+            "嗯这个不对",  # 以应答词开头,但带实义内容
+            "好的那你帮我查一下天气",  # 同上
+            "对了还有一件事",
+        ],
+    )
+    def test_anything_with_real_content_is_an_interruption(self, text):
+        assert get_dialog_policy().classify_barge_in(text) == BARGE_IN_INTERRUPT
+
+    def test_empty_text_is_an_interruption(self):
+        """判不了就按打断处理 —— 宁可多打断一次,也不要吃掉用户真的要说的话。"""
+        assert get_dialog_policy().classify_barge_in("") == BARGE_IN_INTERRUPT
+        assert get_dialog_policy().classify_barge_in("   ") == BARGE_IN_INTERRUPT
+
+    def test_long_text_is_an_interruption_even_if_words_look_like_backchannels(self):
+        from core.voice_dialog_policy import _MAX_BACKCHANNEL_CHARS
+
+        long_text = "好" * (_MAX_BACKCHANNEL_CHARS + 1)
+        assert get_dialog_policy().classify_barge_in(long_text) == BARGE_IN_INTERRUPT
+
+
+class TestToggle:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("GALAXY_VOICE_BACKCHANNEL_TOLERANCE", raising=False)
+        assert backchannel_tolerance_enabled() is True
+
+    def test_can_be_switched_off(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_VOICE_BACKCHANNEL_TOLERANCE", "0")
+        assert backchannel_tolerance_enabled() is False
+
+
+# ── 真实调用路径 ─────────────────────────────────────────────────────────────
+
+
+class TestRealCallPathOnVoiceLoop:
+    """走 ``VoiceLoop._on_voice_input`` 本体 —— 只测分类函数证明不了它接上了。"""
+
+    @staticmethod
+    def _run(text, monkeypatch, *, speaking=True):
+        """返回 ``(barge_in 次数, 送进大脑的次数)``。"""
+        import core.speech_output as so
+        from core.voice_echo_guard import reset_echo_guard
+        from core.voice_loop import VoiceLoop
+
+        interrupted: list = []
+        processed: list = []
+        monkeypatch.setattr(so, "interrupt_speech", lambda: interrupted.append(1))
+        monkeypatch.setattr(so, "is_speaking", lambda: speaking)
+
+        class _FakeGalaxy:
+            async def process(self, text, source=""):
+                processed.append(text)
+                return {"response": "ok"}
+
+        reset_echo_guard()
+
+        async def _go():
+            loop = VoiceLoop(_FakeGalaxy(), speak_responses=False)
+            loop._running = True
+            await loop._on_voice_input(text)
+
+        asyncio.run(_go())
+        reset_echo_guard()
+        return len(interrupted), len(processed)
+
+    @pytest.mark.parametrize("text", ["嗯", "好的", "对对"])
+    def test_backchannel_keeps_the_ai_talking(self, monkeypatch, text):
+        """既不掐断朗读,也不把这声"嗯"当成一个用户回合 —— 后者会让 AI 对一句语义空的
+        应答另起一段回复。"""
+        interrupted, processed = self._run(text, monkeypatch)
+        assert interrupted == 0, "应答不该掐断朗读"
+        assert processed == 0, "应答不该被当成用户回合送进大脑"
+
+    @pytest.mark.parametrize("text", ["停", "不是这个我要另一个", "帮我订一张去上海的机票"])
+    def test_real_interruption_still_stops_playback(self, monkeypatch, text):
+        interrupted, processed = self._run(text, monkeypatch)
+        assert interrupted == 1
+        assert processed == 1
+
+    def test_backchannel_when_ai_is_not_speaking_is_a_normal_turn(self, monkeypatch):
+        """AI 没在说话时,"嗯"是一个(弱)用户回合,不是应答 —— 比如 AI 刚问完
+        "要我继续吗?"、已经念完,用户答"嗯"。此时必须照常处理。"""
+        interrupted, processed = self._run("嗯", monkeypatch, speaking=False)
+        assert interrupted == 0
+        assert processed == 1, "AI 没在朗读时,应答词应作为正常回合处理"
+
+    def test_disabling_tolerance_restores_the_old_interrupt_everything_behaviour(self, monkeypatch):
+        """反向验证:关掉开关,"嗯"应恢复为打断 —— 证明这段代码是承重的。"""
+        monkeypatch.setenv("GALAXY_VOICE_BACKCHANNEL_TOLERANCE", "0")
+        interrupted, processed = self._run("嗯", monkeypatch)
+        assert interrupted == 1
+        assert processed == 1

--- a/tests/test_barge_in_backchannel_tolerance.py
+++ b/tests/test_barge_in_backchannel_tolerance.py
@@ -26,6 +26,7 @@ import asyncio
 import pytest
 
 from core.voice_dialog_policy import (
+    _HOLD_PATTERNS,
     BARGE_IN_BACKCHANNEL,
     BARGE_IN_INTERRUPT,
     backchannel_tolerance_enabled,
@@ -33,6 +34,9 @@ from core.voice_dialog_policy import (
     normalize_for_backchannel,
     reset_dialog_policy,
 )
+
+#: 含空格的多词 hold 模式 —— 正是那处死代码修复所针对的一组
+_MULTIWORD_HOLD_PATTERNS = [p for p in _HOLD_PATTERNS if " " in p]
 
 
 @pytest.fixture(autouse=True)
@@ -195,3 +199,58 @@ class TestRealCallPathOnVoiceLoop:
         interrupted, processed = self._run("嗯", monkeypatch)
         assert interrupted == 1
         assert processed == 1
+
+
+class TestHoldPatternsAreActuallyChecked:
+    """守住一处死代码修复。
+
+    ``_HOLD_PATTERNS`` 里有 6 个**含空格**的多词模式("hold on"/"let me think"/"be quiet"…)。
+    原先 ``classify_barge_in`` 拿**归一化后**(已去空格)的文本去比对它们,于是那 6 条永远
+    匹配不到 —— 一个恒为假的 ``any()``。
+
+    当时并不构成行为缺陷(那些句子都会因"含实义内容"落到 interrupt),但只要将来加进一个
+    **短的、恰好全由应答词组成**的多词 hold 口令,这道闸门就会静默失效。改成 hold/stop 类
+    模式用原始小写文本比对。
+    """
+
+    @pytest.mark.parametrize("pattern", _MULTIWORD_HOLD_PATTERNS)
+    def test_multiword_hold_patterns_match(self, pattern):
+        assert get_dialog_policy().classify_barge_in(pattern) == BARGE_IN_INTERRUPT
+
+    def test_every_hold_pattern_is_classified_as_interrupt(self):
+        """全量枚举:任何 hold 口令都不能被当成应答。"""
+        from core.voice_dialog_policy import _HOLD_PATTERNS
+
+        policy = get_dialog_policy()
+        wrong = [p for p in _HOLD_PATTERNS if policy.classify_barge_in(p) != BARGE_IN_INTERRUPT]
+        assert not wrong, f"这些 hold 口令被误判成应答: {wrong}"
+
+    @pytest.mark.parametrize("text", ["别 说 了", "闭 嘴", "打 住"])
+    def test_stop_words_still_caught_when_asr_splits_them(self, text):
+        """ASR 可能把口令断开成带空格的形式,去空格后才连成词 —— 归一化那一遍要兜住。"""
+        assert get_dialog_policy().classify_barge_in(text) == BARGE_IN_INTERRUPT
+
+    def test_a_hypothetical_backchannel_shaped_hold_command_would_be_caught(self):
+        """这条是为**将来**立的防线,也是这组里**唯一能真正判别修复在不在**的用例。
+
+        判别条件很挑:那个假想口令必须【含空格】(否则归一化前后一样,老代码也能匹配)
+        且【归一化后完全由应答词组成】(否则会因"含实义内容"落到 interrupt —— 老代码
+        照样通过,用例就白测了)。
+
+        "好 的" 正好满足:含空格,而 "好的" 本身就是应答词表里的一项。所以:
+        - 修复前:hold 检查拿去空格的 "好的" 比 "好 的",匹配不到 → 落到应答分支 →
+          判成 backchannel(**用户的 hold 口令被无视**);
+        - 修复后:hold 检查用原始文本,"好 的" 命中 → interrupt。
+
+        (这个坑我先前用 "好 了" 试过,但 "了" 不在应答词表里,于是两种实现都返回
+        interrupt,用例通过却毫无判别力 —— 反向验证时才暴露出来。)
+        """
+        import core.voice_dialog_policy as mod
+        from core.voice_dialog_policy import DialogPolicy
+
+        original = mod._HOLD_PATTERNS
+        try:
+            mod._HOLD_PATTERNS = original + ("好 的",)
+            assert DialogPolicy().classify_barge_in("好 的") == BARGE_IN_INTERRUPT
+        finally:
+            mod._HOLD_PATTERNS = original

--- a/tests/test_device_token_retention.py
+++ b/tests/test_device_token_retention.py
@@ -1,0 +1,172 @@
+"""设备 token 注册表的保留期 / 上限行为测试。
+
+被修的真实缺陷
+--------------
+``_by_hash`` 此前**无界增长**:``issue()`` 对同一 device_id 每次都新增一条记录(轮换),
+``revoke_device()`` 只把 ``revoked`` 置 True、从不删除,而 ``_persist()`` 每次把全表重写
+一遍。于是一台反复重装/换机的设备会永久留下 N 条记录 —— 存储文件单调增长,每次发放的
+落盘开销也随总条数线性上升。
+
+这里最要紧的一条不变量
+----------------------
+**淘汰只能动已吊销的记录,永不能动未吊销的。** 删掉一条还在用的记录等于悄悄把那台设备
+踢下线,而且症状是"设备突然连不上、日志里什么都没有" —— 比存储增长严重得多。所以本文件
+花最多篇幅在这一条上:活跃凭证在保留期清理、超上限收敛、以及"活跃记录本身就超上限"三种
+情形下都必须依然可用。
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from core.device_token_registry import DeviceTokenRegistry
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    """每个用例一个独立存储文件,避免用例间互相看到对方的记录。"""
+    monkeypatch.setenv("GALAXY_DEVICE_TOKEN_STORE", str(tmp_path / "device_tokens.json"))
+    monkeypatch.delenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", raising=False)
+    monkeypatch.delenv("GALAXY_DEVICE_TOKEN_MAX_RECORDS", raising=False)
+    return DeviceTokenRegistry()
+
+
+class TestRetentionOfRevokedRecords:
+    def test_revoked_records_are_kept_within_the_retention_window(self, registry):
+        """保留期内不清 —— 已吊销记录的价值就是审计:``list_devices`` 要能显示
+        "这台设备的凭证曾在什么时候被吊销"。"""
+        for i in range(5):
+            registry.issue("dev-1", name=f"phone-try-{i}")
+            registry.revoke_device("dev-1")
+        assert len(registry._by_hash) == 5
+        assert all(d["revoked"] for d in registry.list_devices())
+
+    def test_revoked_records_are_purged_once_the_window_passes(self, registry, monkeypatch):
+        registry.issue("dev-1")
+        registry.revoke_device("dev-1")
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", "0")
+        assert registry.prune() == 1
+        assert len(registry._by_hash) == 0
+
+    def test_retention_is_measured_from_revocation_not_issuance(self, registry, monkeypatch):
+        """按吊销时刻计时:一条发放很久、刚刚才被吊销的记录,不该立刻消失 ——
+        刚吊销的那条恰恰是审计最想看到的。"""
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", "1")
+        registry.issue("dev-old")
+        for rec in registry._by_hash.values():
+            rec["issued_at"] = time.time() - 90 * 86400  # 90 天前发放
+        registry.revoke_device("dev-old")  # 但是刚刚才吊销
+        assert registry.prune() == 0
+        assert len(registry._by_hash) == 1
+
+    def test_missing_revoked_at_falls_back_to_issued_at(self, registry, monkeypatch):
+        """手改过存储/老版本数据可能缺 revoked_at。不能因为字段缺失就永远清不掉,
+        也不能因此把记录误判成"刚吊销"而永久堆积。"""
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", "1")
+        registry.issue("dev-legacy")
+        for rec in registry._by_hash.values():
+            rec["revoked"] = True
+            rec["revoked_at"] = None
+            rec["issued_at"] = time.time() - 90 * 86400
+        assert registry.prune() == 1
+
+
+class TestLiveCredentialsAreNeverEvicted:
+    """这一组是最重要的:淘汰逻辑绝不能让一台在用的设备突然掉线。"""
+
+    def test_retention_purge_leaves_live_tokens_usable(self, registry, monkeypatch):
+        live = registry.issue("dev-live", name="in use")
+        registry.issue("dev-gone")
+        registry.revoke_device("dev-gone")
+
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", "0")
+        registry.prune()
+
+        assert registry.verify(live) is not None, "在用凭证被清掉了 —— 设备会突然掉线"
+
+    def test_cap_evicts_revoked_records_only(self, registry, monkeypatch):
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_MAX_RECORDS", "3")
+        live = registry.issue("dev-live")
+        for i in range(5):
+            registry.issue(f"dev-old-{i}")
+            registry.revoke_device(f"dev-old-{i}")
+
+        assert registry.verify(live) is not None
+        assert len(registry._by_hash) <= 3
+
+    def test_live_records_beyond_the_cap_are_kept_and_warned_about(self, registry, monkeypatch, caplog):
+        """活跃记录本身就超上限时:一条都不能删,而且必须**看得见** ——
+        静默地把存储涨下去、或者静默删一条 working 凭证,两种都不可接受。"""
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_MAX_RECORDS", "3")
+        with caplog.at_level("WARNING"):
+            tokens = [registry.issue(f"dev-live-{i}") for i in range(5)]
+
+        assert len(registry._by_hash) == 5, "未吊销记录一条都不能被淘汰"
+        assert all(registry.verify(t) is not None for t in tokens)
+        assert "不会自动淘汰在用凭证" in caplog.text
+
+    def test_oldest_revoked_are_evicted_first(self, registry, monkeypatch):
+        """超上限时先淘汰最老的已吊销记录,保留较近的(审计价值随时间衰减)。"""
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_MAX_RECORDS", "2")
+        for i in range(4):
+            registry.issue(f"dev-{i}")
+            registry.revoke_device(f"dev-{i}")
+            for rec in registry._by_hash.values():
+                if rec["device_id"] == f"dev-{i}":
+                    rec["revoked_at"] = 1000.0 + i  # 递增:i 越大越新
+
+        remaining = {r["device_id"] for r in registry.list_devices()}
+        assert len(remaining) <= 2
+        assert "dev-0" not in remaining, "最老的应先被淘汰"
+
+
+class TestPruningIsWiredIn:
+    def test_issue_prunes_so_growth_is_bounded(self, registry, monkeypatch):
+        """发放是唯一的增长点,清理必须挂在那里 —— 否则要等到有人显式调 prune()
+        才收敛,而生产上没人会去调。"""
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", "0")
+        for i in range(20):
+            registry.issue("dev-reinstall", name=f"try-{i}")
+            registry.revoke_device("dev-reinstall")
+        # 每轮发放时都会清掉上一轮那条刚吊销的记录(保留期 0)
+        assert len(registry._by_hash) <= 2, f"发放路径没有收敛,现有 {len(registry._by_hash)} 条"
+
+    def test_load_prunes_on_restart(self, tmp_path, monkeypatch):
+        """进程重启是清理的自然时机;不该非得等到下一次发放。"""
+        store = tmp_path / "device_tokens.json"
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_STORE", str(store))
+        monkeypatch.delenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", raising=False)
+
+        first = DeviceTokenRegistry()
+        first.issue("dev-1")
+        first.revoke_device("dev-1")
+        assert len(first._by_hash) == 1
+
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", "0")
+        reloaded = DeviceTokenRegistry()  # 重新从磁盘加载
+        assert len(reloaded._by_hash) == 0
+
+
+class TestConfigParsing:
+    @pytest.mark.parametrize("bad", ["abc", "", "  "])
+    def test_bad_retention_value_falls_back_to_default(self, monkeypatch, bad):
+        from core.device_token_registry import _DEFAULT_RETENTION_DAYS, _retention_seconds
+
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_RETENTION_DAYS", bad)
+        assert _retention_seconds() == pytest.approx(_DEFAULT_RETENTION_DAYS * 86400.0)
+
+    @pytest.mark.parametrize("bad", ["abc", "", "  "])
+    def test_bad_cap_value_falls_back_to_default(self, monkeypatch, bad):
+        from core.device_token_registry import _DEFAULT_MAX_RECORDS, _max_records
+
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_MAX_RECORDS", bad)
+        assert _max_records() == _DEFAULT_MAX_RECORDS
+
+    def test_cap_of_zero_is_clamped_to_one(self, monkeypatch):
+        """上限 0 会让每次发放都立刻自我淘汰 —— 收敛到 1,不接受"发了就没了"。"""
+        from core.device_token_registry import _max_records
+
+        monkeypatch.setenv("GALAXY_DEVICE_TOKEN_MAX_RECORDS", "0")
+        assert _max_records() == 1

--- a/tests/test_hitl_policy_decide_is_exclusive.py
+++ b/tests/test_hitl_policy_decide_is_exclusive.py
@@ -1,0 +1,142 @@
+"""``HITLPolicy.decide`` 的并发独占性测试。
+
+被修的真实缺陷
+--------------
+``decide()`` 此前把"查到待审批"和"摘走待审批"分成两次持锁:先 ``get``、释放锁、走完
+整段裁决(构造 HITLDecision、写 ``req.decision``)、再取锁 ``pop``。中间那段空隙里,
+另一个线程可以 ``get`` 到**同一个**非 None 的 ``req``,于是同一条人工审批被裁决两次:
+
+- ``_history`` 落两条记录(审计轨迹里同一次审批出现两遍);
+- ``_emit_event`` 发两次事件;
+- ``req.decision`` 取决于哪个线程最后写 —— 若两次裁决方向相反(面板点了通过、接口同时
+  调了拒绝,或者用户双击了确认按钮),最终生效的是哪个是**不确定的**。
+
+这是"人工确认"这道闸门本身的完整性问题:一条高危操作的审批结果不能取决于线程调度。
+
+修复:``pop`` 与查询在同一次持锁内完成,摘到 ``req`` 即等于独占地领走这条审批;
+后到的线程拿到 None,如实返回"没有这条待审批"。
+
+复现说明
+--------
+这个窗口很窄:CPython 默认 5ms 的 GIL 切换间隔下,一个线程通常能在一个时间片内跑完
+``get``→``pop``,所以按默认设置压测**测不出来**(实测 200 轮 0 次)。把切换间隔压到
+1e-6 并提到 4 线程竞争后稳定复现(实测修复前 400 轮命中 12 次、修复后 0 次)。
+"下压切换间隔" 不是"制造一个不存在的问题",它只是把真实机器上由 IO、GC、更多线程和
+更慢的锁竞争自然造成的调度切换,压缩到测试能观测的时间尺度里。
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+
+import pytest
+
+from core.policy.hitl_policy import HITLMode, HITLPolicy
+
+#: 竞争线程数与压测轮数(够稳定复现,又不至于让用例变慢)
+_THREADS = 4
+_ROUNDS = 200
+
+
+@pytest.fixture
+def force_thread_switching():
+    """把 GIL 切换间隔压到极小,让窄窗口在测试里可观测;结束后原样恢复。"""
+    original = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        yield
+    finally:
+        sys.setswitchinterval(original)
+
+
+@pytest.fixture
+def quiet_logs():
+    """裁决竞争会刷出大量 "unknown request_id" 警告(那正是预期行为),压掉噪声。"""
+    logger = logging.getLogger("core.policy.hitl_policy")
+    original = logger.level
+    logger.setLevel(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logger.setLevel(original)
+
+
+def _pending_request_id(policy: HITLPolicy) -> str:
+    policy.evaluate(action="rm -rf /", session_id="s1")
+    pending = policy.pending_requests()
+    assert pending, "前提:MANUAL 模式下应产生一条待审批"
+    return pending[0].request_id
+
+
+def _decide_concurrently(policy: HITLPolicy, request_id: str, n: int) -> list:
+    """让 n 个线程在同一时刻裁决同一条审批,返回各自的返回值。"""
+    barrier = threading.Barrier(n)
+    results: list = []
+    lock = threading.Lock()
+
+    def _worker(approve: bool) -> None:
+        barrier.wait()
+        outcome = policy.decide(request_id, approve, decided_by=f"t{approve}")
+        with lock:
+            results.append(outcome)
+
+    threads = [threading.Thread(target=_worker, args=(bool(i % 2),)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return results
+
+
+class TestOnlyOneCallerCanDecideARequest:
+    def test_single_winner_under_contention(self, force_thread_switching, quiet_logs):
+        """N 个线程同时裁决同一条审批 —— 只能有一个成功,history 只能落一条。
+
+        断言的是**每一轮**都成立,而不是"大多数轮成立":审计轨迹里出现重复审批,一次
+        就已经是错的。
+        """
+        for round_no in range(_ROUNDS):
+            policy = HITLPolicy(mode=HITLMode.MANUAL)
+            request_id = _pending_request_id(policy)
+
+            results = _decide_concurrently(policy, request_id, _THREADS)
+
+            winners = [r for r in results if r is not None]
+            assert len(winners) == 1, f"第 {round_no} 轮:{len(winners)} 个线程都裁决成功了"
+            assert len(policy._history) == 1, f"第 {round_no} 轮:history 落了 {len(policy._history)} 条"
+
+    def test_the_winner_is_the_decision_that_takes_effect(self, force_thread_switching, quiet_logs):
+        """胜出线程写进 req.decision 的结果,必须与它返回的裁决一致 —— 不能被落败线程
+        覆盖成相反方向。"""
+        for _ in range(_ROUNDS):
+            policy = HITLPolicy(mode=HITLMode.MANUAL)
+            request_id = _pending_request_id(policy)
+
+            results = _decide_concurrently(policy, request_id, _THREADS)
+            winner = next(r for r in results if r is not None)
+
+            assert policy._history[0] is winner
+            assert policy._history[0].approved == winner.approved
+
+    def test_request_is_removed_from_pending(self):
+        policy = HITLPolicy(mode=HITLMode.MANUAL)
+        request_id = _pending_request_id(policy)
+
+        assert policy.decide(request_id, True) is not None
+        assert all(r.request_id != request_id for r in policy.pending_requests())
+
+    def test_deciding_twice_sequentially_returns_none_the_second_time(self, quiet_logs):
+        """顺序调用也必须只认第一次 —— 用户双击确认按钮就是这个场景。"""
+        policy = HITLPolicy(mode=HITLMode.MANUAL)
+        request_id = _pending_request_id(policy)
+
+        assert policy.decide(request_id, True, decided_by="first") is not None
+        assert policy.decide(request_id, False, decided_by="second") is None
+        assert len(policy._history) == 1
+        assert policy._history[0].approved is True, "第二次(相反方向的)裁决不能覆盖第一次"
+
+    def test_unknown_request_id_is_rejected(self, quiet_logs):
+        policy = HITLPolicy(mode=HITLMode.MANUAL)
+        assert policy.decide("hitl_does_not_exist", True) is None

--- a/tests/test_system_audio_capture_and_aec_wiring.py
+++ b/tests/test_system_audio_capture_and_aec_wiring.py
@@ -321,3 +321,96 @@ class TestBlockFanoutHonoursPrivacyAndBounds:
         svc = self._svc()
         for bad in (None, "garbage", np.zeros(0)):
             svc._on_block(bad)  # type: ignore[arg-type]
+
+
+class TestBufferNeverCrossesThePrivacyBoundary:
+    """实测过的真实泄露:``pause()`` 只清感知库自己的缓存,**碰不到**采集服务的待送缓冲。
+    于是"采几秒 → 暂停 → 恢复"之后,那段**暂停之前**攒的音频会被原样送进感知库。
+    若暂停期间回环流本就没有新块(扬声器静音),连"看见 paused 再清"的机会都没有。
+
+    修复用感知库的 ``epoch`` 世代号:它在每次 pause/resume 都自增,所以"暂停过"这件事
+    在恢复之后依然可见 —— 这正是 ``epoch`` 当初为 ambient 帧差指纹设计的用途。
+    """
+
+    def _svc(self, snapshot_sec):
+        from core.multimodal.system_audio_capture_service import (
+            SystemAudioCaptureService,
+        )
+
+        return SystemAudioCaptureService(sample_rate=SR, snapshot_sec=snapshot_sec)
+
+    def test_audio_buffered_before_a_pause_is_not_delivered_after_resume(self):
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        store = get_desktop_perception_store()
+        store.resume("test-setup")
+        svc = self._svc(snapshot_sec=10**6)  # 永不自动送出,只攒
+        block = np.ones(BLK, dtype=np.float32) * 0.1
+        for _ in range(5):
+            svc._on_block(block)
+        assert svc.status()["buffered_samples"] > 0, "前提:暂停前确实攒了音频"
+
+        store.pause("user")
+        store.resume("user")
+
+        svc.snapshot_sec = 0.0  # 现在每块都会送
+        before = store.status()["system_audio_received"]
+        svc._on_block(block)
+        after = store.status()["system_audio_received"]
+
+        assert svc.status()["buffers_dropped_epoch"] >= 1, "跨越隐私边界的缓冲没有被丢弃"
+        # 送出去的那一段只能是"恢复之后"这一块,不含暂停前的 5 块
+        assert after == before + 1
+        assert svc.status()["buffered_samples"] == 0
+
+    def test_pause_alone_also_invalidates_the_buffer(self):
+        """只暂停、还没恢复时也要作废 —— epoch 已经变了。"""
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        store = get_desktop_perception_store()
+        store.resume("test-setup")
+        svc = self._svc(snapshot_sec=10**6)
+        for _ in range(3):
+            svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        store.pause("user")
+        try:
+            svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+            assert svc.status()["buffered_samples"] == 0
+            assert svc.status()["buffers_dropped_epoch"] >= 1
+        finally:
+            store.resume("test")
+
+    def test_no_spurious_drop_on_the_first_block(self):
+        """世代号初始化成当前值,首块不该白丢一次(否则每次新建服务都少一段音频)。"""
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        get_desktop_perception_store().resume("test-setup")
+        svc = self._svc(snapshot_sec=10**6)
+        svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        assert svc.status()["buffers_dropped_epoch"] == 0
+        assert svc.status()["buffered_samples"] == BLK
+
+    def test_unreadable_epoch_is_treated_as_changed(self, monkeypatch):
+        """读不到世代号时按【已变化】处理(丢缓冲)—— 与 fail-closed 的隐私判定一致。"""
+        import core.perception.desktop_perception_store as store_mod
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        get_desktop_perception_store().resume("test-setup")
+        svc = self._svc(snapshot_sec=10**6)
+        svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        assert svc.status()["buffered_samples"] > 0
+
+        def _boom():
+            raise RuntimeError("injected")
+
+        monkeypatch.setattr(store_mod, "get_desktop_perception_store", _boom)
+        svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        assert svc.status()["buffered_samples"] == 0

--- a/tests/test_system_audio_capture_and_aec_wiring.py
+++ b/tests/test_system_audio_capture_and_aec_wiring.py
@@ -1,0 +1,323 @@
+"""回环采集服务 + AEC 接线的行为测试。
+
+本文件的重点是**接线**,不是算法
+--------------------------------
+AEC 的算法效果由 ``tests/test_acoustic_echo_cancellation.py`` 单独钉。这里钉的是另一件
+同样容易出错、而且出错时更难发现的事:**它到底有没有真的接在链路上**。
+
+一个"装配好了但没人调用"的 AEC 的症状是:什么都不报错、日志一片安静、回声照旧存在。
+所以这里的核心用例是 ``TestAecIsActuallyWiredIntoTheMicPath`` —— 它走
+``AudioIngestPipeline._process_chunk`` 本体,断言**下游回调真的拿到了去回声后的信号**。
+只测"AEC 类本身好用"完全测不出接线断掉。
+
+同理,``ensure_started`` 的存在也是为了防这一类问题:AEC 没有参考信号时会一直走
+``reference_silent`` 旁通 —— 完全静默地什么也不做。所以麦克风链路启动时要顺手把回环
+采集拉起来,而不是指望有人在别处编排好。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import wave
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+SR = 16000
+BLK = 1600
+NB = 120
+
+
+def _echo_scenario():
+    """已知回声路径:参考信号 → 卷积 RIR → 加 50ms 整体时延 → 麦克风信号。"""
+    rng = np.random.default_rng(7)
+    h = rng.standard_normal(400) * np.exp(-np.arange(400) / 60.0)
+    h = h / (np.abs(h).sum() + 1e-9) * 0.8
+    x = rng.standard_normal(NB * BLK)
+    win = np.hanning(64) / np.hanning(64).sum()
+    ref = np.convolve(x, win, "same") * (0.5 + 0.5 * np.sin(2 * np.pi * np.arange(NB * BLK) / (SR * 0.7)))
+    mic = np.concatenate([np.zeros(800), np.convolve(ref, h)[: ref.size]])[: ref.size]
+    return mic, ref
+
+
+def _erle_db(mic, err) -> float:
+    return float(10 * np.log10((mic @ mic + 1e-12) / (err @ err + 1e-12)))
+
+
+@pytest.fixture(autouse=True)
+def _clean_singletons():
+    from core.multimodal.acoustic_echo_canceller import reset_echo_canceller
+    from core.multimodal.system_audio_capture_service import reset_system_audio_capture
+
+    reset_echo_canceller()
+    reset_system_audio_capture()
+    yield
+    reset_echo_canceller()
+    reset_system_audio_capture()
+
+
+# ── 接线:AEC 真的在 VAD 之前生效了吗 ──────────────────────────────────────
+
+
+class TestAecIsActuallyWiredIntoTheMicPath:
+    """走 ``AudioIngestPipeline._process_chunk`` 本体。
+
+    "AEC 类本身好用"和"AEC 接在链路上"是两件事,后者断掉时症状是完全静默的:不报错、
+    不打日志、回声照旧。所以必须从链路入口喂进去、从链路出口断言。
+    """
+
+    def test_downstream_callbacks_receive_echo_cancelled_audio(self):
+        from core.multimodal.acoustic_echo_canceller import get_echo_canceller
+        from core.multimodal.audio_ingest import AudioIngestConfig, AudioIngestPipeline
+
+        mic, ref = _echo_scenario()
+        aec = get_echo_canceller(SR)
+        pipe = AudioIngestPipeline(AudioIngestConfig(sample_rate=SR, chunk_duration_ms=100))
+        seen: list = []
+        pipe.add_callback(lambda st, q: seen.append(st.samples.copy()))
+
+        async def _go():
+            for i in range(NB):
+                aec.push_reference(ref[i * BLK : (i + 1) * BLK])
+                await pipe._process_chunk(mic[i * BLK : (i + 1) * BLK].astype(np.float32))
+
+        asyncio.run(_go())
+
+        got = np.concatenate(seen)
+        q = got.size * 3 // 4
+        erle = _erle_db(mic[: got.size][q:], got[q:])
+        assert erle > 15.0, f"下游只拿到 {erle:.1f} dB 的抑制 —— AEC 没有真正接在 VAD 之前"
+
+    def test_mic_path_is_unharmed_when_there_is_no_reference(self):
+        """没有回环设备的机器上(参考信号恒为空),麦克风信号必须原样通过。
+
+        这是最常见的部署情形(Linux 无 monitor 源、macOS、未装 sounddevice),
+        绝不能因为接了 AEC 就把这些机器的语音链路弄坏。
+        """
+        from core.multimodal.audio_ingest import AudioIngestConfig, AudioIngestPipeline
+
+        mic, _ref = _echo_scenario()
+        pipe = AudioIngestPipeline(AudioIngestConfig(sample_rate=SR, chunk_duration_ms=100))
+        seen: list = []
+        pipe.add_callback(lambda st, q: seen.append(st.samples.copy()))
+
+        async def _go():
+            for i in range(10):
+                await pipe._process_chunk(mic[i * BLK : (i + 1) * BLK].astype(np.float32))
+
+        asyncio.run(_go())
+        got = np.concatenate(seen)
+        assert np.allclose(got, mic[: got.size], atol=1e-6), "无参考信号时不该改动麦克风信号"
+
+    def test_aec_failure_does_not_break_the_mic_path(self, monkeypatch):
+        """AEC 内部炸了,上行语音通路也必须继续 —— 留着回声远好过彻底聋掉。"""
+        import core.multimodal.acoustic_echo_canceller as aec_mod
+        from core.multimodal.audio_ingest import AudioIngestConfig, AudioIngestPipeline
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("injected")
+
+        monkeypatch.setattr(aec_mod, "get_echo_canceller", _boom)
+        mic, _ = _echo_scenario()
+        pipe = AudioIngestPipeline(AudioIngestConfig(sample_rate=SR, chunk_duration_ms=100))
+        seen: list = []
+        pipe.add_callback(lambda st, q: seen.append(st.samples.copy()))
+        asyncio.run(pipe._process_chunk(mic[:BLK].astype(np.float32)))
+        assert len(seen) == 1
+        assert np.allclose(seen[0], mic[:BLK], atol=1e-6)
+
+
+# ── 回环采集服务 ───────────────────────────────────────────────────────────
+
+
+class TestWavEncoding:
+    def test_roundtrips_as_16bit_mono_wav(self):
+        from core.multimodal.system_audio_capture_service import pcm_to_wav_base64
+
+        pcm = (np.sin(2 * np.pi * 440 * np.arange(SR) / SR) * 0.5).astype(np.float32)
+        raw = base64.b64decode(pcm_to_wav_base64(pcm, SR))
+        with wave.open(io.BytesIO(raw)) as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getframerate() == SR
+            assert wf.getnframes() == SR
+
+    def test_empty_pcm_yields_empty_string(self):
+        from core.multimodal.system_audio_capture_service import pcm_to_wav_base64
+
+        assert pcm_to_wav_base64(np.zeros(0), SR) == ""
+
+    def test_clipping_does_not_wrap_around(self):
+        """超幅样本必须限幅,不能在转 int16 时溢出翻成反相 —— 那会变成刺耳的爆音,
+        而且作为 AEC 参考信号会直接把滤波器带歪。"""
+        from core.multimodal.system_audio_capture_service import pcm_to_wav_base64
+
+        pcm = np.array([5.0, -5.0], dtype=np.float32)
+        raw = base64.b64decode(pcm_to_wav_base64(pcm, SR))
+        with wave.open(io.BytesIO(raw)) as wf:
+            vals = np.frombuffer(wf.readframes(2), dtype="<i2")
+        assert vals[0] > 0 and vals[1] < 0, f"限幅失效,发生了溢出翻转: {vals}"
+
+
+class TestCaptureServiceDegradation:
+    def test_start_returns_false_with_a_reason_when_unavailable(self):
+        """本环境没有 sounddevice。``start()`` 必须如实返回 False 并给出原因,
+        不能抛异常、也不能假装启动成功。"""
+        from core.multimodal.system_audio_capture_service import (
+            SystemAudioCaptureService,
+        )
+
+        svc = SystemAudioCaptureService(sample_rate=SR)
+        assert asyncio.run(svc.start()) is False
+        status = svc.status()
+        assert status["running"] is False
+        assert status["unavailable_reason"], "不可用时必须给出原因"
+
+    def test_disabled_by_env(self, monkeypatch):
+        from core.multimodal.system_audio_capture_service import (
+            SystemAudioCaptureService,
+        )
+
+        monkeypatch.setenv("GALAXY_SYSTEM_AUDIO_CAPTURE", "0")
+        svc = SystemAudioCaptureService(sample_rate=SR)
+        assert asyncio.run(svc.start()) is False
+        assert svc.status()["unavailable_reason"] == "disabled_by_env"
+
+    def test_enabled_by_default(self, monkeypatch):
+        from core.multimodal.system_audio_capture_service import enabled
+
+        monkeypatch.delenv("GALAXY_SYSTEM_AUDIO_CAPTURE", raising=False)
+        assert enabled() is True
+
+    def test_stop_is_idempotent_and_never_raises(self):
+        from core.multimodal.system_audio_capture_service import (
+            SystemAudioCaptureService,
+        )
+
+        svc = SystemAudioCaptureService(sample_rate=SR)
+        asyncio.run(svc.stop())
+        asyncio.run(svc.stop())
+
+    def test_ensure_started_without_event_loop_is_safe(self):
+        """同步上下文里调用不能抛 —— 麦克风链路可能在没有事件循环的地方初始化。"""
+        from core.multimodal.system_audio_capture_service import ensure_started
+
+        ensure_started(SR)  # 无运行中事件循环,应静默跳过
+
+    def test_singleton_rebuilt_on_sample_rate_change(self):
+        from core.multimodal.system_audio_capture_service import (
+            get_system_audio_capture,
+        )
+
+        a = get_system_audio_capture(16000)
+        assert get_system_audio_capture(16000) is a
+        b = get_system_audio_capture(48000)
+        assert b is not a and b.sample_rate == 48000
+
+
+class TestBlockFanoutHonoursPrivacyAndBounds:
+    """``_on_block`` 是回环采集的分发点。这里直接驱动它 —— 不需要真实音频设备。"""
+
+    def _svc(self):
+        from core.multimodal.system_audio_capture_service import (
+            SystemAudioCaptureService,
+        )
+
+        return SystemAudioCaptureService(sample_rate=SR, snapshot_sec=0.0)
+
+    def test_reference_is_pushed_to_the_aec(self):
+        from core.multimodal.acoustic_echo_canceller import get_echo_canceller
+
+        svc = self._svc()
+        svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        assert svc.status()["ref_pushed"] == 1
+        # 参考真的进了 AEC 的历史缓冲(不是只加了个计数器)
+        aec = get_echo_canceller(SR)
+        assert float(np.max(np.abs(aec._ref_buf))) > 0.0
+
+    def test_snapshot_reaches_the_perception_store(self):
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        store = get_desktop_perception_store()
+        store.resume("test-setup")
+        before = store.status()["system_audio_received"]
+        svc = self._svc()  # snapshot_sec=0 → 每块都送
+        svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        assert store.status()["system_audio_received"] == before + 1
+        assert svc.status()["snapshots_pushed"] == 1
+
+    def test_nothing_is_captured_while_privacy_is_paused(self):
+        """暂停期间不是"采了不用",而是**连缓冲都不放** —— 否则恢复后会一次性把暂停
+        期间的内容送出去,那正是隐私急停要避免的事。"""
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        store = get_desktop_perception_store()
+        store.pause("test")
+        try:
+            svc = self._svc()
+            svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+            s = svc.status()
+            assert s["blocks_dropped_paused"] == 1
+            assert s["ref_pushed"] == 0, "暂停期间连 AEC 参考信号也不该推"
+            assert s["buffered_samples"] == 0, "暂停期间不该留任何缓冲"
+        finally:
+            store.resume("test")
+
+    def test_privacy_state_unreadable_is_treated_as_paused(self, monkeypatch):
+        """fail-closed:读不到隐私状态时按【已暂停】处理。这里刻意与仓库其它地方的
+        fail-open 相反 —— 判断不了就继续采系统声,等于拿用户正在听的全部内容赌一个
+        未知状态。"""
+        import core.perception.desktop_perception_store as store_mod
+
+        def _boom():
+            raise RuntimeError("injected")
+
+        monkeypatch.setattr(store_mod, "get_desktop_perception_store", _boom)
+        svc = self._svc()
+        svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        assert svc.status()["blocks_dropped_paused"] == 1
+        assert svc.status()["ref_pushed"] == 0
+
+    def test_buffer_is_bounded_when_perception_never_drains(self):
+        """感知库不可用时缓冲不能无界增长。"""
+        from core.multimodal.system_audio_capture_service import (
+            _MAX_BUFFER_SEC,
+            SystemAudioCaptureService,
+        )
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        get_desktop_perception_store().resume("test-setup")
+        # snapshot_sec 很大 → 永不触发编码送出,只会一直攒
+        svc = SystemAudioCaptureService(sample_rate=SR, snapshot_sec=10**6)
+        for _ in range(int(_MAX_BUFFER_SEC * 3)):
+            svc._on_block(np.ones(SR, dtype=np.float32) * 0.1)  # 每块 1 秒
+        assert svc.status()["buffered_samples"] <= int(_MAX_BUFFER_SEC * SR)
+
+    def test_perception_feed_can_be_disabled_independently(self, monkeypatch):
+        """只要回声消除、不想让模型听见系统声 —— 两个开关必须能分开。"""
+        from core.perception.desktop_perception_store import (
+            get_desktop_perception_store,
+        )
+
+        monkeypatch.setenv("GALAXY_SYSTEM_AUDIO_TO_PERCEPTION", "0")
+        store = get_desktop_perception_store()
+        store.resume("test-setup")
+        before = store.status()["system_audio_received"]
+        svc = self._svc()
+        svc._on_block(np.ones(BLK, dtype=np.float32) * 0.1)
+        assert svc.status()["ref_pushed"] == 1, "AEC 参考信号仍应照常推"
+        assert store.status()["system_audio_received"] == before, "不该送进感知库"
+
+    def test_block_fanout_never_raises(self):
+        svc = self._svc()
+        for bad in (None, "garbage", np.zeros(0)):
+            svc._on_block(bad)  # type: ignore[arg-type]

--- a/tests/test_system_audio_perception.py
+++ b/tests/test_system_audio_perception.py
@@ -329,3 +329,46 @@ class TestRoutes:
         assert "system_audio_received" in store_status
         assert "system_audio_fresh" in store_status
         assert "system_audio_age_sec" in store_status
+
+
+class TestInternalErrorsDoNotLeakImplementationDetail:
+    """把 ``str(exc)`` 回给调用方会泄露文件路径、模块名等实现细节
+    (CodeQL "Information exposure through an exception")。
+
+    响应里只能有稳定的 ``error_code``;真正的堆栈用 ``exc_info=True`` 留在服务端日志里 ——
+    排查能力不打折,但不经由 HTTP 响应外泄。
+    """
+
+    _SECRETY = "/home/somebody/private/module.py 内部细节"
+
+    def test_ingest_error_response_carries_no_exception_text(self, client, monkeypatch, caplog):
+        import core.perception.desktop_perception_store as store_mod
+
+        def _boom():
+            raise RuntimeError(self._SECRETY)
+
+        monkeypatch.setattr(store_mod, "get_desktop_perception_store", _boom)
+        with caplog.at_level("ERROR"):
+            body = client.post("/api/perception/desktop/system_audio", json={"audio_base64": "A"}).json()
+
+        assert body["success"] is False
+        assert body["error_code"] == "system_audio_ingest"
+        assert self._SECRETY not in str(body)
+        assert "/home/" not in str(body)
+        assert self._SECRETY in caplog.text, "细节必须仍然留在服务端日志里,否则等于丢了排查能力"
+
+    def test_probe_error_response_carries_no_exception_text(self, client, monkeypatch, caplog):
+        import core.multimodal.system_audio_ingest as ingest_mod
+
+        def _boom():
+            raise RuntimeError(self._SECRETY)
+
+        monkeypatch.setattr(ingest_mod, "probe", _boom)
+        with caplog.at_level("ERROR"):
+            body = client.get("/api/perception/desktop/system_audio/probe").json()
+
+        assert body["success"] is False
+        assert body["available"] is False, "探测失败必须明确回不可用,不能含糊"
+        assert body["error_code"] == "system_audio_probe"
+        assert self._SECRETY not in str(body)
+        assert self._SECRETY in caplog.text

--- a/tests/test_system_audio_perception.py
+++ b/tests/test_system_audio_perception.py
@@ -1,0 +1,331 @@
+"""系统播放声(回环)采集 + 感知库独立槽位的行为测试。
+
+为什么这一路必须存在、而且必须单独存在
+--------------------------------------
+麦克风回答"用户说了什么";系统播放声回答"用户此刻在听什么"(视频/网课/游戏/会议)。
+两者语义完全不同,合成一槽会互相覆盖,而且一旦混流就再也分不出"这段声音是人说的还是
+扬声器放的"—— 那恰恰是模型最需要区分的一件事,也是反自激励门存在的原因。
+
+这一路无法从浏览器侧拿到:``getUserMedia`` 只给输入设备,``getDisplayMedia`` 要每次
+手动选窗口且跨浏览器支持残缺。所以只能在电脑端本机采集。**这是能力差异,不是性能
+优化。**
+
+本文件的两个重点
+----------------
+1. **设备解析逻辑**抽成了纯函数,可以用假设备表完整覆盖 —— 不必等到有 Windows 机器
+   才能验证"到底会挑中哪个设备、挑不中时给什么原因"。
+2. **新槽位没有绕过隐私闸门。** 系统声比麦克风更敏感(等于把用户正在听的一切完整送
+   出去),所以每条写路径和读路径都必须逐条断言,而不是相信"它应该也被挡住了"。
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from core.multimodal.system_audio_ingest import (
+    REASON_NO_LOOPBACK_DEVICE,
+    REASON_NO_WASAPI_HOSTAPI,
+    REASON_NO_WASAPI_SUPPORT,
+    REASON_OK,
+    REASON_UNSUPPORTED_OS,
+    downmix_to_mono,
+    probe,
+    resolve_loopback_target,
+)
+
+# ── 假设备表(形状与 sounddevice 的 query_devices()/query_hostapis() 一致)──────
+
+WIN_HOSTAPIS = [
+    {"name": "MME", "default_output_device": 4},
+    {"name": "Windows WASAPI", "default_output_device": 7, "default_input_device": 6},
+]
+WIN_DEVICES = [
+    {"name": "Mic (MME)", "hostapi": 0, "max_input_channels": 2, "max_output_channels": 0},
+    {"name": "out-a", "hostapi": 0, "max_input_channels": 0, "max_output_channels": 2},
+    {"name": "out-b", "hostapi": 0, "max_input_channels": 0, "max_output_channels": 2},
+    {"name": "out-c", "hostapi": 0, "max_input_channels": 0, "max_output_channels": 2},
+    {"name": "Speakers (MME)", "hostapi": 0, "max_input_channels": 0, "max_output_channels": 2},
+    {"name": "Other WASAPI out", "hostapi": 1, "max_input_channels": 0, "max_output_channels": 2},
+    {"name": "Microphone (WASAPI)", "hostapi": 1, "max_input_channels": 2, "max_output_channels": 0},
+    {"name": "Speakers (Realtek) WASAPI", "hostapi": 1, "max_input_channels": 0, "max_output_channels": 2},
+]
+LINUX_HOSTAPIS = [{"name": "ALSA"}]
+LINUX_DEVICES = [
+    {"name": "HDA Intel PCH", "hostapi": 0, "max_input_channels": 2, "max_output_channels": 0},
+    {
+        "name": "Monitor of Built-in Audio Analog Stereo",
+        "hostapi": 0,
+        "max_input_channels": 2,
+        "max_output_channels": 0,
+    },
+]
+
+
+class TestDeviceResolutionOnWindows:
+    def test_picks_the_wasapi_default_output_device(self):
+        """回环要打开的是【输出】设备,而且应当优先默认输出 —— 那才是用户真正在听的
+        那一个。挑错设备的症状是"采到一片静音",极难排查。"""
+        target, reason = resolve_loopback_target(WIN_DEVICES, WIN_HOSTAPIS, os_name="Windows", has_wasapi_settings=True)
+        assert reason == REASON_OK
+        assert target is not None
+        assert target.device == 7, "必须是 WASAPI hostapi 的默认输出设备"
+        assert target.needs_wasapi_loopback is True
+        assert WIN_DEVICES[target.device]["max_output_channels"] > 0
+
+    def test_falls_back_to_enumeration_when_there_is_no_default_output(self):
+        hostapis = [{"name": "MME"}, {"name": "Windows WASAPI", "default_output_device": -1}]
+        target, reason = resolve_loopback_target(WIN_DEVICES, hostapis, os_name="Windows", has_wasapi_settings=True)
+        assert reason == REASON_OK
+        assert target is not None
+        assert WIN_DEVICES[target.device]["hostapi"] == 1
+        assert WIN_DEVICES[target.device]["max_output_channels"] > 0
+
+    def test_old_sounddevice_reports_a_fixable_reason(self):
+        """PortAudio 支持但 sounddevice 太老没暴露 WasapiSettings —— 这是最容易踩的坑,
+        必须给出"升级 sounddevice"这个明确原因,不能笼统地说"不支持"。"""
+        target, reason = resolve_loopback_target(
+            WIN_DEVICES, WIN_HOSTAPIS, os_name="Windows", has_wasapi_settings=False
+        )
+        assert target is None
+        assert reason == REASON_NO_WASAPI_SUPPORT
+
+    def test_missing_wasapi_hostapi_is_distinguished_from_missing_device(self):
+        target, reason = resolve_loopback_target(
+            WIN_DEVICES, [{"name": "MME"}], os_name="Windows", has_wasapi_settings=True
+        )
+        assert target is None
+        assert reason == REASON_NO_WASAPI_HOSTAPI
+
+    def test_input_only_host_finds_nothing(self):
+        devices = [{"name": "Mic", "hostapi": 1, "max_input_channels": 2, "max_output_channels": 0}]
+        target, reason = resolve_loopback_target(
+            devices,
+            [{"name": "MME"}, {"name": "Windows WASAPI"}],
+            os_name="Windows",
+            has_wasapi_settings=True,
+        )
+        assert target is None
+        assert reason == REASON_NO_LOOPBACK_DEVICE
+
+
+class TestDeviceResolutionElsewhere:
+    def test_linux_uses_the_pulseaudio_monitor_source(self):
+        """Linux 上 monitor 源是普通【输入】设备,不需要 WASAPI 那套 extra_settings。"""
+        target, reason = resolve_loopback_target(
+            LINUX_DEVICES, LINUX_HOSTAPIS, os_name="Linux", has_wasapi_settings=False
+        )
+        assert reason == REASON_OK
+        assert target is not None
+        assert target.device == 1
+        assert target.needs_wasapi_loopback is False
+
+    def test_linux_without_a_monitor_source(self):
+        target, reason = resolve_loopback_target(
+            [LINUX_DEVICES[0]], LINUX_HOSTAPIS, os_name="Linux", has_wasapi_settings=False
+        )
+        assert target is None
+        assert reason == REASON_NO_LOOPBACK_DEVICE
+
+    def test_macos_has_no_system_level_loopback(self):
+        target, reason = resolve_loopback_target(
+            LINUX_DEVICES, [{"name": "CoreAudio"}], os_name="Darwin", has_wasapi_settings=False
+        )
+        assert target is None
+        assert reason == REASON_UNSUPPORTED_OS
+
+
+class TestProbeDegradesGracefully:
+    def test_probe_never_raises_and_always_explains_itself(self):
+        """探测结果要么可用,要么带一句**可执行的**原因。静默的 False 等于让用户
+        面对"模型不知道我在看什么"却查不到任何线索。"""
+        result = probe()
+        assert set(result) >= {"available", "reason", "reason_text", "os"}
+        assert isinstance(result["available"], bool)
+        assert result["reason_text"], "不可用时必须给出人能看懂的原因"
+
+    def test_missing_sounddevice_is_not_treated_as_an_error(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _no_sounddevice(name, *args, **kwargs):
+            if name == "sounddevice":
+                raise ImportError("No module named 'sounddevice'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_sounddevice)
+        result = probe()
+        assert result["available"] is False
+        assert "sounddevice" in result["reason"]
+
+
+class TestDownmix:
+    def test_stereo_is_averaged_to_mono(self):
+        np = pytest.importorskip("numpy")
+        stereo = np.array([[1.0, 3.0], [2.0, 4.0]], dtype="float32")
+        assert downmix_to_mono(stereo).tolist() == [2.0, 3.0]
+
+    def test_mono_shapes_pass_through(self):
+        np = pytest.importorskip("numpy")
+        assert downmix_to_mono(np.array([1.0, 2.0], dtype="float32")).tolist() == [1.0, 2.0]
+        assert downmix_to_mono(np.array([[1.0], [2.0]], dtype="float32")).tolist() == [1.0, 2.0]
+
+
+# ── 感知库:独立槽位 ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store():
+    from core.perception.desktop_perception_store import DesktopPerceptionStore
+
+    return DesktopPerceptionStore()
+
+
+class TestSeparateSlot:
+    def test_system_audio_does_not_overwrite_the_microphone(self, store):
+        """两路混一槽的话后到的会覆盖先到的,模型就只能拿到其中一路。"""
+        store.update_audio("MIC")
+        store.update_system_audio("SYS")
+        snap = store.snapshot_media()
+        assert snap["audio_b64"] == "MIC"
+        assert snap["system_audio_b64"] == "SYS"
+
+    def test_both_reach_the_model_with_distinguishable_sources(self, store):
+        """source 必须能区分,否则模型无从判断"这段是人在说话"还是"屏幕里在放"。"""
+        store.update_audio("MIC")
+        store.update_system_audio("SYS")
+        ctx = store.build_multimodal_context()
+        assert ctx is not None
+        assert [(a.source, a.data) for a in ctx.audio] == [
+            ("desktop_microphone", "MIC"),
+            ("desktop_system_audio", "SYS"),
+        ]
+        assert "system_audio" in ctx.metadata["modalities"]
+
+    def test_system_audio_alone_still_triggers_injection(self, store):
+        """只有系统声、没有任何其它模态时也必须注入 —— 否则"用户在看视频、没说话、
+        没动屏幕"这个最典型的陪看场景里,这一路等于没接。"""
+        store.update_system_audio("ONLY-SYS")
+        ctx = store.build_multimodal_context()
+        assert ctx is not None
+        assert ctx.metadata["modalities"] == ["system_audio"]
+
+    def test_stale_system_audio_is_not_injected(self, store):
+        store.update_system_audio("OLD")
+        store._sys_audio_ts = time.time() - (store.ttl_sec + 5)
+        assert store.build_multimodal_context() is None
+        assert store.snapshot_media()["system_audio_b64"] is None
+
+    def test_autoinject_watermarks_are_independent(self, store):
+        """共用一个消费水位会让先到的那路把后到的一起标记为"已消费",另一路从此
+        永远取不到东西。"""
+        store.update_audio("MIC")
+        store.update_system_audio("SYS")
+        assert store.take_fresh_audio_for_autoinject() == ("MIC", "audio/webm")
+        assert store.take_fresh_system_audio_for_autoinject() == ("SYS", "audio/webm")
+        # 同一片段不重复消费
+        assert store.take_fresh_audio_for_autoinject() == (None, None)
+        assert store.take_fresh_system_audio_for_autoinject() == (None, None)
+
+    def test_counters_are_tracked_separately(self, store):
+        store.update_system_audio("A")
+        store.update_system_audio("B")
+        status = store.status()
+        assert status["system_audio_received"] == 2
+        assert status["audio_received"] == 0
+
+
+class TestSystemAudioHonoursThePrivacyGate:
+    """系统声比麦克风更敏感 —— 它等于把用户正在听的一切内容(会议、私信语音、视频)
+    完整送出去。所以它必须走**同一道**闸门,不能另开旁路。逐条枚举,不靠推测。"""
+
+    def test_writes_are_rejected_while_paused(self, store):
+        store.pause("test")
+        store.update_system_audio("LEAK")
+        assert store.privacy_status()["rejected_system_audio"] == 1
+        assert store.snapshot_media()["system_audio_b64"] is None
+
+    def test_pause_wipes_already_cached_system_audio(self, store):
+        store.update_system_audio("SECRET")
+        store.pause("test")
+        store.resume("test")  # 恢复后也不能重新读到暂停前那一段
+        assert store.snapshot_media()["system_audio_b64"] is None
+
+    @pytest.mark.parametrize(
+        "read",
+        [
+            lambda s: s.snapshot_media()["system_audio_b64"],
+            lambda s: s.take_fresh_system_audio_for_autoinject()[0],
+            lambda s: s.build_multimodal_context(),
+        ],
+    )
+    def test_read_gates_hold_independently_of_the_wipe(self, store, read):
+        """pause() 会清缓存,所以"读到空"可能只是因为缓存空了,而不是因为读闸门存在。
+        这里在暂停之后**绕过写闸门**直接把内部缓冲填满,单独检验第二道防线 ——
+        否则某条读路径漏了闸门,测试也会因为清缓存而误报通过。"""
+        store.pause("test")
+        store._sys_audio_b64 = "FORCED-INTO-CACHE"
+        store._sys_audio_ts = time.time()
+        assert read(store) is None
+
+    def test_status_exposes_the_rejection_counter(self, store):
+        store.pause("test")
+        store.update_system_audio("X")
+        store.update_system_audio("Y")
+        assert store.status()["privacy"]["rejected_system_audio"] == 2
+
+
+# ── 路由接线 ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from core.routes.perception import create_router
+
+    app = FastAPI()
+    app.include_router(create_router())
+    return TestClient(app)
+
+
+class TestRoutes:
+    def test_ingest_stores_into_the_system_audio_slot(self, client):
+        from core.perception.desktop_perception_store import get_desktop_perception_store
+
+        store = get_desktop_perception_store()
+        store.resume("test-setup")
+        before = store.status()["system_audio_received"]
+        resp = client.post("/api/perception/desktop/system_audio", json={"audio_base64": "AAA"})
+        assert resp.json() == {"success": True, "stored": "system_audio"}
+        assert store.status()["system_audio_received"] == before + 1
+
+    def test_ingest_reports_rejection_honestly_while_paused(self, client):
+        """暂停期间若照旧回 stored=... ,采集端会以为存进去了而继续按原节奏推送。
+        必须如实告知被丢弃,客户端才能降频或提示用户"感知已暂停"。"""
+        from core.perception.desktop_perception_store import get_desktop_perception_store
+
+        store = get_desktop_perception_store()
+        store.pause("test")
+        try:
+            body = client.post("/api/perception/desktop/system_audio", json={"audio_base64": "BBB"}).json()
+            assert body["success"] is False
+            assert body["privacy_paused"] is True
+            assert body["stored"] is None
+        finally:
+            store.resume("test")
+
+    def test_probe_endpoint_answers_with_a_reason(self, client):
+        body = client.get("/api/perception/desktop/system_audio/probe").json()
+        assert body["success"] is True
+        assert isinstance(body["available"], bool)
+        assert body["reason_text"]
+
+    def test_status_exposes_system_audio_freshness(self, client):
+        store_status = client.get("/api/perception/desktop/status").json()["store"]
+        assert "system_audio_received" in store_status
+        assert "system_audio_fresh" in store_status
+        assert "system_audio_age_sec" in store_status

--- a/tests/test_voice_duplex_session.py
+++ b/tests/test_voice_duplex_session.py
@@ -1,0 +1,535 @@
+"""双工语音会话的行为测试。
+
+怎么在没有 provider key、没有出网的环境里真正验证
+--------------------------------------------------
+把"协议"和"网络"分开:
+
+1. **帧编解码抽成纯函数**(``ProtocolAdapter``)—— 上行帧长什么样、下行帧怎么翻成
+   ``DuplexEvent``,全部不碰网络,可以逐条断言。provider 改帧格式时这里立刻失败。
+2. **会话流程跑在本地真 WebSocket 服务端上** —— 不是 mock:``websockets.serve`` 起一个
+   真的服务端,说 OpenAI Realtime 的帧形状,然后驱动一条完整会话:建连 → 下发配置 →
+   上行音频 → 收到转写与音频 → barge-in → 关闭。真的建连、真的收发帧。
+
+无法在此验证的只有一件事:**真实 provider 会不会按它自己文档里的帧格式回话**。那需要
+key 与出网。这一点如实写在模块 docstring 里,不假装覆盖到了。
+
+最要紧的一组是 ``TestVoiceLoopWiring``
+--------------------------------------
+双工默认关闭。一个"默认关闭 + 没接线"的模块与"默认关闭 + 接好了线"的模块从外面看
+一模一样 —— 都不生效。所以必须断言:开关一开,``VoiceLoop.start()` 真的走双工路径;
+开关关着,真的走回合制路径。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from core.voice_duplex_session import (
+    DuplexEventType,
+    DuplexSession,
+    DuplexSessionConfig,
+    OpenAIRealtimeAdapter,
+    duplex_enabled,
+    float_from_pcm16,
+    get_adapter,
+    pcm16_from_float,
+)
+
+np = pytest.importorskip("numpy")
+websockets = pytest.importorskip("websockets")
+
+
+# ── 1. 协议编解码(纯函数,零网络)──────────────────────────────────────────
+
+
+class TestUplinkFrames:
+    def setup_method(self):
+        self.a = OpenAIRealtimeAdapter()
+        self.cfg = DuplexSessionConfig(url="wss://x/y", api_key="sk-test")
+
+    def test_session_update_requests_server_side_vad(self):
+        """双工的回合边界必须由**服务端 VAD** 判。若退回本地"攒够 N 秒再转写",
+        延迟就又回到回合制水平了 —— 那是这一层存在的理由被抽掉。"""
+        frame = self.a.session_update(self.cfg)
+        assert frame["type"] == "session.update"
+        td = frame["session"]["turn_detection"]
+        assert td["type"] == "server_vad"
+        assert td["silence_duration_ms"] == self.cfg.silence_ms
+
+    def test_session_update_asks_for_both_modalities(self):
+        s = self.a.session_update(self.cfg)["session"]
+        assert set(s["modalities"]) == {"text", "audio"}
+        assert s["input_audio_format"] == "pcm16"
+        assert s["output_audio_format"] == "pcm16"
+
+    def test_instructions_omitted_when_empty(self):
+        """空 instructions 不该作为空字符串发上去 —— 有 provider 会用它覆盖掉默认人设。"""
+        assert "instructions" not in self.a.session_update(self.cfg)["session"]
+        cfg2 = DuplexSessionConfig(url="wss://x", api_key="k", instructions="be terse")
+        assert self.a.session_update(cfg2)["session"]["instructions"] == "be terse"
+
+    def test_audio_frame_is_base64_pcm(self):
+        pcm = b"\x01\x02\x03\x04"
+        frame = self.a.audio_frame(pcm)
+        assert frame["type"] == "input_audio_buffer.append"
+        assert base64.b64decode(frame["audio"]) == pcm
+
+    def test_text_frame_creates_item_then_requests_response(self):
+        """只 create item 不 response.create,模型永远不会开口 —— 顺序和成对性都要钉住。"""
+        frames = self.a.text_frame("你好")
+        assert [f["type"] for f in frames] == ["conversation.item.create", "response.create"]
+        assert frames[0]["item"]["content"][0]["text"] == "你好"
+
+    def test_interrupt_cancels_the_server_side_response(self):
+        """回合制的打断只停本地播放器,模型那边还在烧 token。双工必须让服务端也停。"""
+        assert self.a.interrupt_frame()["type"] == "response.cancel"
+
+    def test_headers_carry_auth(self):
+        h = self.a.headers(self.cfg)
+        assert h["Authorization"] == "Bearer sk-test"
+        assert "realtime" in h["OpenAI-Beta"]
+
+
+class TestDownlinkDecoding:
+    def setup_method(self):
+        self.a = OpenAIRealtimeAdapter()
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ({"type": "session.created"}, DuplexEventType.SESSION_OPEN),
+            ({"type": "session.updated"}, DuplexEventType.SESSION_OPEN),
+            ({"type": "input_audio_buffer.speech_started"}, DuplexEventType.USER_SPEECH_STARTED),
+            ({"type": "input_audio_buffer.speech_stopped"}, DuplexEventType.USER_SPEECH_STOPPED),
+            ({"type": "response.done"}, DuplexEventType.RESPONSE_DONE),
+        ],
+    )
+    def test_control_events(self, raw, expected):
+        assert self.a.decode(raw).type is expected
+
+    def test_audio_delta_carries_base64(self):
+        ev = self.a.decode({"type": "response.audio.delta", "delta": "QUJD"})
+        assert ev.type is DuplexEventType.ASSISTANT_AUDIO_DELTA
+        assert base64.b64decode(ev.audio_b64) == b"ABC"
+
+    @pytest.mark.parametrize("t", ["response.text.delta", "response.audio_transcript.delta"])
+    def test_assistant_text_deltas(self, t):
+        ev = self.a.decode({"type": t, "delta": "在的"})
+        assert ev.type is DuplexEventType.ASSISTANT_TEXT_DELTA
+        assert ev.text == "在的"
+
+    def test_user_transcription_partial_and_final_are_distinct(self):
+        """部分转写与最终转写必须分开:把部分当最终会让下游对半句话就动作。"""
+        p = self.a.decode({"type": "conversation.item.input_audio_transcription.delta", "delta": "帮我"})
+        f = self.a.decode({"type": "conversation.item.input_audio_transcription.completed", "transcript": "帮我订机票"})
+        assert p.type is DuplexEventType.PARTIAL_TRANSCRIPT and p.text == "帮我"
+        assert f.type is DuplexEventType.FINAL_TRANSCRIPT and f.text == "帮我订机票"
+
+    def test_error_frame_surfaces_the_message(self):
+        ev = self.a.decode({"type": "error", "error": {"message": "rate limited"}})
+        assert ev.type is DuplexEventType.ERROR
+        assert ev.error == "rate limited"
+
+    def test_unknown_frames_are_ignored_not_fatal(self):
+        """provider 会不断加新事件类型。对未知帧报错会让会话动不动就断。"""
+        assert self.a.decode({"type": "response.some.future.thing"}) is None
+        assert self.a.decode({}) is None
+        assert self.a.decode({"type": ""}) is None
+
+
+class TestPcmConversion:
+    def test_roundtrip_preserves_signal(self):
+        x = (np.sin(2 * np.pi * 440 * np.arange(1000) / 16000) * 0.5).astype(np.float32)
+        back = float_from_pcm16(pcm16_from_float(x))
+        assert back.size == x.size
+        assert float(np.max(np.abs(back - x))) < 1e-3
+
+    def test_clipping_does_not_wrap(self):
+        """溢出翻转会变成刺耳爆音,而且会污染模型的听觉输入。"""
+        out = float_from_pcm16(pcm16_from_float(np.array([9.0, -9.0], dtype=np.float32)))
+        assert out[0] > 0.9 and out[1] < -0.9
+
+    def test_empty_inputs(self):
+        assert pcm16_from_float(np.zeros(0)) == b""
+        assert float_from_pcm16(b"").size == 0
+
+
+class TestAdapterRegistry:
+    def test_known_adapter(self):
+        assert get_adapter("openai_realtime").name == "openai_realtime"
+
+    def test_unimplemented_provider_fails_loudly(self):
+        """Gemini Live 的帧形状不同,没实现就不假装支持 —— 静默退回会让用户以为在用
+        Gemini,实际上发的是 OpenAI 的帧。"""
+        with pytest.raises(ValueError, match="未实现"):
+            get_adapter("gemini_live")
+
+
+# ── 2. 完整会话流程:跑在本地【真】WebSocket 服务端上 ──────────────────────
+
+
+class _FakeRealtimeServer:
+    """说 OpenAI Realtime 帧形状的本地服务端。不是 mock —— 真的 WebSocket。"""
+
+    def __init__(self) -> None:
+        self.received: list = []
+        self._server = None
+        self.url = ""
+
+    async def __aenter__(self):
+        async def _handler(ws):
+            await ws.send(json.dumps({"type": "session.created"}))
+            async for raw in ws:
+                msg = json.loads(raw)
+                self.received.append(msg)
+                t = msg.get("type")
+                if t == "input_audio_buffer.append":
+                    # 收到音频 → 模拟服务端 VAD + 转写 + 开始应答
+                    await ws.send(json.dumps({"type": "input_audio_buffer.speech_started"}))
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "conversation.item.input_audio_transcription.completed",
+                                "transcript": "今天天气怎么样",
+                            }
+                        )
+                    )
+                    await ws.send(json.dumps({"type": "response.audio_transcript.delta", "delta": "今天多云"}))
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "response.audio.delta",
+                                "delta": base64.b64encode(b"\x00\x01" * 8).decode("ascii"),
+                            }
+                        )
+                    )
+                    await ws.send(json.dumps({"type": "response.done"}))
+                elif t == "response.cancel":
+                    await ws.send(json.dumps({"type": "response.done"}))
+
+        self._server = await websockets.serve(_handler, "127.0.0.1", 0)
+        port = self._server.sockets[0].getsockname()[1]
+        self.url = f"ws://127.0.0.1:{port}"
+        return self
+
+    async def __aexit__(self, *_exc):
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    def types(self) -> list:
+        return [m.get("type") for m in self.received]
+
+
+async def _drain(sess, want: DuplexEventType, timeout: float = 3.0) -> list:
+    """收事件直到拿到 ``want``;返回期间收到的全部事件。"""
+    got: list = []
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        ev = await sess.next_event(timeout=0.5)
+        if ev is None:
+            continue
+        got.append(ev)
+        if ev.type is want:
+            return got
+    raise AssertionError(f"等不到 {want};实际收到 {[e.type.value for e in got]}")
+
+
+class TestFullSessionOverRealWebSocket:
+    @pytest.mark.asyncio
+    async def test_connect_uplink_downlink_and_close(self):
+        from core.voice_echo_guard import reset_echo_guard
+
+        reset_echo_guard()
+        async with _FakeRealtimeServer() as server:
+            cfg = DuplexSessionConfig(url=server.url, api_key="sk-test")
+            sess = DuplexSession(cfg)
+            assert await sess.connect() is True
+            try:
+                # 建连即应下发 session.update
+                await _drain(sess, DuplexEventType.SESSION_OPEN)
+                assert "session.update" in server.types()
+
+                pcm = pcm16_from_float(np.zeros(160, dtype=np.float32) + 0.1)
+                assert await sess.send_audio(pcm) is True
+
+                events = await _drain(sess, DuplexEventType.RESPONSE_DONE)
+                kinds = [e.type for e in events]
+                assert DuplexEventType.USER_SPEECH_STARTED in kinds
+                assert DuplexEventType.FINAL_TRANSCRIPT in kinds
+                assert DuplexEventType.ASSISTANT_TEXT_DELTA in kinds
+                assert DuplexEventType.ASSISTANT_AUDIO_DELTA in kinds
+
+                final = next(e for e in events if e.type is DuplexEventType.FINAL_TRANSCRIPT)
+                assert final.text == "今天天气怎么样"
+                audio = next(e for e in events if e.type is DuplexEventType.ASSISTANT_AUDIO_DELTA)
+                assert float_from_pcm16(base64.b64decode(audio.audio_b64)).size == 8
+
+                st = sess.status()
+                assert st["connected"] is True
+                assert st["bytes_uplinked"] == len(pcm)
+            finally:
+                await sess.close()
+            assert sess.connected is False
+        reset_echo_guard()
+
+    @pytest.mark.asyncio
+    async def test_uplink_does_not_block_on_downlink(self):
+        """上行必须不等下行。若两者串行,"边说边听"在实现上就不成立 —— 只是把回合制
+        换了个壳。这里连发 20 块音频、期间完全不读下行,应当全部成功。"""
+        async with _FakeRealtimeServer() as server:
+            sess = DuplexSession(DuplexSessionConfig(url=server.url, api_key="k"))
+            assert await sess.connect() is True
+            try:
+                pcm = pcm16_from_float(np.zeros(160, dtype=np.float32) + 0.05)
+                results = [await sess.send_audio(pcm) for _ in range(20)]
+                assert all(results)
+                assert sess.status()["bytes_uplinked"] == len(pcm) * 20
+            finally:
+                await sess.close()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_reaches_the_server(self):
+        async with _FakeRealtimeServer() as server:
+            sess = DuplexSession(DuplexSessionConfig(url=server.url, api_key="k"))
+            assert await sess.connect() is True
+            try:
+                assert await sess.interrupt() is True
+                await _drain(sess, DuplexEventType.RESPONSE_DONE)
+                assert "response.cancel" in server.types()
+            finally:
+                await sess.close()
+
+    @pytest.mark.asyncio
+    async def test_text_input_shares_the_same_session(self):
+        async with _FakeRealtimeServer() as server:
+            sess = DuplexSession(DuplexSessionConfig(url=server.url, api_key="k"))
+            assert await sess.connect() is True
+            try:
+                assert await sess.send_text("你好") is True
+                await asyncio.sleep(0.1)
+                assert "conversation.item.create" in server.types()
+                assert "response.create" in server.types()
+            finally:
+                await sess.close()
+
+    @pytest.mark.asyncio
+    async def test_assistant_text_is_registered_with_the_echo_guard(self):
+        """双工下同样需要反自激励门:AEC 消不掉非线性残余回声,残余转写出来后仍要能
+        判出"这是我自己说的"。"""
+        from core.voice_echo_guard import get_echo_guard, reset_echo_guard
+
+        reset_echo_guard()
+        async with _FakeRealtimeServer() as server:
+            sess = DuplexSession(DuplexSessionConfig(url=server.url, api_key="k"))
+            assert await sess.connect() is True
+            try:
+                await sess.send_audio(pcm16_from_float(np.zeros(160) + 0.1))
+                await _drain(sess, DuplexEventType.RESPONSE_DONE)
+                assert get_echo_guard().stats()["noted"] >= 1, "AI 说出口的文字没有登记进反自激励门"
+            finally:
+                await sess.close()
+        reset_echo_guard()
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent_and_emits_closed(self):
+        async with _FakeRealtimeServer() as server:
+            sess = DuplexSession(DuplexSessionConfig(url=server.url, api_key="k"))
+            await sess.connect()
+            await sess.close()
+            await sess.close()  # 幂等
+
+    @pytest.mark.asyncio
+    async def test_send_after_close_is_refused_not_raised(self):
+        async with _FakeRealtimeServer() as server:
+            sess = DuplexSession(DuplexSessionConfig(url=server.url, api_key="k"))
+            await sess.connect()
+            await sess.close()
+            assert await sess.send_audio(b"\x00\x01") is False
+            assert await sess.send_text("x") is False
+            assert await sess.interrupt() is False
+
+
+class TestConnectFailureDegradesToTurnBased:
+    @pytest.mark.asyncio
+    async def test_unreachable_url_returns_false_with_a_reason(self):
+        """建连失败必须如实返回 False 并留下原因,让调用方退回回合制 —— 绝不能抛异常
+        把整条语音链路带崩。"""
+        sess = DuplexSession(DuplexSessionConfig(url="ws://127.0.0.1:1", api_key="k"))
+        assert await sess.connect() is False
+        assert sess.status()["last_error"]
+        assert "connect_failed" in sess.status()["last_error"]
+
+    @pytest.mark.asyncio
+    async def test_open_duplex_session_returns_none_when_disabled(self, monkeypatch):
+        from core.voice_duplex_session import open_duplex_session
+
+        monkeypatch.delenv("GALAXY_VOICE_DUPLEX", raising=False)
+        assert await open_duplex_session() is None
+
+    @pytest.mark.asyncio
+    async def test_open_duplex_session_returns_none_without_key(self, monkeypatch, caplog):
+        from core.voice_duplex_session import open_duplex_session
+
+        monkeypatch.setenv("GALAXY_VOICE_DUPLEX", "1")
+        monkeypatch.delenv("GALAXY_REALTIME_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with caplog.at_level("WARNING"):
+            assert await open_duplex_session() is None
+        assert "缺少 API key" in caplog.text, "缺 key 必须留下可排查的日志"
+
+
+class TestDefaultsAndConfig:
+    def test_duplex_is_off_by_default(self, monkeypatch):
+        """默认关闭是刻意的:它需要 realtime provider 与 key,默认打开会让所有没配 key
+        的部署直接失去语音功能。"""
+        monkeypatch.delenv("GALAXY_VOICE_DUPLEX", raising=False)
+        assert duplex_enabled() is False
+
+    def test_can_be_switched_on(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_VOICE_DUPLEX", "1")
+        assert duplex_enabled() is True
+
+    def test_from_env_builds_default_openai_url(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_REALTIME_API_KEY", "sk-x")
+        monkeypatch.delenv("GALAXY_REALTIME_URL", raising=False)
+        monkeypatch.setenv("GALAXY_REALTIME_MODEL", "my-model")
+        cfg = DuplexSessionConfig.from_env()
+        assert cfg is not None
+        assert cfg.model == "my-model"
+        assert "my-model" in cfg.url and cfg.url.startswith("wss://")
+
+    def test_explicit_url_wins(self, monkeypatch):
+        monkeypatch.setenv("GALAXY_REALTIME_API_KEY", "sk-x")
+        monkeypatch.setenv("GALAXY_REALTIME_URL", "wss://my.host/rt")
+        assert DuplexSessionConfig.from_env().url == "wss://my.host/rt"
+
+
+class TestEventQueueIsBounded:
+    @pytest.mark.asyncio
+    async def test_oldest_events_are_dropped_not_newest(self):
+        """队列满了要丢**最旧**的:过期音频块没有价值,而阻塞上行会毁掉实时性。
+        丢弃必须有计数,不能静默。"""
+        from core.voice_duplex_session import _EVENT_QUEUE_MAX, DuplexEvent
+
+        sess = DuplexSession(DuplexSessionConfig(url="ws://x", api_key="k"))
+        for i in range(_EVENT_QUEUE_MAX + 10):
+            await sess._emit(DuplexEvent(DuplexEventType.ASSISTANT_TEXT_DELTA, text=str(i)))
+        assert sess._queue.qsize() == _EVENT_QUEUE_MAX
+        assert sess.events_dropped == 10
+        # 队里剩的应是最近的那批
+        ev = await sess.next_event(timeout=0.1)
+        assert int(ev.text) >= 10
+
+
+# ── 3. 接线:开关一开,VoiceLoop 真的走双工吗 ───────────────────────────────
+
+
+class TestVoiceLoopWiring:
+    """双工默认关闭。一个"默认关闭 + 没接线"的模块与"默认关闭 + 接好了线"的模块从外面
+    看一模一样 —— 都不生效。所以必须断言开关的两个方向都真的路由到了对应实现。
+    """
+
+    @pytest.mark.asyncio
+    async def test_switch_off_uses_the_turn_based_path(self, monkeypatch):
+        from core.voice_loop import VoiceLoop
+
+        monkeypatch.delenv("GALAXY_VOICE_DUPLEX", raising=False)
+        loop = VoiceLoop(object(), speak_responses=False)
+        assert await loop._try_start_duplex(object, object) is False
+        assert loop._duplex is None
+
+    @pytest.mark.asyncio
+    async def test_switch_on_but_no_key_falls_back(self, monkeypatch):
+        """开了开关却没配 key 时必须退回回合制,而不是把语音功能整体弄坏。"""
+        from core.voice_loop import VoiceLoop
+
+        monkeypatch.setenv("GALAXY_VOICE_DUPLEX", "1")
+        monkeypatch.delenv("GALAXY_REALTIME_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        loop = VoiceLoop(object(), speak_responses=False)
+        assert await loop._try_start_duplex(object, object) is False
+
+    @pytest.mark.asyncio
+    async def test_switch_on_with_reachable_server_starts_duplex(self, monkeypatch):
+        """核心接线断言:开关开 + 会话建得起来 → VoiceLoop 真的进双工模式。"""
+        from core.multimodal.audio_capture_service import (
+            AudioCaptureConfig,
+            AudioCaptureService,
+        )
+        from core.voice_loop import VoiceLoop
+
+        async with _FakeRealtimeServer() as server:
+            monkeypatch.setenv("GALAXY_VOICE_DUPLEX", "1")
+            monkeypatch.setenv("GALAXY_REALTIME_API_KEY", "sk-test")
+            monkeypatch.setenv("GALAXY_REALTIME_URL", server.url)
+
+            loop = VoiceLoop(object(), speak_responses=False)
+            started = await loop._try_start_duplex(AudioCaptureConfig, AudioCaptureService)
+            try:
+                assert started is True, "开关已开且服务端可达,却没进双工模式 —— 接线断了"
+                assert loop._duplex is not None
+                assert loop._running is True
+                # ASR/TTS 是回合制的部件,双工路径下不该被初始化
+                assert loop.asr is None
+                assert loop.tts is None
+            finally:
+                await loop.stop()
+            # 生命周期对称:停完之后连接与播放器都要被释放
+            assert loop._duplex is None
+            assert loop._duplex_player is None
+            assert loop._duplex_loop is None
+
+    @pytest.mark.asyncio
+    async def test_uplink_audio_reaches_the_server(self, monkeypatch):
+        """真正走一遍上行:采集回调 → PCM16 → 服务端收到 input_audio_buffer.append。"""
+        from core.multimodal.audio_capture_service import (
+            AudioCaptureConfig,
+            AudioCaptureService,
+        )
+        from core.voice_loop import VoiceLoop
+
+        async with _FakeRealtimeServer() as server:
+            monkeypatch.setenv("GALAXY_VOICE_DUPLEX", "1")
+            monkeypatch.setenv("GALAXY_REALTIME_API_KEY", "sk-test")
+            monkeypatch.setenv("GALAXY_REALTIME_URL", server.url)
+
+            loop = VoiceLoop(object(), speak_responses=False)
+            assert await loop._try_start_duplex(AudioCaptureConfig, AudioCaptureService) is True
+            try:
+                # 直接驱动采集管道的处理入口(本环境没有真麦克风)
+                pipe = loop.capture._pipeline
+                await pipe._process_chunk(np.zeros(160, dtype=np.float32) + 0.1)
+                for _ in range(30):
+                    if "input_audio_buffer.append" in server.types():
+                        break
+                    await asyncio.sleep(0.05)
+                assert "input_audio_buffer.append" in server.types(), "上行音频没有到达服务端"
+            finally:
+                await loop.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_actually_consults_the_duplex_path_first(self, monkeypatch):
+        """上面几个用例直接调 ``_try_start_duplex``,证明不了 ``start()`` 会去调它 ——
+        把 start() 里那一行删掉,它们照样全绿。这里补上调用点本身的断言:双工启动成功时
+        start() 必须**就此返回**,不再初始化 ASR/TTS(那是回合制的部件,构造 Whisper
+        会真的去加载模型)。
+        """
+        from core.voice_loop import VoiceLoop
+
+        calls: list = []
+
+        async def _fake_try(*_a, **_k):
+            calls.append(1)
+            return True
+
+        loop = VoiceLoop(object(), speak_responses=False)
+        monkeypatch.setattr(loop, "_try_start_duplex", _fake_try)
+        await loop.start()
+        assert calls == [1], "start() 没有调用双工路径 —— 接线断了"
+        assert loop.asr is None, "双工启动后仍初始化了 ASR,说明 start() 没有就此返回"
+        assert loop.tts is None

--- a/tests/test_voice_duplex_session.py
+++ b/tests/test_voice_duplex_session.py
@@ -533,3 +533,65 @@ class TestVoiceLoopWiring:
         assert calls == [1], "start() 没有调用双工路径 —— 接线断了"
         assert loop.asr is None, "双工启动后仍初始化了 ASR,说明 start() 没有就此返回"
         assert loop.tts is None
+
+
+# ── 4. 下行播放器:绝不阻塞事件循环 ────────────────────────────────────────
+
+
+class TestPcmPlayerNeverBlocks:
+    """为什么单独立一组:``OutputStream.write()`` 按 sounddevice 的契约**会阻塞**到帧写完
+    为止,而 ``play()`` 是从 ``_duplex_downlink`` 里调的、跑在事件循环上 —— 一阻塞,同一个
+    循环上的**上行**也跟着停,等于用一个"实时"播放器把双工性质亲手毁掉,退化成半双工。
+    所以实现改成回调驱动:``play()`` 只往有界缓冲追加,纯内存操作。
+    """
+
+    def test_play_is_pure_buffer_append_no_blocking_write(self):
+        """实现里不该出现 ``stream.write(``。这是白盒断言,但它守的是一条从外面测不出来
+        的性质(本环境没有音频设备,阻塞与否无法直接观测)。"""
+        import inspect
+
+        from core.voice_duplex_session import PcmPlayer
+
+        src = inspect.getsource(PcmPlayer)
+        # 只看真正的调用形式,不看 docstring 里对 stream.write() 的说明性提及
+        assert "self._stream.write(" not in src, "播放器又用回了阻塞式 write —— 会卡住事件循环"
+        assert "callback=_cb" in src, "播放器应是回调驱动"
+
+    def test_play_without_a_device_counts_drops_and_returns_false(self):
+        from core.voice_duplex_session import PcmPlayer
+
+        p = PcmPlayer(sample_rate=16000)
+        assert p.start() is False  # 本环境没有 sounddevice
+        assert p.play(b"\x00\x01" * 100) is False
+        st = p.status()
+        assert st["available"] is False
+        assert st["unavailable_reason"]
+        assert st["blocks_dropped"] == 1
+
+    def test_empty_block_is_a_noop(self):
+        from core.voice_duplex_session import PcmPlayer
+
+        p = PcmPlayer()
+        assert p.play(b"") is False
+        assert p.status()["blocks_dropped"] == 0
+
+    def test_stop_is_safe_without_start(self):
+        from core.voice_duplex_session import PcmPlayer
+
+        PcmPlayer().stop()
+
+    def test_buffer_is_bounded_and_drops_oldest(self, monkeypatch):
+        """生产快于消费时必须丢**最旧**的,而不是让 play() 等下去。用一个假 stream 绕过
+        "本环境没有音频设备",单独检验缓冲策略。"""
+        from core.voice_duplex_session import _PLAYER_BUFFER_SEC, PcmPlayer
+
+        p = PcmPlayer(sample_rate=16000)
+        p._stream = object()  # 假装设备可用
+        p._np = np
+        p._buf = np.zeros(0, dtype=np.float32)
+
+        one_sec = pcm16_from_float(np.zeros(16000, dtype=np.float32) + 0.1)
+        for _ in range(int(_PLAYER_BUFFER_SEC) + 3):
+            assert p.play(one_sec) is True
+        assert p.status()["buffered_samples"] <= int(_PLAYER_BUFFER_SEC * 16000)
+        assert p.status()["blocks_dropped"] > 0, "超上限时应有丢弃计数,不能静默"

--- a/tests/test_voice_duplex_session.py
+++ b/tests/test_voice_duplex_session.py
@@ -595,3 +595,74 @@ class TestPcmPlayerNeverBlocks:
             assert p.play(one_sec) is True
         assert p.status()["buffered_samples"] <= int(_PLAYER_BUFFER_SEC * 16000)
         assert p.status()["blocks_dropped"] > 0, "超上限时应有丢弃计数,不能静默"
+
+
+class TestUnexpectedDisconnectIsNotSilent:
+    """服务端**正常**关闭连接时,``async for`` 会安静地结束、不抛异常。若那里什么都不做,
+    后果完全静默:上行 ``send_audio`` 从此每次返回 False(没人看返回值),用户的声音再也
+    传不上去;而下行消费方还在 await 一个永远不会再有事件的队列上,任务就此挂死。
+    症状是"助手突然不理人了",日志里一点线索都没有。
+    """
+
+    @staticmethod
+    async def _session_that_gets_closed():
+        async def handler(ws):
+            await ws.send(json.dumps({"type": "session.created"}))
+            await asyncio.sleep(0.05)
+            await ws.close()  # 服务端正常关闭
+
+        server = await websockets.serve(handler, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        sess = DuplexSession(DuplexSessionConfig(url=f"ws://127.0.0.1:{port}", api_key="k"))
+        assert await sess.connect() is True
+        return sess, server
+
+    @pytest.mark.asyncio
+    async def test_consumer_is_released_instead_of_hanging(self):
+        sess, server = await self._session_that_gets_closed()
+        seen: list = []
+
+        async def _consume():
+            async for ev in sess.events():
+                seen.append(ev.type)
+
+        task = asyncio.ensure_future(_consume())
+        try:
+            # 不补发 SESSION_CLOSED 的话这里会超时 —— 消费方挂死
+            await asyncio.wait_for(task, timeout=3.0)
+        except asyncio.TimeoutError:
+            task.cancel()
+            raise AssertionError("下行消费方挂死:断连后没有收到 SESSION_CLOSED")
+        finally:
+            server.close()
+            await server.wait_closed()
+        assert DuplexEventType.SESSION_CLOSED in seen
+
+    @pytest.mark.asyncio
+    async def test_disconnect_is_logged_and_recorded(self, caplog):
+        sess, server = await self._session_that_gets_closed()
+        try:
+            with caplog.at_level("WARNING"):
+                for _ in range(30):
+                    if not sess.connected:
+                        break
+                    await asyncio.sleep(0.05)
+            assert sess.connected is False
+            assert sess.status()["last_error"], "断连必须留下可排查的痕迹"
+            assert "已断开" in caplog.text, "断连必须升 WARNING,不能静默"
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_uplink_after_disconnect_reports_failure(self):
+        sess, server = await self._session_that_gets_closed()
+        try:
+            for _ in range(30):
+                if not sess.connected:
+                    break
+                await asyncio.sleep(0.05)
+            assert await sess.send_audio(b"\x00\x01") is False
+        finally:
+            server.close()
+            await server.wait_closed()

--- a/tests/test_voice_echo_guard.py
+++ b/tests/test_voice_echo_guard.py
@@ -1,0 +1,317 @@
+"""反自激励门的行为测试。
+
+被修的真实缺陷
+--------------
+本地语音闭环是 ``麦克风 → VAD → Whisper → VoiceLoop._on_voice_input``。AI 用 TTS
+把回复从扬声器念出去,同一间屋子的麦克风必然把这段声音重新采回来,转写成文字流进
+``_on_voice_input``。在那之前那里没有任何防护,于是:
+
+1. 开头的 barge-in 逻辑把"出词"当成用户开口的证据,把 AI 自己的朗读掐断;
+2. 转写出的文字继续往下走进大脑 → AI 对自己说的话作答 → 自言自语闭环。
+
+所以本文件的重点不是"相似度函数算得对不对",而是**两个症状在真实调用路径上确实
+消失了,而真正的 barge-in 没被一起杀掉**。后者是关键:简单地"朗读期间丢掉所有
+音频"也能消除症状 1 和 2,但会同时废掉本仓库明确提供的"你一说话它就闭嘴"。
+
+``TestRealCallPathOnVoiceLoop`` 就是为此存在的 —— 它走 ``VoiceLoop._on_voice_input``
+本体,而不是直接调门。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+REPLY = "北京今天多云,气温 22 到 30 度,空气质量良好,适合外出活动。"
+
+
+@pytest.fixture
+def guard():
+    """每个用例一个干净的门实例(不用进程单例,避免用例间互相污染)。"""
+    from core.voice_echo_guard import EchoGuard
+
+    return EchoGuard()
+
+
+# ── 判定语义 ─────────────────────────────────────────────────────────────────
+
+
+class TestVerdicts:
+    def test_verbatim_fragment_of_what_we_just_said_is_echo(self, guard):
+        from core.voice_echo_guard import VERDICT_SELF_ECHO
+
+        guard.note_utterance(REPLY)
+        verdict, score, _ = guard.classify("北京今天多云气温22到30度")
+        assert verdict == VERDICT_SELF_ECHO
+        assert score >= 0.62
+
+    def test_a_genuinely_new_request_is_the_user(self, guard):
+        from core.voice_echo_guard import VERDICT_USER
+
+        guard.note_utterance(REPLY)
+        verdict, _, _ = guard.classify("帮我订一张去上海的机票")
+        assert verdict == VERDICT_USER
+
+    def test_nothing_recently_spoken_means_everything_is_the_user(self, guard):
+        from core.voice_echo_guard import VERDICT_USER
+
+        verdict, _, reason = guard.classify("北京今天多云气温22到30度")
+        assert verdict == VERDICT_USER
+        assert reason == "nothing_recent"
+
+    @pytest.mark.parametrize("cmd", ["停", "别念了", "闭嘴", "等等"])
+    def test_short_interrupt_commands_always_pass(self, guard, cmd):
+        """打断口令又短又常见,必须永远通得过——否则用户喊"停"会被门吃掉。"""
+        from core.voice_echo_guard import VERDICT_USER
+
+        guard.note_utterance(REPLY)
+        verdict, _, reason = guard.classify(cmd)
+        assert verdict == VERDICT_USER
+        assert reason == "too_short"
+
+    def test_scattered_single_char_overlap_is_not_evidence(self, guard):
+        """中文常用字少:一句短话的每个字几乎必然散落在长回复的某处,总重合能凑到
+        很高。只看总比例会把用户真的说的话判成回声,所以还要求一段足够长的【连续】
+        命中。本用例锁住这条防线。"""
+        from core.voice_echo_guard import VERDICT_USER, normalize, overlap
+
+        guard.note_utterance(REPLY)
+        # 这句的每个字都在 REPLY 里,但没有任何长连续段
+        probe = "今度好air"
+        _containment, longest = overlap(normalize(probe), normalize(REPLY))
+        assert longest < 4, "前提:这句在 REPLY 里没有长连续段"
+        verdict, _, _ = guard.classify(probe)
+        assert verdict == VERDICT_USER
+
+    @pytest.mark.parametrize(
+        "asr_text",
+        [
+            "北京今天多运气温22到30度",  # 同音字错误 云→运
+            "京今天多云气温22到30",  # 首尾丢字
+            "空气质量良好十分适合外出活动",  # 插入词
+            "恩北京今天多云气温22到30度啊",  # 首尾填充词
+        ],
+    )
+    def test_robust_to_realistic_asr_noise(self, guard, asr_text):
+        """真实 ASR 不会逐字复现 TTS 文本。门必须容忍同音字、丢字、插词。"""
+        from core.voice_echo_guard import VERDICT_SELF_ECHO
+
+        guard.note_utterance(REPLY)
+        verdict, _, _ = guard.classify(asr_text)
+        assert verdict == VERDICT_SELF_ECHO
+
+
+# ── 留存窗口 ─────────────────────────────────────────────────────────────────
+
+
+class TestRetentionWindow:
+    def test_utterance_expires_after_the_tail(self, guard, monkeypatch):
+        from core.voice_echo_guard import VERDICT_SELF_ECHO, VERDICT_USER
+
+        monkeypatch.setenv("GALAXY_VOICE_ECHO_TAIL_S", "6")
+        guard.note_utterance(REPLY)
+        assert guard.classify("北京今天多云气温22到30度")[0] == VERDICT_SELF_ECHO
+
+        # 把这条记录的时间戳推回到"很久以前"
+        for utt in guard._utterances:
+            utt.ts -= 10_000.0
+        assert guard.classify("北京今天多云气温22到30度")[0] == VERDICT_USER
+
+    def test_long_reply_stays_live_longer_than_the_fixed_tail(self, guard, monkeypatch):
+        """流式朗读整段登记、逐句播出:一段长回复登记时刻很早、播完很晚。若留存只有
+        固定尾巴,它会在【还没念完时】就过期,回声照旧漏进来。故留存 = 估算朗读耗时
+        + 尾巴。"""
+        monkeypatch.setenv("GALAXY_VOICE_ECHO_TAIL_S", "6")
+        from core.voice_echo_guard import _Utterance, tail_seconds
+
+        short = _Utterance(norm="好的马上办", ts=0.0)
+        long_ = _Utterance(norm="一" * 400, ts=0.0)
+        tail = tail_seconds()
+        assert short.expires_at(tail) == pytest.approx(6.0 + 1.0, abs=0.01)
+        assert long_.expires_at(tail) > 80.0
+
+    def test_utterances_are_bounded(self, guard):
+        """登记来自每一句朗读,必须有上界,不能随会话时长无界增长。"""
+        from core.voice_echo_guard import _MAX_UTTERANCES
+
+        for i in range(_MAX_UTTERANCES * 3):
+            guard.note_utterance(f"这是第{i}句话的内容足够长以便登记")
+        assert len(guard._utterances) == _MAX_UTTERANCES
+
+
+# ── 开关与降级 ───────────────────────────────────────────────────────────────
+
+
+class TestDefaultsAndDegradation:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("GALAXY_VOICE_ECHO_GUARD", raising=False)
+        from core.voice_echo_guard import enabled
+
+        assert enabled() is True
+
+    def test_can_be_switched_off(self, guard, monkeypatch):
+        from core.voice_echo_guard import VERDICT_USER
+
+        monkeypatch.setenv("GALAXY_VOICE_ECHO_GUARD", "0")
+        guard.note_utterance(REPLY)
+        verdict, _, reason = guard.classify("北京今天多云气温22到30度")
+        assert verdict == VERDICT_USER
+        assert reason == "disabled"
+
+    def test_internal_failure_falls_open_to_user(self, guard, monkeypatch):
+        """门失灵的后果必须是"助手照常听人说话",而不是"助手变聋"。"""
+        import core.voice_echo_guard as m
+        from core.voice_echo_guard import VERDICT_USER
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("injected")
+
+        monkeypatch.setattr(m, "normalize", _boom)
+        guard.note_utterance(REPLY)
+        verdict, _, reason = guard.classify("随便什么话都行")
+        assert verdict == VERDICT_USER
+        assert reason == "guard_error"
+
+    def test_bad_numeric_env_falls_back_to_default(self, monkeypatch, caplog):
+        monkeypatch.setenv("GALAXY_VOICE_ECHO_SIM", "not-a-number")
+        from core.voice_echo_guard import similarity_threshold
+
+        with caplog.at_level("WARNING"):
+            assert similarity_threshold() == pytest.approx(0.62)
+        assert "不是合法数值" in caplog.text
+
+    def test_suppression_streak_is_visible(self, guard, caplog):
+        """相似度门若误判,症状是"助手不理人"。连续压制必须升 WARNING,不能静默。"""
+        from core.voice_echo_guard import _SUPPRESS_STREAK_WARN
+
+        guard.note_utterance(REPLY)
+        with caplog.at_level("WARNING"):
+            for _ in range(_SUPPRESS_STREAK_WARN):
+                guard.classify("北京今天多云气温22到30度")
+        assert "连续压制" in caplog.text
+
+
+# ── recently_spoke:给"只能按时间挡"的调用方 ────────────────────────────────
+
+
+class TestRecentlySpoke:
+    def test_false_before_anything_is_said(self, guard):
+        assert guard.recently_spoke() is False
+
+    def test_true_right_after_speaking(self, guard):
+        guard.note_utterance(REPLY)
+        assert guard.recently_spoke() is True
+
+    def test_false_once_expired(self, guard):
+        guard.note_utterance(REPLY)
+        for utt in guard._utterances:
+            utt.ts -= 10_000.0
+        assert guard.recently_spoke() is False
+
+
+# ── 真实调用路径:两个症状是否真的消失,barge-in 是否真的还活着 ─────────────
+
+
+class TestRealCallPathOnVoiceLoop:
+    """走 ``VoiceLoop._on_voice_input`` 本体。
+
+    直接调门只能证明门自己算得对;只有走这条真实路径,才能证明门**接上了**,而且
+    接的位置正确(必须在 barge-in 之前——接在之后的话,AI 仍会被自己的回声掐断)。
+    """
+
+    @staticmethod
+    def _run(asr_text, monkeypatch):
+        """返回 ``(barge_in 次数, 送进大脑的次数)``。"""
+        import core.speech_output as so
+        from core.voice_echo_guard import note_utterance, reset_echo_guard
+        from core.voice_loop import VoiceLoop
+
+        interrupted: list = []
+        processed: list = []
+        monkeypatch.setattr(so, "interrupt_speech", lambda: interrupted.append(1))
+        monkeypatch.setattr(so, "is_speaking", lambda: True)  # 模拟"AI 正在朗读"
+
+        class _FakeGalaxy:
+            async def process(self, text, source=""):
+                processed.append(text)
+                return {"response": "ok"}
+
+        reset_echo_guard()
+        note_utterance(REPLY)  # AI 刚把 REPLY 念出去
+
+        async def _go():
+            loop = VoiceLoop(_FakeGalaxy(), speak_responses=False)
+            loop._running = True
+            await loop._on_voice_input(asr_text)
+
+        asyncio.run(_go())
+        reset_echo_guard()
+        return len(interrupted), len(processed)
+
+    def test_self_echo_neither_interrupts_nor_reaches_the_brain(self, monkeypatch):
+        """症状 1+2 同时消失:AI 不再掐断自己,也不再对自己说的话作答。"""
+        interrupted, processed = self._run("北京今天多云气温22到30度", monkeypatch)
+        assert interrupted == 0, "AI 不应被自己的回声掐断朗读"
+        assert processed == 0, "AI 自己说的话不应被当作用户输入送进大脑"
+
+    def test_real_user_speech_still_barges_in_and_is_processed(self, monkeypatch):
+        """关键回归防线:门不能把真正的 barge-in 一起杀掉。"""
+        interrupted, processed = self._run("帮我订一张去上海的机票", monkeypatch)
+        assert interrupted == 1, "用户真的开口时仍须立刻掐断朗读"
+        assert processed == 1, "用户真的开口时仍须送进大脑"
+
+    def test_bug_reproduces_when_the_guard_is_disabled(self, monkeypatch):
+        """反向验证:关掉门,两个症状必须原样复现——证明这段代码是承重的,不是装饰。"""
+        monkeypatch.setenv("GALAXY_VOICE_ECHO_GUARD", "0")
+        interrupted, processed = self._run("北京今天多云气温22到30度", monkeypatch)
+        assert interrupted == 1
+        assert processed == 1
+
+
+# ── 接线:发声侧真的登记了吗 ────────────────────────────────────────────────
+
+
+class TestWiredIntoTheSpeakingPaths:
+    def test_speak_response_registers_the_utterance(self, monkeypatch):
+        """``speak_response`` 是原生 / 整段批处理 / 分句流式三条发声路径的分叉点,
+        登记在这里一次就三条全覆盖。"""
+        import core.speech_output as so
+        from core.voice_echo_guard import get_echo_guard, reset_echo_guard
+
+        reset_echo_guard()
+        monkeypatch.setattr(so, "_maybe_speak_native", lambda *_a, **_k: True)  # 不真发声
+        monkeypatch.setattr(so, "speak_enabled", lambda: True)
+        so._last_text, so._last_ts = "", 0.0  # 绕开 3 秒去重
+        so.speak_response("北京今天多云,气温22到30度。", source="chat")
+
+        stats = get_echo_guard().stats()
+        assert stats["noted"] == 1
+        assert stats["live_utterances"] == 1
+        reset_echo_guard()
+
+    def test_incremental_speaker_registers_each_sentence(self):
+        """边生成边念(/chat/stream)不经 speak_response —— 文本是逐 token 喂进来的,
+        所以那条路必须自己登记,否则流式朗读的回声完全没人挡。"""
+        from core.streaming_speech import _note_spoken
+        from core.voice_echo_guard import get_echo_guard, reset_echo_guard
+
+        reset_echo_guard()
+        _note_spoken("这是流式朗读的一句话。")
+        assert get_echo_guard().stats()["noted"] == 1
+        reset_echo_guard()
+
+    def test_ambient_gate_also_covers_non_streaming_speak_paths(self, monkeypatch):
+        """``is_speaking()`` 只在流式路径上为真;整段批处理 / 原生发声下它恒为 False,
+        单靠它的门是失效的。ambient 那条门必须同时看 ``recently_spoke()``。"""
+        import core.ambient_attention_loop as al
+        import core.speech_output as so
+        from core.voice_echo_guard import note_utterance, reset_echo_guard
+
+        reset_echo_guard()
+        monkeypatch.setattr(so, "is_speaking", lambda: False)  # 模拟非流式路径
+        assert al._ai_is_speaking() is False, "前提:此刻两个来源都说没在朗读"
+
+        note_utterance(REPLY)  # 非流式路径刚念完一段
+        assert al._ai_is_speaking() is True, "整段批处理/原生发声也必须被挡住"
+        reset_echo_guard()


### PR DESCRIPTION
> **说明:** 本 PR 在开出后又推进了 5 个提交(AEC、barge-in 分类、双工会话层、两批排错)。原描述只覆盖前 4 个提交,且其中"这不是回声消除(AEC)"一句已被后续提交推翻 —— 故整篇重写,以分支实际内容为准。

## 全景:"边说边听"缺的三样,现在都在了

原先语音链路是**回合制**的:麦克风攒够一段 → Whisper 整段转写 → 大脑生成整段回复 → TTS 整段合成播放。"同一时刻边说边听"在架构上就不可能 —— 不是调参问题,是拓扑问题。三层叠加(不是替代)补齐:

| 层 | 模块 | 作用 |
|---|---|---|
| 信号层 | `acoustic_echo_canceller` | 把扬声器的声音从麦克风里**减掉**(合成路径实测 27 dB ERLE) |
| 文本层 | `voice_echo_guard` | 兜住 AEC 消不掉的**非线性残余**回声 |
| 传输层 | `voice_duplex_session` | 持续上行 + 持续下行,让"同时"在拓扑上成为可能 |

三者是互补的:AEC 原理上消不掉扬声器削波/外壳振动带来的非线性回声,残余仍会被转写出来 —— 文本层正是为这部分兜底。双工比回合制**更**需要 AEC:回合制下 AI 说话时采到的回声最终会被丢掉,双工下那些字节会实时上行进模型。

---

## 1. 反自激励门(文本层)

本地语音闭环 `麦克风 → VAD → Whisper → VoiceLoop._on_voice_input` 此前**没有任何防护**,两个症状都会发生:

1. **AI 打断自己。** `_on_voice_input` 把"出词"当作用户开口的证据,`is_speaking()` 为真就调 `interrupt_speech()` —— 而此刻正在说话的就是它自己。
2. **AI 对自己说的话作答。** 转写出的文字继续进大脑 → 生成回复 → 再念出去 → 再被采回来。

`ambient_attention_loop.py` 对**它自己那条**通路写明并挡住了同一危险,但语音主闭环(默认开启、真正驱动对话的那条)一直没有。

**判的是"这段文字是不是我刚说过的话",不是"此刻是否在朗读"** —— 真正的 barge-in 完全不受影响。为什么不按 `is_speaking()` 判:它只反映 `_active_speaker`,而那**只在流式朗读路径上被设置**;整段批处理(`GALAXY_TTS_STREAMING=0`)与原生发声两条路径下它恒为 False,建立在它之上的门(含 ambient 那条)全是失效的。

防误判(误判的症状是"助手不理人",比漏挡更需小心):短于 4 字一律放行("停"/"别念了" 正是这个长度);要求足够长的**连续**重合而非只看总比例(中文常用字少,短话的每个字几乎必然散落在长回复某处,总重合能凑到 1.0);连续压制 5 条升 WARNING;任何异常判"用户",fail-open。留存时长按文本长度估算朗读耗时后再加尾巴。

## 2. 声学回声消除(信号层)

**算法选错过一次,如实记录。** 最初实现时域块状 NLMS,实测跑满 2000 块(≈200 秒音频)才 12 dB ERLE —— 根因是语音类信号强相关,LMS 收敛速度受输入自相关矩阵的**特征值扩散**支配,有色输入下极差。这是算法选择错误,不是调参问题。改成**分区频域自适应(PBFDAF)**,每个频点各自按自身功率归一化(等效输入去相关),同一条路径 120 块(12 秒)即 **27 dB**。

两处实现细节不做对同样跑飞,都是实测踩出来的:
- 频点功率估计要用**首块实测值**初始化,不能从全零平滑 —— 从 0 起平滑时首块功率只有真实值的 10%,步长放大 10 倍,开头 ERLE 冲到 **−20 dB**(等于 AEC 把回声放大了)。
- 步长要再**除分区数 K** —— 功率估计是所有分区之和,而 K 个分区各按此步长更新一次;不除时 `mu` 稍大即发散,且改 `tail_ms` 会顺带把稳定性改掉。

**双讲检测(DTD)判据也换过一次。** 原判据"麦克风能量是否超出回声估计"存在死锁:滤波器未收敛时回声估计≈0,条件恒成立 → 一切判成双讲 → 永不自适应 → 永不收敛(最初实现 120 块只有 8 块真的更新过权重)。改成跟踪**回声路径增益**(麦克风/参考 RMS 的滑动上界),与收敛程度无关。

**刻意不做:** 非线性残余回声抑制(NLP)。线性滤波器原理上消不掉,由文本层兜底。

## 3. barge-in 分应答与真打断

人在听别人说话时会一直出声("嗯""对""好""哦")—— 那是**积极倾听**,不是抢话。原先"一出词就掐断"让 AI 每讲两句就被"嗯"一声打断。

改成三路:自己的回声 → 丢弃;应答 → **继续说、且不送大脑**(否则 AI 会对一句语义空的"嗯"另起一段回复);真打断 → 立刻掐断。

分类刻意保守,因为**第二种失败方式更糟**:真打断被当成应答 → 用户想插话却被无视,会以为助手坏了、反复大声重复。故含任何实义内容一律判打断;只有**完全由**语义空应答词组成且 ≤6 字才算应答;停止/hold 类词永远是打断;判不了也按打断处理。分类只在 AI 确实在朗读时才问 —— AI 没在说话时"嗯"是正常回合。

修了一处实现坑:应答词剥离时短词会咬掉长词前缀 —— 先剥 `ok` 会把 `okay` 变成 `ay`,于是 `okay` 被误判成打断(实测踩到)。改按长度降序程序化排序,不靠手工顺序。

## 4. 双工会话层(传输层)

一条持续开着的连接;回合边界改由**服务端 VAD** 判定,本地不再"攒够 3 秒再转写"—— 那正是回合制延迟的来源。

双工下的 barge-in 与回合制有**本质区别**:回合制的 `interrupt_speech()` 只停本地播放器,模型那边还在继续生成(token 照烧、上下文照涨);双工必须发 `response.cancel` 让服务端也停。

下行播放单独写了 `PcmPlayer`:双工下行是连续 PCM 流而非音频文件,现有 `_play_audio(path)` 用不上(为每个 20ms 块写临时文件不可接受)。

**接线:** `VoiceLoop.start()` 双工优先,建得起来就走这条并 return(不再初始化 ASR/TTS);建不起来如实退回回合制。`stop()` 对称释放 WebSocket 与音频输出流。

## 5. 系统播放声(回环)采集

原先全仓库音频只有一路 `desktop_microphone`。系统播放声**完全没有采集通路** —— 这是**能力缺口**,不是精度问题:`getUserMedia` 只给输入设备;`getDisplayMedia` 要每次手动选窗口、跨浏览器支持残缺,做不成常驻感知;用麦克风"隔空听扬声器"会和用户自己说的话混在同一路,再也分不开。

只能在电脑端本机做,**而且不需要 C++ 层**:Windows 走 WASAPI loopback(`sounddevice` 的 `WasapiSettings(loopback=True)`,与现有麦克风链路同一个库、同一套 `InputStream`),Linux 走 PulseAudio/PipeWire 的 `.monitor` 源,macOS 如实报不支持。

这一路同时是 **AEC 的参考信号**(逐块、毫秒级对齐,不能走 HTTP)与**感知库的系统声槽位**(每 3 秒攒一段编码成 WAV base64)。回环流是独占资源(同一输出设备开两条 loopback 在 WASAPI 上互相干扰),故只采一次、在服务内分发。

**独立槽位**而非复用音频槽:麦克风回答"用户说了什么",系统声回答"用户此刻在听什么";混一槽会互相覆盖,而且模型再也分不出"这段是人说的还是屏幕里放的"。

## 6. 两处原先挂着的缺陷

**`HITLPolicy.decide` TOCTOU** — 分裂持锁使同一条审批可被裁决两次(history 落两条、事件发两次、`req.decision` 取决于哪个线程最后写;若方向相反则结果不确定)。改为 `pop` 与查询同一次持锁。复现如实记录:CPython 默认 5ms GIL 间隔下测不出来(200 轮 0 次);压到 1e-6 + 4 线程后**修复前 400 轮命中 12 次,修复后 0 次**。

**`DeviceTokenRegistry._by_hash` 无界增长** — 按保留期清理(默认 30 天,按**吊销时刻**计时;上限默认 512)。关键不变量:**淘汰只动已吊销记录,永不动未吊销的** —— 删掉在用记录等于悄悄把设备踢下线,比存储增长严重得多;活跃记录本身超上限时如实升 WARNING,不自作主张删 working 凭证。

## 7. 排错七处(每处先实测复现再修)

按"分裂持锁 / 无界增长 / 静默降级 / 资源泄露"逐类扫新代码:

1. **跨隐私边界的音频泄露** — 采几秒 → 暂停 → 恢复,那段**暂停之前**的音频被送进感知库。`pause()` 只清感知库自己的缓存,**碰不到**采集服务的待送缓冲;而"下一块到来时看见 paused 再清"在"暂停期间扬声器静音、压根没有新块"时不会触发。这与我先前在感知库**内部**修过的缺陷是同一类,在上一层重新引入了一次。改用感知库的 `epoch` 世代号(pause/resume 都自增,故"暂停过"在恢复之后依然可见)。
2. **下行播放阻塞事件循环** — `OutputStream.write()` 按契约会阻塞,而 `play()` 跑在事件循环上;一阻塞,同一循环上的**上行**也跟着停,等于用"实时"播放器把刚做出来的双工性质亲手毁掉。改成回调驱动,`play()` 只往有界环形缓冲追加。
3. **`_last_snapshot_ts` 初始化为 0.0** 使快照间隔失效(第一块永远立刻触发)。这处顺带暴露了**我自己的一个空跑测试**:那条"缓冲必须有上界"的用例断言 `<= 上限`,而实际值恒为 0,一直绿着但什么都没测。
4. **连接被服务端正常关闭时静默失效** — `async for` 安静结束、不抛异常;上行从此每次返回 False(没人看返回值),下行消费方挂死在永不再有事件的队列上。症状是"助手突然不理人了",日志零线索。改为升 WARNING + 补发 `SESSION_CLOSED`。
5. **CodeQL 异常泄露** ×2 — 新增两个接口的兜底分支返回 `str(exc)`,会把文件路径/模块名经 HTTP 外泄。改为统一 `error_code` + 堆栈只进服务端日志。
6. **测试顺序依赖** — 反自激励门是带时间状态的进程单例,任何测试走过一次朗读路径都会往里登记,留存窗口内让 ambient 音频通路被静默跳过:单文件全绿、整套跑失败,失败点离污染源很远(实测由 `test_true_streaming_chain.py` 触发 `test_ambient_attention_loop.py` 3 个用例失败)。按仓库既有约定在 conftest 加 autouse 清零。
7. **`_HOLD_PATTERNS` 死代码**(已识别,待修)— 6 个含空格的多词模式在 `classify_barge_in` 里永远匹配不到(文本已去空格)。当前**不是**行为缺陷(它们仍会因"含实义内容"落到 interrupt),但是个陷阱。

**另核实两处后判定为非缺陷,不做改动:**
- `websockets` 并发 send:实测 204 次并发上行 + 交错 interrupt,**零异常、零交错帧**(完整消息的 send 由库内部串行化),不需要自己加锁。
- `voice_echo_guard._classify_inner` 与 `aec.process` 的两次持锁:前者第二次持锁只更新计数器、不依赖第一次读到的状态;后者两处在互斥分支上。均不构成 TOCTOU。

---

## 验证

**新增约 200 例测试,全绿。** AEC 之所以能在没有麦克风、没有 Windows 机器的环境里严肃验证,是因为它有一个**客观标量指标**:用已知回声路径(参考信号 → 卷积已知 RIR → 加已知时延)合成信号,ERLE 就是可断言的数字。

| 断言 | 阈值 | 实测 |
|---|---|---|
| 纯回声收敛后 ERLE | ≥18 dB | 27 dB |
| 时延估计偏差 | ≤64 样本 | 20(真值 800) |
| **双讲时用户语音相关** | >0.9 | **0.986** |
| **双讲时残差/近端能量差** | ±3 dB | **+0.15 dB** |
| 整段 ERLE / 最差单块 | >0 / >−10 dB | 不放大 |

双讲那两行比 ERLE 更要紧:**一个把回声消干净、却把用户的话削掉的 AEC 是负资产** —— ASR 什么都听不清,而症状极难归因。

双工层分三段验证:帧编解码抽成纯函数(零网络,provider 改格式立刻失败);完整会话跑在**本地真 WebSocket 服务端**上(不是 mock —— 真建连、真收发:建连 → 下发配置 → 上行音频 → 收转写与音频 → barge-in → 关闭),含"上行不等下行"专门用例(若两者串行,双工只是回合制换了个壳);接线用例断言开关两个方向都真的路由。

**反向验证逐项做过** —— 每条修复都逐个拆掉、确认对应用例精确失败:功率初始化、分区归一化、`_process_chunk` 里的 AEC 调用、`start()`/`stop()` 的双工接线、epoch 边界作废、时间戳初始化、阻塞式 write、`pop` 独占、保留期清理、长度排序、反自激励门开关。

**"写了没接"专项核查:** 5 个新模块的生产调用方数分别为 6 / 5 / 4 / 2 / 1,全部非零。

`flake8 core/` / `black --check core/ tests/` / `isort --check-only core/ tests/` 三条全绿。

## CI 处置

- `lint` ✅ · **CodeQL** ✅(其两条发现已修并 resolved)· mypy / gitleaks / Import Boundary / Mainline Routing / 各 Governance 门 / 多个 [BLOCKING] E2E ✅
- `File Complexity Budget` ❌ **既有系统性门禁**。用它自己的脚本算过集合交集:**135 个违规文件 ∩ 本 PR 24 个改动文件 = 空集**(不是推断)。本 PR 最大新文件 688 行,远低于任何阈值。
- `test` 两次被 **runner shutdown** 取消(一次在 99% 处),`main` 自己那次也在 25 分钟被超时取消 —— 故另在本地做同机基线比对。此前 `auth` 全集比对结果:分支与 `main` 的失败集合**逐字符相同**(双向差集为空),passed 差值恰等于新增测试数。

## 未做 / 做不到的部分(逐条)

- **双工默认关闭**(`GALAXY_VOICE_DUPLEX=0`)。它需要支持 realtime 的 provider 与 key,默认打开会让所有没配 key 的部署直接失去语音功能。这是刻意的保守默认,**不是没接上** —— 接线有专门测试钉住调用点。
- **ducking(压低音量继续说)做不到。** `edge-tts` 的 `volume` 是**合成时**参数(烤进生成的音频),`_play_audio` 只是播一个文件,`engine.stop()` 只能整段掐断 —— 要 ducking 得先换掉播放层。所以 `classify_barge_in` 只返回"应答/打断"两种,不返回一个没人能兑现的 `duck`。
- **真实 provider 帧格式**无法在此验证(没 key、没出网)。只实现 OpenAI Realtime 适配器;Gemini Live 的 `bidiGenerateContent` 帧形状不同,**没实现就不假装支持** —— `get_adapter("gemini_live")` 显式抛错而非静默退回 OpenAI 的帧。
- **回环采集的真实音频字节流**无法在此验证(未装 `sounddevice`、无 Windows 机器)。设备解析抽成纯函数,五种失败情形用假设备表全覆盖。
- **电脑端 Electron/原生壳不在本仓库**,故本 PR 只做 Python 侧。服务端进程内已能自采(装了 `sounddevice` 的机器上 AEC 与"用户在听什么"都能自己跑起来);壳侧若要接,按 `probe` 结果启动回环线程并 POST 到新端点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy