### PR TITLE
feat(ambient): 接住手表的可打扰性——把「克制是美德」从祈使句变成可测量的输入

### DIFF
--- a/core/ambient_attention_loop.py
+++ b/core/ambient_attention_loop.py
@@ -114,6 +114,10 @@ class AmbientObservation:
     audio_transcript: Optional[str] = None  # 听:能力驱动桥接转写(asr_bridge)后的文字
     screen_meta: Optional[Dict[str, Any]] = None
     recent_memory: List[str] = field(default_factory=list)
+    #: 手表报上来的「现在能不能打扰他」(见 core/interruptibility_registry)。
+    #: 空串 = 没有可用证据 —— 注意「没有证据」既不构成放行、也不构成阻拦,
+    #: 此时循环的行为与接手表之前完全一致。
+    interruptibility_note: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +184,11 @@ class LLMRouterDecider:
             text_lines.append(f"（麦克风此刻听到：「{obs.audio_transcript}」）")
         elif obs.audio_b64:
             text_lines.append("（麦克风此刻有新的声音输入。）")
+
+        # 可打扰性:把「克制是美德」从祈使句变成可测量的输入。
+        # 没有可用证据时是空串 —— 不写模棱两可的话进提示词。
+        if obs.interruptibility_note:
+            text_lines.append(obs.interruptibility_note)
 
         # 融合看:屏幕 + 摄像头两路都发给模型(此前只发一路)。仅当统一模态协商层
         # 判定当前模型【看得见】(vision 可用)时才附图——换到无视觉模型自动省掉图像,
@@ -403,6 +412,62 @@ def _ai_is_speaking() -> bool:
         return False
 
 
+def _interruptibility_note() -> str:
+    """手表报的「现在能不能打扰他」,取一行提示词;拿不到就空串。
+
+    登记处不可用(没装手表、模块导入失败)时返回空串,循环行为与接手表
+    之前完全一致 —— **没有证据既不放行也不阻拦**。
+    """
+    try:
+        from core.interruptibility_registry import get_interruptibility_registry
+
+        return get_interruptibility_registry().prompt_line()
+    except Exception:  # noqa: BLE001 — 可打扰性是增强项,永远不该拖垮本拍
+        return ""
+
+
+def _interruptibility_blocked() -> bool:
+    """此刻是否**明确**不宜主动开口(手表 band=blocked)。
+
+    只有明确的 BLOCKED 才是 True。UNKNOWN / 陈旧 / 没有手表一律 False。
+    """
+    try:
+        from core.interruptibility_registry import get_interruptibility_registry
+
+        return get_interruptibility_registry().is_blocked()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _apply_interruptibility_gate(decision: AmbientDecision) -> AmbientDecision:
+    """手表说「明确别打扰」时,把 SPEAK 降级为 SILENT。
+
+    这是提示词之外的**硬闸**:提示词只是建议,模型可能无视它;
+    用户开着勿扰或正在睡觉时,主动开口是不可接受的失败模式。
+
+    刻意**不拦 DELEGATE**:委托是后台静默干活,不发出声音、不占用户注意力,
+    正是"此刻别说话"时最该做的事。拦掉它等于把"别吵我"误读成"别干活"。
+
+    也刻意**不拦用户显式发起的请求** —— 那条路根本不经过本函数
+    (走 handle_request 正门)。这里管的只有自发注意力。
+
+    降级是**有界延迟**而非丢弃:循环每一拍都会重新判断,勿扰一解除,
+    同样的情形会重新有机会 SPEAK。
+    """
+    if decision.action != AmbientAction.SPEAK:
+        return decision
+    if not _interruptibility_blocked():
+        return decision
+    logger.info("Ambient SPEAK 被可打扰性硬闸降级为 SILENT(手表报告 blocked)")
+    return AmbientDecision(
+        action=AmbientAction.SILENT,
+        # 保留原本要说的话在理由里:事后查日志能看出"它本来想说什么、
+        # 为什么没说",而不是凭空少了一拍。
+        rationale=f"手表报告此刻不宜打扰,原判 SPEAK 已降级(原拟发言:{decision.utterance[:60]})",
+        salient=False,
+    )
+
+
 def _bool_env(name: str, default: bool) -> bool:
     raw = os.getenv(name)
     if raw is None:
@@ -598,6 +663,7 @@ class AmbientAttentionLoop:
             audio_transcript=None,  # 由 tick() 异步补上
             screen_meta=media.get("screen_meta"),
             recent_memory=list(self._recent_rationales[-_RECENT_MEMORY_N:]),
+            interruptibility_note=_interruptibility_note(),
         )
 
     async def _transcribe_async(self, obs: AmbientObservation) -> None:
@@ -649,6 +715,8 @@ class AmbientAttentionLoop:
         except Exception as exc:  # noqa: BLE001 — 决策不可致命
             logger.debug("Ambient decide 异常,视为 SILENT: %s", exc)
             decision = AmbientDecision(action=AmbientAction.SILENT, rationale=f"决策异常: {exc}")
+
+        decision = _apply_interruptibility_gate(decision)
 
         self.decisions += 1
         await self._route(decision, obs)

--- a/core/interruptibility_registry.py
+++ b/core/interruptibility_registry.py
@@ -1,0 +1,241 @@
+"""可打扰性登记处 —— 手表报上来的「现在能不能打扰他」。
+
+## 这块解决什么
+
+常驻注意力循环(``core/ambient_attention_loop.py``)的决策提示词里写着
+「克制是美德——拿不准就选 SILENT」。那只是一句**祈使句**:模型无从知道
+此刻用户是在发呆还是在跑步、在开会还是在睡觉。手表能知道,于是这里把
+那句话变成一个**可测量的输入**。
+
+## 隐私边界(所有者拍板)
+
+心率/运动/睡眠这些原始信号**只在手表本地参与运算,从不上传**。上来的
+只有一个标量报告(见 galaxy-wearos 的 ``com.galaxy.wear.sensing``)。
+本模块只认那几个字段,多余字段一律丢弃 —— 就算某天手表侧被改坏了往上
+塞生物数据,也进不了这里。
+
+## 三条不能含糊的语义
+
+1. **UNKNOWN ≠ FREE**。「没有传感证据」不是「可以打扰」。
+   :meth:`InterruptibilityRegistry.is_blocked` 对 UNKNOWN 返回 False
+   (不阻拦),但 :meth:`prompt_line` 对 UNKNOWN 返回空串(不误导模型)。
+   这两件事必须分开:不阻拦 ≠ 有理由放行。
+2. **陈旧即不存在**。手表掉线后,最后一条报告不能被无限期当成现状。
+   超过 :data:`STALE_AFTER_S` 一律视为没有数据。手表侧每 10 分钟发一次
+   心跳(``InterruptibilityUplinkPolicy.HEARTBEAT_MS``),这里给到 25 分钟,
+   容得下两次丢包。
+3. **有界延迟,不是丢弃**(bounded deferral)。BLOCKED 的语义是「此刻别
+   **主动**开口」,不是「把这件事扔掉」。用户**显式发起**的请求完全不受
+   这个分数约束。
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+#: 手表侧 ``InterruptibilityBand`` 的线上字符串。跨仓协议,改动即漂移
+#: (手表侧由 ``InterruptibilityWireContractTest`` 钉死)。
+KNOWN_BANDS = ("unknown", "blocked", "busy", "neutral", "free")
+
+#: 超过这么久没收到新报告,就当作没有数据(手表心跳周期 10 分钟)。
+STALE_AFTER_S = 25 * 60.0
+
+#: 原因标签的数量与长度上限。手表是可信端,但登记处不该无条件相信任何
+#: 上行内容 —— 否则一条畸形报文就能把提示词撑爆。
+_MAX_REASONS = 8
+_MAX_REASON_LEN = 32
+
+#: 粗粒度标签 → 中文说法。未登记的标签原样透传(前向兼容,不吞掉新标签)。
+_REASON_LABELS = {
+    "dnd": "已开勿扰",
+    "likely_asleep": "极可能在睡",
+    "attending": "正抬腕在看",
+    "high_motion": "运动量大",
+    "moderate_motion": "有一定活动",
+    "still": "静止",
+    "elevated_arousal": "心率高于其个人静息",
+    "calm": "平静",
+    "recent_interaction": "刚交互过",
+    "no_sensor_data": "无传感证据",
+}
+
+
+@dataclass(frozen=True)
+class InterruptibilitySnapshot:
+    """一条已校验的报告。"""
+
+    score: float
+    band: str
+    reasons: tuple = field(default_factory=tuple)
+    confidence: float = 0.0
+    device_id: str = ""
+    received_at: float = 0.0
+
+    @property
+    def usable(self) -> bool:
+        """有没有值得据此行动的证据。
+
+        UNKNOWN 或零置信度 = 手表在,但说不出个所以然 —— 这条报告本身是
+        有意义的(至少说明手表在线),但**不能**拿来当判断依据。
+        """
+        return self.band != "unknown" and self.confidence > 0.0
+
+    def is_stale(self, now: Optional[float] = None) -> bool:
+        return (now if now is not None else time.time()) - self.received_at > STALE_AFTER_S
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "score": round(self.score, 2),
+            "band": self.band,
+            "reasons": list(self.reasons),
+            "confidence": round(self.confidence, 2),
+            "device_id": self.device_id,
+            "received_at": self.received_at,
+        }
+
+
+def _coerce_unit(value: Any, default: float = 0.0) -> float:
+    """任何东西 → [0,1] 的 float。转不动就取默认值,不抛异常炸掉 WS 主流程。"""
+    try:
+        return min(1.0, max(0.0, float(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_reasons(value: Any) -> tuple:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    out: List[str] = []
+    for item in value[:_MAX_REASONS]:
+        if isinstance(item, str) and item:
+            out.append(item[:_MAX_REASON_LEN])
+    return tuple(out)
+
+
+class InterruptibilityRegistry:
+    """按设备存最新一条报告;读的时候只认新鲜的那条。"""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._by_device: Dict[str, InterruptibilitySnapshot] = {}
+
+    # ── 写 ──────────────────────────────────────────────────────────────
+
+    def record(
+        self,
+        payload: Dict[str, Any],
+        device_id: str = "",
+        now: Optional[float] = None,
+    ) -> Optional[InterruptibilitySnapshot]:
+        """收下一条上行报告。band 不认识就整条拒收(协议漂移要看得见)。"""
+        if not isinstance(payload, dict):
+            return None
+
+        band = str(payload.get("band") or "").strip().lower()
+        if band not in KNOWN_BANDS:
+            # 不静默吞:手表侧新增档位而这里没跟上,是必须被人看见的漂移。
+            logger.warning(
+                "可打扰性上报的 band=%r 不在已知集合 %s 内(协议漂移?),整条拒收",
+                band,
+                KNOWN_BANDS,
+            )
+            return None
+
+        snapshot = InterruptibilitySnapshot(
+            score=_coerce_unit(payload.get("score"), 0.5),
+            band=band,
+            reasons=_coerce_reasons(payload.get("reasons")),
+            confidence=_coerce_unit(payload.get("confidence"), 0.0),
+            device_id=str(device_id or payload.get("device") or ""),
+            received_at=now if now is not None else time.time(),
+        )
+        with self._lock:
+            self._by_device[snapshot.device_id] = snapshot
+        return snapshot
+
+    # ── 读 ──────────────────────────────────────────────────────────────
+
+    def current(self, now: Optional[float] = None) -> Optional[InterruptibilitySnapshot]:
+        """最新且未过期的那条;一条都没有则 None。
+
+        多块手表时取**最新**那条 —— 人只有一个,后报的更接近现状。
+        """
+        ts = now if now is not None else time.time()
+        with self._lock:
+            fresh = [s for s in self._by_device.values() if not s.is_stale(ts)]
+        if not fresh:
+            return None
+        return max(fresh, key=lambda s: s.received_at)
+
+    def is_blocked(self, now: Optional[float] = None) -> bool:
+        """此刻是否明确不宜**主动**开口。
+
+        只有 BLOCKED 才返回 True。UNKNOWN/陈旧/没有手表一律 False ——
+        「不知道」不构成阻拦的理由,正如它不构成放行的理由。
+        """
+        snapshot = self.current(now)
+        return bool(snapshot and snapshot.band == "blocked")
+
+    def prompt_line(self, now: Optional[float] = None) -> str:
+        """给决策脑的一行提示;没有可用证据时返回空串(**不写模棱两可的话**)。
+
+        NEUTRAL 也返回空串:它的信息量是零,写进提示词只会占 token、
+        还可能被模型当成某种暗示。
+        """
+        snapshot = self.current(now)
+        if snapshot is None or not snapshot.usable:
+            return ""
+
+        labels = "、".join(_REASON_LABELS.get(r, r) for r in snapshot.reasons)
+        detail = f"({labels})" if labels else ""
+        hedge = "，但证据不足、仅供参考" if snapshot.confidence < 0.5 else ""
+
+        if snapshot.band == "blocked":
+            return f"（手表：此刻明确不宜打扰{detail}{hedge}。除非极其紧要，请选 SILENT。）"
+        if snapshot.band == "busy":
+            return f"（手表：用户此刻偏忙{detail}{hedge}。除非要紧，倾向 SILENT。）"
+        if snapshot.band == "free":
+            return f"（手表：用户此刻大概率可被打扰{detail}{hedge}。）"
+        return ""
+
+    # ── 运维 ────────────────────────────────────────────────────────────
+
+    def snapshot_all(self, now: Optional[float] = None) -> Dict[str, Any]:
+        """给面板/诊断看的全量视图,含陈旧标记(陈旧也要看得见,不能藏起来)。"""
+        ts = now if now is not None else time.time()
+        with self._lock:
+            items = list(self._by_device.values())
+        return {
+            "devices": [{**s.to_dict(), "stale": s.is_stale(ts)} for s in items],
+            "stale_after_s": STALE_AFTER_S,
+        }
+
+    def clear(self) -> None:
+        with self._lock:
+            self._by_device.clear()
+
+
+_registry: Optional[InterruptibilityRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def get_interruptibility_registry() -> InterruptibilityRegistry:
+    global _registry
+    if _registry is None:
+        with _registry_lock:
+            if _registry is None:
+                _registry = InterruptibilityRegistry()
+    return _registry
+
+
+def reset_interruptibility_registry() -> None:
+    """测试用:丢掉单例,避免用例之间互相污染。"""
+    global _registry
+    with _registry_lock:
+        _registry = None

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -830,6 +830,47 @@ async def handle_command(connection_id: str, aip_msg):
             }
             await connection_manager.send_message(connection_id, response)
             return
+        elif command_text == "interruptibility":
+            # WearOS sendInterruptibility → command="interruptibility"
+            # {score, band, reasons, confidence, device, timestamp}。
+            #
+            # 手表回答的是「现在能不能打扰他」,**不**交出身体数据 —— 心率/运动/
+            # 睡眠只在手表本地参与运算(见 galaxy-wearos 的 com.galaxy.wear.sensing)。
+            # 这里落进登记处,供常驻注意力循环把「克制是美德」从祈使句变成
+            # 可测量的输入。
+            snapshot = None
+            try:
+                from core.interruptibility_registry import get_interruptibility_registry
+
+                snapshot = get_interruptibility_registry().record(_payload, device_id=device_id)
+            except Exception as _int_err:  # noqa: BLE001 — 登记失败不该影响 WS 主流程
+                logger.debug("interruptibility record skipped: %s", _int_err)
+
+            if snapshot is None:
+                # 拒收的唯一原因是 band 不认识(协议漂移),registry 已 warning。
+                result = {"success": False, "error": "unrecognised interruptibility band"}
+            else:
+                logger.info(
+                    "⌚ 可打扰性上报: device=%s band=%s score=%.2f conf=%.2f",
+                    device_id,
+                    snapshot.band,
+                    snapshot.score,
+                    snapshot.confidence,
+                )
+                result = {"success": True, "band": snapshot.band}
+            response = {
+                "version": "3.0",
+                "message_id": str(uuid.uuid4()),
+                "correlation_id": aip_msg.message_id,
+                "type": MessageType.COMMAND_RESULT.value,
+                "device_id": aip_msg.device_id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "success": result["success"],
+                "data": result,
+                "payload": result,
+            }
+            await connection_manager.send_message(connection_id, response)
+            return
         elif command_text == "human_input":
             # WearOS sendHumanInput → command="human_input"
             # {decision_id, selected_option?, voice_input?}. 人在回路(HITL)的决策回复。

--- a/tests/test_interruptibility_registry.py
+++ b/tests/test_interruptibility_registry.py
@@ -1,0 +1,309 @@
+"""手表可打扰性接进常驻注意力循环的契约。
+
+所有者拍板的隐私边界:心率/运动/睡眠**只在手表本地参与运算**,上来的
+只有一个标量报告。因此这一侧的责任不是"解读生理数据",而是三件事:
+
+1. **UNKNOWN ≠ FREE** —— "没有传感证据"不是"可以打扰";
+2. **陈旧即不存在** —— 手表掉线后最后一条报告不能被无限期当成现状;
+3. **有界延迟不是丢弃** —— BLOCKED 只压制**自发**开口,不影响委托,
+   更不影响用户显式发起的请求。
+
+这三条只要有一条松了,「克制是美德」就又退回成一句无法执行的祈使句。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.ambient_attention_loop import (
+    AmbientAction,
+    AmbientDecision,
+    AmbientObservation,
+    LLMRouterDecider,
+    _apply_interruptibility_gate,
+)
+from core.interruptibility_registry import (
+    KNOWN_BANDS,
+    STALE_AFTER_S,
+    InterruptibilityRegistry,
+    get_interruptibility_registry,
+    reset_interruptibility_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_interruptibility_registry()
+    yield
+    reset_interruptibility_registry()
+
+
+def _payload(band="free", score=0.8, confidence=1.0, reasons=("calm",)):
+    return {
+        "score": score,
+        "band": band,
+        "reasons": list(reasons),
+        "confidence": confidence,
+        "device": "wear_os",
+        "timestamp": 1_700_000_000_000,
+    }
+
+
+# ── 1. 收报与校验 ────────────────────────────────────────────────────────
+
+
+def test_records_a_valid_report():
+    reg = InterruptibilityRegistry()
+    snap = reg.record(_payload(), device_id="watch-1", now=100.0)
+
+    assert snap is not None
+    assert snap.band == "free"
+    assert snap.score == pytest.approx(0.8)
+    assert snap.reasons == ("calm",)
+    assert snap.device_id == "watch-1"
+
+
+def test_unknown_band_is_rejected_loudly_not_silently_coerced(caplog):
+    """手表侧新增档位而这里没跟上,是必须被人看见的协议漂移。
+
+    静默把它当成 neutral 收下,才是最坏的处理 —— 漂移会一直藏着。
+    """
+    reg = InterruptibilityRegistry()
+    with caplog.at_level("WARNING"):
+        assert reg.record(_payload(band="super_busy")) is None
+    assert any("协议漂移" in r.message or "band" in r.message for r in caplog.records)
+    assert reg.current(now=100.0) is None
+
+
+def test_malformed_fields_are_coerced_not_crashing():
+    """畸形报文不该炸掉 WS 主流程,但也不该被原样信任。"""
+    reg = InterruptibilityRegistry()
+    snap = reg.record(
+        {
+            "band": "busy",
+            "score": "not-a-number",
+            "confidence": 99.0,  # 越界
+            "reasons": "high_motion",  # 不是列表
+        },
+        now=100.0,
+    )
+
+    assert snap is not None
+    assert snap.score == pytest.approx(0.5)  # 转不动 → 中性默认
+    assert snap.confidence == pytest.approx(1.0)  # 钳到 [0,1]
+    assert snap.reasons == ()  # 不是列表 → 丢弃,不猜
+
+
+def test_reason_list_is_bounded():
+    """一条畸形报文不该把提示词撑爆。"""
+    reg = InterruptibilityRegistry()
+    snap = reg.record(_payload(reasons=[f"tag_{i}" for i in range(100)]), now=100.0)
+
+    assert snap is not None
+    assert len(snap.reasons) <= 8
+    assert all(len(r) <= 32 for r in snap.reasons)
+
+
+# ── 2. 陈旧即不存在 ──────────────────────────────────────────────────────
+
+
+def test_stale_report_is_treated_as_absent():
+    """手表掉线后,最后一条报告不能被无限期当成现状。"""
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="free"), now=100.0)
+
+    assert reg.current(now=100.0 + STALE_AFTER_S - 1) is not None
+    assert reg.current(now=100.0 + STALE_AFTER_S + 1) is None
+
+
+def test_stale_blocked_report_stops_blocking():
+    """反向同样要成立:掉线的手表不该永久封住主动开口。"""
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="blocked", score=0.0), now=100.0)
+
+    assert reg.is_blocked(now=200.0) is True
+    assert reg.is_blocked(now=100.0 + STALE_AFTER_S + 1) is False
+
+
+def test_stale_after_exceeds_watch_heartbeat():
+    """过期窗口必须容得下手表的心跳周期(10 分钟),否则一次丢包就误判掉线。"""
+    assert STALE_AFTER_S >= 2 * 10 * 60
+
+
+def test_freshest_device_wins():
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="busy"), device_id="old-watch", now=100.0)
+    reg.record(_payload(band="free"), device_id="new-watch", now=200.0)
+
+    snap = reg.current(now=250.0)
+    assert snap is not None and snap.device_id == "new-watch"
+
+
+# ── 3. UNKNOWN ≠ FREE(整个设计的安全阀)──────────────────────────────
+
+
+def test_unknown_band_is_not_a_green_light():
+    """ "没有传感证据"既不构成放行,也不构成阻拦。"""
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="unknown", score=0.5, confidence=0.0, reasons=["no_sensor_data"]), now=100.0)
+
+    snap = reg.current(now=100.0)
+    assert snap is not None  # 手表在线这件事本身是真的
+    assert snap.usable is False  # 但说不出个所以然
+    assert reg.is_blocked(now=100.0) is False  # 不阻拦
+    assert reg.prompt_line(now=100.0) == ""  # 也不写进提示词误导模型
+
+
+def test_zero_confidence_is_never_usable_even_with_a_confident_looking_band():
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="free", score=0.95, confidence=0.0), now=100.0)
+
+    assert reg.current(now=100.0).usable is False
+    assert reg.prompt_line(now=100.0) == ""
+
+
+def test_no_watch_at_all_produces_no_line_and_no_block():
+    reg = InterruptibilityRegistry()
+
+    assert reg.current(now=100.0) is None
+    assert reg.is_blocked(now=100.0) is False
+    assert reg.prompt_line(now=100.0) == ""
+
+
+# ── 4. 提示词一行 ────────────────────────────────────────────────────────
+
+
+def test_blocked_line_tells_the_model_to_stay_silent():
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="blocked", score=0.0, reasons=["dnd"]), now=100.0)
+
+    line = reg.prompt_line(now=100.0)
+    assert "不宜打扰" in line and "SILENT" in line
+    assert "已开勿扰" in line  # 粗粒度标签被译成人话
+
+
+def test_neutral_writes_nothing_because_it_says_nothing():
+    """NEUTRAL 的信息量是零,写进提示词只会占 token、还可能被当成暗示。"""
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="neutral", score=0.5), now=100.0)
+
+    assert reg.prompt_line(now=100.0) == ""
+
+
+def test_low_confidence_line_hedges_instead_of_asserting():
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="busy", score=0.2, confidence=0.4), now=100.0)
+
+    assert "证据不足" in reg.prompt_line(now=100.0)
+
+
+def test_unregistered_reason_tag_passes_through_verbatim():
+    """手表侧新增标签时不该被吞掉 —— 未登记的原样透传,前向兼容。"""
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(band="busy", reasons=["driving"]), now=100.0)
+
+    assert "driving" in reg.prompt_line(now=100.0)
+
+
+def test_prompt_line_reaches_the_decider_prompt():
+    """光有一行不够,得真的进模型看到的那段文本。"""
+    obs = AmbientObservation(interruptibility_note="（手表：此刻明确不宜打扰。）")
+    messages = LLMRouterDecider()._build_messages(obs)
+
+    content = messages[0]["content"]
+    text = content if isinstance(content, str) else content[0]["text"]
+    assert "此刻明确不宜打扰" in text
+
+
+def test_empty_note_adds_nothing_to_the_prompt():
+    obs = AmbientObservation(interruptibility_note="")
+    messages = LLMRouterDecider()._build_messages(obs)
+
+    content = messages[0]["content"]
+    text = content if isinstance(content, str) else content[0]["text"]
+    assert "手表" not in text
+
+
+# ── 5. 硬闸:提示词只是建议,勿扰时主动开口是不可接受的失败模式 ────────
+
+
+def test_blocked_downgrades_speak_to_silent():
+    get_interruptibility_registry().record(_payload(band="blocked", score=0.0, reasons=["likely_asleep"]))
+
+    gated = _apply_interruptibility_gate(
+        AmbientDecision(action=AmbientAction.SPEAK, utterance="你回来了", salient=True)
+    )
+
+    assert gated.action == AmbientAction.SILENT
+    assert gated.salient is False
+    # 原本要说的话必须留在理由里:事后查日志能看出"它本来想说什么、为什么没说"。
+    assert "你回来了" in gated.rationale
+
+
+def test_blocked_does_not_stop_delegation():
+    """ "别吵我"不等于"别干活" —— 委托是后台静默执行,正是此刻最该做的事。"""
+    get_interruptibility_registry().record(_payload(band="blocked", score=0.0))
+
+    decision = AmbientDecision(action=AmbientAction.DELEGATE, task="查一下那个报错")
+    assert _apply_interruptibility_gate(decision) is decision
+
+
+def test_busy_does_not_hard_gate_speak():
+    """BUSY 只进提示词让模型权衡,硬拦太钝 —— 要紧的事仍该说。"""
+    get_interruptibility_registry().record(_payload(band="busy", score=0.2))
+
+    decision = AmbientDecision(action=AmbientAction.SPEAK, utterance="服务器挂了")
+    assert _apply_interruptibility_gate(decision).action == AmbientAction.SPEAK
+
+
+def test_no_watch_leaves_behaviour_identical_to_before():
+    """没接手表时,整条链路的行为必须与接手表之前一模一样。"""
+    decision = AmbientDecision(action=AmbientAction.SPEAK, utterance="随便说点什么")
+    assert _apply_interruptibility_gate(decision) is decision
+
+
+def test_gate_is_bounded_deferral_not_permanent_drop():
+    """降级是有界延迟:勿扰一解除,同样的情形重新有机会 SPEAK。"""
+    reg = get_interruptibility_registry()
+    reg.record(_payload(band="blocked", score=0.0))
+    assert _apply_interruptibility_gate(AmbientDecision(action=AmbientAction.SPEAK, utterance="x")).action == (
+        AmbientAction.SILENT
+    )
+
+    reg.record(_payload(band="free", score=0.9))
+    assert _apply_interruptibility_gate(AmbientDecision(action=AmbientAction.SPEAK, utterance="x")).action == (
+        AmbientAction.SPEAK
+    )
+
+
+# ── 6. 跨仓协议 ──────────────────────────────────────────────────────────
+
+
+def test_known_bands_match_the_watch_side_contract():
+    """与 galaxy-wearos 的 InterruptibilityBand.wire 一一对应。
+
+    手表侧由 `InterruptibilityWireContractTest` 钉死同一份字符串;
+    任何一侧单独改动都会让这两个测试之一变红。
+    """
+    assert set(KNOWN_BANDS) == {"unknown", "blocked", "busy", "neutral", "free"}
+
+
+def test_snapshot_all_exposes_staleness_instead_of_hiding_it():
+    reg = InterruptibilityRegistry()
+    reg.record(_payload(), device_id="watch-1", now=100.0)
+
+    view = reg.snapshot_all(now=100.0 + STALE_AFTER_S + 1)
+    assert view["devices"][0]["stale"] is True
+    assert view["stale_after_s"] == STALE_AFTER_S
+
+
+def test_wire_payload_carries_no_biometric_fields():
+    """隐私契约的这一侧:就算手表被改坏了往上塞生物数据,也进不了登记处。"""
+    reg = InterruptibilityRegistry()
+    snap = reg.record(
+        {**_payload(), "heart_rate_bpm": 132, "resting_bpm": 58, "hrv_rmssd": 21},
+        now=100.0,
+    )
+
+    assert snap is not None
+    assert not any("heart" in k or "bpm" in k or "hrv" in k for k in snap.to_dict())


### PR DESCRIPTION
配对 PR:[galaxy-wearos#14](https://github.com/DannyFish-11/galaxy-wearos/pull/14)(手表侧,CI 已实测全绿)。

## 这一版在解决什么

常驻注意力循环的决策提示词末尾一直写着「**克制是美德——拿不准就选 SILENT**」。

那只是一句**祈使句**。模型无从知道此刻用户是在发呆还是在跑步、在开会还是在睡觉,所以这句话既不可能被遵守,也不可能被违反 —— 它没有对应的可观测量。手表侧现在能算出这件事(全部在表上本地算),这个 PR 把它接进来。

## 新增 `core/interruptibility_registry.py`

按设备存手表报上来的标量报告,读的时候只认新鲜的那条。三条不能含糊的语义,每一条都有对应用例钉死:

### 1. UNKNOWN ≠ FREE

「没有传感证据」不是「可以打扰」。

- `is_blocked()` 对 UNKNOWN 返回 `False`(**不阻拦**)
- `prompt_line()` 对 UNKNOWN 返回空串(**不误导模型**)

这两件事必须分开:**不阻拦 ≠ 有理由放行**。把它们合并成一个布尔量,是这类设计最常见的坍塌方式。

### 2. 陈旧即不存在

手表掉线后,最后一条报告不能被无限期当成现状。超过 25 分钟一律视为没有数据。

窗口取手表心跳周期(10 分钟)的两倍以上,容得下两次丢包 —— 有专门用例守住这个不等式,免得日后有人单独改一边。

### 3. 有界延迟不是丢弃(bounded deferral)

`blocked` 的语义是「此刻别**主动**开口」,不是「把这件事扔掉」。循环每一拍都会重新判断,勿扰一解除,同样的情形重新有机会 SPEAK。

### 协议漂移要看得见

`band` 不在已知集合内时**整条拒收并 warning**,不静默当 `neutral` 收下。静默强转才是最坏的处理 —— 跨仓协议漂移会一直藏着,直到某天以别的形态爆出来。

## 软硬两层

| 层 | 做什么 | 为什么 |
|---|---|---|
| 软(提示词) | 把粗粒度标签译成人话,进决策提示词 | 让模型自己权衡 BUSY / FREE,保留判断力 |
| 硬(闸) | BLOCKED 时把 SPEAK 降级为 SILENT | 提示词只是建议,模型可能无视它 |

**为什么需要硬闸**:用户开着勿扰、或正在睡觉时主动开口,是不可接受的失败模式,不能只靠模型自觉。

**硬闸刻意不拦 `DELEGATE`** —— 委托是后台静默干活,不发声、不占注意力,正是「此刻别说话」时最该做的事。拦掉它等于把「别吵我」误读成「别干活」。

**也不拦用户显式发起的请求** —— 那条路走 `handle_request` 正门,根本不经过这里。这里管的只有自发注意力。

降级时把原拟发言留在 `rationale` 里:事后查日志能看出「它本来想说什么、为什么没说」,而不是凭空少了一拍。

`NEUTRAL` 返回空串 —— 它的信息量是零,写进提示词只会占 token、还可能被模型当成某种暗示。置信度低于 0.5 时措辞自动加「证据不足、仅供参考」。

## 隐私边界(所有者拍板)

心率 / 运动 / 睡眠**只在手表本地参与运算,从不上传**。登记处只认 `score` / `band` / `reasons` / `confidence` 四个字段,多余字段一律丢弃 —— 就算某天手表侧被改坏了往上塞生物数据,也进不了这里。

有用例直接喂 `heart_rate_bpm` / `hrv_rmssd` 进去,验证它们不会出现在存下来的快照里。手表那一侧另有一个「键集合完全相等」的契约测试把源头堵死,两侧各守一道。

## 没接手表时行为完全不变

登记处不可用、没有手表、报告陈旧 —— 任一情况下 `prompt_line()` 是空串、`is_blocked()` 是 `False`,整条链路与接手表之前一模一样。有用例守住这条。

## 验证(CI 实测为准,以下为本地)

- 新增 **25 个用例,全绿**;
- 回归 `-k "ambient or websocket_handler or wear or protocol_msgtype"` → **110 passed / 3 skipped / 0 failed**;
- `flake8` 新文件 0 错;`websocket_handler.py` 改动前后**同为 17 条存量告警**(`git stash` 交叉验证,零新增);`black` / `isort` 均过;
- `ambient_attention_loop.py` 956 行,仍在 1000 行 WARN 线以下。

## 如实说明

没有真机端到端:我没有手表、没有传感器。这条链路的**协议侧与判定侧**都有测试覆盖,但「手表真的采到心率、真的报上来、桌面真的因此闭嘴」这一整条,需要所有者戴上表实测。手表侧所有阈值集中在 `InterruptibilityThresholds` 一处,便于按自己的身体数据调整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_