### PR TITLE
ci: 给测试加超时,并修掉它照出来的全部 14 条基线失败

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,12 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # 硬性上限。此前挂死时这个作业会一直耗到 runner 被回收(实测有 64 分钟的),
+    # GitHub 只丢下一句 "The runner has received a shutdown signal",既没有失败清单
+    # 也没有任何线索。设了之后至少得到一个明确的"作业超时",而且
+    # pytest.ini 的 faulthandler_timeout 会在此之前把挂点的线程堆栈打进日志。
+    # 正常全量约 20 分钟,60 分钟留了 3 倍余量。
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:

--- a/core/credential_vault.py
+++ b/core/credential_vault.py
@@ -79,6 +79,24 @@ _DEFAULT_VAULT_URL = "http://localhost:8003"
 #: detection logic without duplicating the list.
 PLACEHOLDER_PREFIXES: tuple = ("your_", "your-", "change_me", "todo", "<", "example", "xxx")
 
+
+def is_placeholder(value: Optional[str]) -> bool:
+    """``value`` 是不是 ``.env.example`` / ``secrets.example.env`` 里未编辑的模板值。
+
+    「已配置」在整个仓库里必须只有一个定义。此前这份表在 vault 里**只用在环境变量
+    兜底那一层**:``get_credential()`` 的内存层与远端后端层原样返回,
+    ``list_credential_keys()`` 也原样列出。于是 ``POST /api/v1/vault/credentials``
+    把一串 ``your_deepseek_api_key_here`` 存进来之后:
+
+      * ``MultiLLMRouter._get_key()`` 的第 2 层(vault)会把它当真密钥返回 —— 而第 1 层
+        (面板/UnifiedConfig)和第 3 层(环境变量)都是过滤过的,唯独中间这层没有;
+      * provider 因此被注册成"可用",面板显示"已连接",真实调用必然 401。
+
+    这正是本仓库反复修的那类「看起来已保存,实际用不了」。收口成一个函数,三层共用。
+    """
+    return bool(value) and str(value).strip().lower().startswith(PLACEHOLDER_PREFIXES)
+
+
 # 支持的凭证键名 -> 对应的环境变量名
 #
 # 之前只覆盖 8 个 provider，漏了 google/xai/mistral/qwen/zhipu/minimax/step/
@@ -231,16 +249,24 @@ class CredentialVault:
           2. SecretVault HTTP backend（若 GALAXY_SECRET_BACKEND=vault）
           3. 环境变量回退
         """
+        # 三层一律过占位符。未编辑的模板值不是凭证——不管它是从哪一层来的。
+        # 此前只有第 3 层过滤,前两层原样返回,详见 is_placeholder() 的说明。
         # 1. 内存 Vault
         if key_name in self._credentials:
             value = self._credentials[key_name]
-            self._record_audit("get", key_name, actor=actor, token=None)
-            return value
+            if is_placeholder(value):
+                logger.warning(
+                    "凭证 '%s' 存的是未编辑的模板值,按未配置处理(请填入真实密钥)",
+                    key_name,
+                )
+            else:
+                self._record_audit("get", key_name, actor=actor, token=None)
+                return value
 
         # 2. Remote SecretVault backend
         if self._backend is not None:
             remote = self._backend.get(key_name)
-            if remote:
+            if remote and not is_placeholder(remote):
                 # Cache locally for subsequent calls
                 self._credentials[key_name] = remote
                 self._record_audit("get_vault", key_name, actor=actor, token=None)
@@ -250,7 +276,7 @@ class CredentialVault:
         env_key = _ENV_MAPPING.get(key_name, "")
         if env_key:
             value = os.environ.get(env_key, "")
-            if value and not value.lower().startswith(PLACEHOLDER_PREFIXES):
+            if value and not is_placeholder(value):
                 self._record_audit("get_env", key_name, actor=actor, token=None)
                 return value
 
@@ -265,13 +291,17 @@ class CredentialVault:
         return False
 
     def list_credential_keys(self) -> List[str]:
-        """列出所有已存储的凭证键名（不返回值）"""
-        vault_keys = list(self._credentials.keys())
-        env_keys = [
-            k
-            for k, v in _ENV_MAPPING.items()
-            if os.environ.get(v, "") and not os.environ.get(v, "").lower().startswith(PLACEHOLDER_PREFIXES)
-        ]
+        """列出所有已存储的凭证键名（不返回值）
+
+        内存层同样要过占位符:这个列表是面板判断"哪些 provider 已配置"的依据之一,
+        把一个存着 ``your_..._here`` 的键列进来,面板就会显示"已连接"——而
+        ``get_credential()`` 现在对它返回 None,两边会自相矛盾。环境变量那半边
+        本来就过滤了,这里补齐,让两半用同一个判据。
+        """
+        # 注意 ``is_placeholder("")`` 是 False(空值不是占位符),所以非空判断不能省——
+        # 少了它会把「环境变量存在但为空」也列成已配置。
+        vault_keys = [k for k, v in self._credentials.items() if v and not is_placeholder(v)]
+        env_keys = [k for k, v in _ENV_MAPPING.items() if (_ev := os.environ.get(v, "")) and not is_placeholder(_ev)]
         all_keys = sorted(set(vault_keys + env_keys))
         return all_keys
 

--- a/core/routes/vault.py
+++ b/core/routes/vault.py
@@ -47,10 +47,22 @@ def create_router(service_manager=None, config=None) -> APIRouter:
         if not key_name or not value:
             raise HTTPException(status_code=400, detail="key_name and value are required")
         try:
-            from core.credential_vault import get_vault
+            from core.credential_vault import get_vault, is_placeholder
 
+            # 当场退回,不要收下再说。收下的话调用方看到 success=True、面板显示"已连接",
+            # 但 get_credential() 会把它当未配置返回 None,真实调用则一路 401 ——
+            # 用户完全看不出问题出在"粘的是模板文字"。
+            if is_placeholder(value):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"'{key_name}' 的值看起来是示例文件里未编辑的模板占位符,不是真实密钥。" "请填入实际的 API key。"
+                    ),
+                )
             get_vault().set_credential(key_name, value)
             return JSONResponse({"success": True, "key_name": key_name})
+        except HTTPException:
+            raise
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
 

--- a/galaxy_gateway/android/handlers/capability_report.py
+++ b/galaxy_gateway/android/handlers/capability_report.py
@@ -188,11 +188,24 @@ async def handle_capability_report(bridge: "AndroidBridge", websocket: Any, mess
         len(capability_schemas),
     )
 
-    async with bridge._lock:
-        if device_id in bridge._devices:
-            # 根因：_devices 为 transport cache（SSOT 在 UDM）；transport handle
-            # 的 supported_actions/心跳字段写入封装到 AndroidDevice.update_supported_actions()。
-            bridge._devices[device_id].update_supported_actions(list(supported_actions))
+    # 根因：_devices 为 transport cache（SSOT 在 UDM）；transport handle
+    # 的 supported_actions/心跳字段写入封装到 AndroidDevice.update_supported_actions()。
+    #
+    # 这条腿必须是**非致命**的。它写的是明确声明为「非事实来源」的 transport cache，
+    # 而紧随其后的 _sync_supported_actions_to_capability_authority() 写的才是权威能力面。
+    # 此前它是本函数里唯一没有 try 兜的一条腿，又恰好排在最前面 —— 于是缓存写一旦抛异常，
+    # 权威写连同后面所有步骤会被一起吞掉，设备的能力就此在权威面上「不存在」，而调用方
+    # 只会看到一个异常，完全看不出权威面没被写。非权威的写不该给权威的写当门槛。
+    try:
+        async with bridge._lock:
+            if device_id in bridge._devices:
+                bridge._devices[device_id].update_supported_actions(list(supported_actions))
+    except Exception as cache_exc:
+        logger.warning(
+            "capability_report: transport cache 更新失败（非致命，权威能力面照写）: device_id=%s error=%s",
+            device_id,
+            cache_exc,
+        )
 
     if device_id:
         try:

--- a/galaxy_gateway/android/handlers/registration.py
+++ b/galaxy_gateway/android/handlers/registration.py
@@ -932,20 +932,34 @@ async def handle_device_register(bridge: "AndroidBridge", websocket: Any, messag
             pass
 
         # PR-28: Sync tailscale_ip to MeshCoordinator + TailscaleP2PAdapter
+        #
+        # 这里刻意用 ``_cached_device`` 而不是复用 ``device``:Python 没有块级作用域,
+        # 在这个 try 里写 ``device = ...`` 会把上面第 874 行那个「本次注册刚建出来的」
+        # 对象**换掉**,而且一路泄漏到函数剩下的三百行 —— 能力同化(device.capabilities)、
+        # 角色分配(device.platform)、注册日志(device.model)、跨设备相位推送
+        # (device.websocket.send_json)全都跟着换。两种真实后果:
+        #   * 缓存里没有这个 id 时(调用方自带 bridge / 缓存被换实现),``.get()`` 返回
+        #     None,``device.model`` 这行没有 try 兜着,直接把整个注册打成 success=False
+        #     —— 而 UDM 的规范写入在第 870 行**已经成功了**,设备状态就此撕裂;
+        #   * 缓存里有、但不是同一个对象时,后续全作用在别的连接上。第 874-876 行是在
+        #     ``bridge._lock`` 内建的,这里的读**不在锁内**,同一 device_id 的重复
+        #     register(弱网重连的典型形态)会在两者之间替换缓存条目,于是第 1223 行
+        #     会把相位 send_json 到**另一条 websocket** 上。
+        # 这个 block 只需要缓存条目上的 tailscale_ip,拿完就该扔,不该动 ``device``。
         try:
-            device = bridge._devices.get(device_id)
-            if device and device.tailscale_ip:
+            _cached_device = bridge._devices.get(device_id)
+            if _cached_device and _cached_device.tailscale_ip:
                 from core.mesh_coordinator import get_mesh_coordinator
 
                 mesh = get_mesh_coordinator()
                 mesh.register_peer(
                     device_id=device_id,
-                    tailscale_ip=device.tailscale_ip,
+                    tailscale_ip=_cached_device.tailscale_ip,
                 )
                 logger.debug(
                     "PR-28: Device %s tailscale_ip=%s synced to MeshCoordinator",
                     device_id,
-                    device.tailscale_ip,
+                    _cached_device.tailscale_ip,
                 )
         except Exception:
             pass

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,28 @@ markers =
     g7_smoke: PR-G7 developer-experience quick-verify smoke suite
     slow: slow tests (skipped by default in fast CI runs)
     manual: manual integration tests that require live services (always skipped in CI)
+# ── 单条测试的超时上限 ────────────────────────────────────────────────────────
+# 修的是什么:没有它,**挂死的测试永远不会中止**。实测 `test` 作业连续多次在跑到 99%
+# 时静默卡住 —— 一条测试进去就再没出来,直到 runner 整体被回收(GitHub 打出 "The runner
+# has received a shutdown signal"),整轮 4 万多条测试**一个结论都拿不到**:既看不到失败
+# 清单,也看不到卡在哪。main 自己也有同样签名(某次 test 作业卡 64 分钟被杀,同 run 其它
+# 16 个作业全绿)。
+#
+# 120s 的来历:实测仓库里最可能慢的那批(duplex/websocket/e2e/session/nats/mesh),最慢的
+# 真实用例是 30.11s,其次 16.04s,再往下是一批 ~10s。120s 给了最慢者 4 倍余量,同时能抓住
+# CI 上那个 4 分 19 秒的异常者与无限挂死。个别确实需要更久的用例可用
+# @pytest.mark.timeout(N) 单独放宽,不必抬高全局值。
+#
+# 为什么是 signal 而不是 thread(实测选出来的):
+#   signal —— 打断那一条并如实报成 failure,**整轮继续跑完**,拿得到完整失败清单;
+#   thread —— dump 所有线程栈后直接杀进程,整轮中止,还是拿不到清单。
+# 已实测两种真实挂法(等永不释放的锁、长 sleep)在 signal 方式下都能被打断且不影响后续。
+#
+# 刻意写成 ini 选项而不是塞进 addopts:没装 pytest-timeout 的环境下,ini 里的未知键只会
+# 产生一条 PytestConfigWarning(exit 0),而 addopts 里的 --timeout 会直接让 pytest 报错。
+timeout = 120
+timeout_method = signal
+
 filterwarnings =
     ignore::DeprecationWarning:launcher.*
     ignore:launcher.config_manager is HARD_DEPRECATED.*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,21 @@ markers =
 timeout = 120
 timeout_method = signal
 
+# ── 兜底诊断:不依赖信号的堆栈快照 ──────────────────────────────────────────────
+# 上面那套 per-test 超时**本地实测有效**(等永不释放的锁、thread.join 两种挂法都能在设定
+# 秒数被打断,整轮继续跑完),但在 CI 上没能救回来:`test` 作业仍然挂死在 92% 处,日志
+# 逐字节停住四十多分钟,而且**一条 Timeout 行都没有** —— 说明 SIGALRM 那条路在真实挂点上
+# 没走通。可能的原因是挂点不在 pytest_runtest_protocol 覆盖的范围内(pytest-timeout 只挂
+# 这一个钩子),也可能是卡在不响应信号递送的 C 调用里。这里不猜。
+#
+# faulthandler 走的是**独立看门狗线程**,不经过信号,所以上面那条不管为什么没走通,它都
+# 照样能打出快照:实测输出包含**每个线程**的完整堆栈,精确到文件与行号。它只 dump、不终止
+# —— 但我们要的正是"卡在哪一行",终止交给下面的作业级超时。
+#
+# 取 120s 与 per-test 超时同值:正常情况下 per-test 先动手,轮不到它;只有 per-test 失灵时
+# 它才是唯一的线索来源。
+faulthandler_timeout = 120
+
 filterwarnings =
     ignore::DeprecationWarning:launcher.*
     ignore:launcher.config_manager is HARD_DEPRECATED.*:DeprecationWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,4 +27,15 @@ pytest>=7.4.4
 pytest-asyncio>=0.23.3
 pytest-cov>=4.1.0
 pytest-mock>=3.12.0
+# 真 bug 修复(CI 排查):没有它,**挂死的测试永远不会中止**。
+#
+# 实测:`test` 作业连续多次在跑到 99% 时静默卡住 —— 单条测试进去就再没出来,直到
+# runner 整体被回收(GitHub 打出 "The runner has received a shutdown signal"),于是
+# 整轮 4 万多条测试**一个结论都拿不到**,既看不到失败清单,也看不到卡在哪。main 自己
+# 也有同样签名(某次 test 作业卡 64 分钟被杀,同 run 其它 16 个作业全绿)。
+#
+# 装上之后,超时的那条会被打断并如实报成 failure,**整轮继续跑完** —— 这才拿得到完整
+# 的失败清单,traceback 也直接指出卡在哪一行。已实测两种真实挂法(等永不释放的锁、
+# 长 sleep)都能被打断且不影响后续用例。
+pytest-timeout>=2.3.0
 coverage>=7.4.0

--- a/tests/conformance/test_gateway_routing.py
+++ b/tests/conformance/test_gateway_routing.py
@@ -266,7 +266,7 @@ class TestCapabilityRegistryRegisterValidation:
         """Return a fresh CapabilityRegistry instance for testing."""
         from core.agent.capability_registry import CapabilityRegistry
 
-        reg = CapabilityRegistry.__new__(CapabilityRegistry)
+        reg = object.__new__(CapabilityRegistry)
         reg._initialized = False
         reg.__init__()
         return reg
@@ -316,7 +316,7 @@ class TestCapabilityRegistryInjectMCPTool:
     def _fresh_registry(self):
         from core.agent.capability_registry import CapabilityRegistry
 
-        reg = CapabilityRegistry.__new__(CapabilityRegistry)
+        reg = object.__new__(CapabilityRegistry)
         reg._initialized = False
         reg.__init__()
         return reg
@@ -358,7 +358,7 @@ class TestCapabilityRegistryInjectSkill:
     def _fresh_registry(self):
         from core.agent.capability_registry import CapabilityRegistry
 
-        reg = CapabilityRegistry.__new__(CapabilityRegistry)
+        reg = object.__new__(CapabilityRegistry)
         reg._initialized = False
         reg.__init__()
         return reg

--- a/tests/test_agent_kernel.py
+++ b/tests/test_agent_kernel.py
@@ -63,7 +63,7 @@ class TestPolicyLoader:
 
         monkeypatch.setattr(policy_loader, "_POLICIES_DIR", tmp_path)
         # 重置单例
-        policy_loader._loader = policy_loader.PolicyLoader.__new__(policy_loader.PolicyLoader)
+        policy_loader._loader = object.__new__(policy_loader.PolicyLoader)
         policy_loader._loader._initialized = False
         policy_loader._loader.__init__()
         policy_loader._loader._cache.clear()

--- a/tests/test_all_provider_api_keys_survive_restart.py
+++ b/tests/test_all_provider_api_keys_survive_restart.py
@@ -116,7 +116,7 @@ def fresh_env_and_config(tmp_path):
 
         load_dotenv(dotenv_path=str(env_path), override=True)
 
-        cfg = uc.UnifiedConfig.__new__(uc.UnifiedConfig)
+        cfg = object.__new__(uc.UnifiedConfig)
         cfg._config = {}
         cfg._callbacks = {}
         cfg.project_root = tmp_path

--- a/tests/test_all_provider_api_keys_survive_restart.py
+++ b/tests/test_all_provider_api_keys_survive_restart.py
@@ -86,17 +86,35 @@ def fresh_env_and_config(tmp_path):
     做快照/精确恢复(而不是只清理"已知的" _EXPECTED 键)，避免残留污染到本
     进程里运行的其它测试(真实复现过:遗留的 DEEPSEEK_API_KEY 等会让同一
     pytest 会话里其它文件的"未配置应为空"断言拿到脏数据)。
+
+    **还原 os.environ 并不够。** 这个 fixture 会把一整套假 Key 灌进 os.environ,
+    在这期间只要有任何代码碰了**真正的** UnifiedConfig 单例、触发它的 ``_load_env()``,
+    这批假 Key 就会被**烤进它的 ``_config`` 缓存**——那份缓存是独立于 os.environ 的
+    另一层,上面的 ``os.environ.clear()/update()`` 完全够不着它。实测泄漏(本 fixture
+    跑完之后,在别的文件里查):
+
+        os.environ["ONEAPI_API_KEY"]           -> 已正确还原
+        uc.get("api_keys.ONEAPI_API_KEY")      -> 'sk-oneapi-x'   ← 从缓存里出来的
+        MultiLLMRouter()._get_key("oneapi")    -> 'sk-oneapi-x'
+
+    后果:同一会话里 ``test_panel_apikey_placeholder_detection.py`` 的
+    ``test_underscore_placeholder_env_fallback_not_registered`` 会拿到这个残留值、
+    把 OneAPI provider 注册起来,于是那条断言假红(单跑绿、合并跑红)。所以这里连
+    ``_backend._config`` 一起快照/还原。
     """
     env_path = tmp_path / ".env"
     env_path.write_text(ALL_ENV_CONTENT, encoding="utf-8")
 
+    import core.unified_config as uc
+
     env_snapshot = dict(os.environ)
+    # uc.config 是 UnifiedConfigManager,真正装配置的缓存在它委托的 _backend 上。
+    _backend = getattr(uc.config, "_backend", None)
+    cache_snapshot = dict(_backend._config) if _backend is not None else None
     try:
         from dotenv import load_dotenv
 
         load_dotenv(dotenv_path=str(env_path), override=True)
-
-        import core.unified_config as uc
 
         cfg = uc.UnifiedConfig.__new__(uc.UnifiedConfig)
         cfg._config = {}
@@ -114,6 +132,9 @@ def fresh_env_and_config(tmp_path):
     finally:
         os.environ.clear()
         os.environ.update(env_snapshot)
+        if cache_snapshot is not None and _backend is not None:
+            _backend._config.clear()
+            _backend._config.update(cache_snapshot)
 
 
 class TestAllProviderKeysResolveAfterRestart:

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -283,7 +283,7 @@ class TestNodeFailover(unittest.TestCase):
     def test_failover_method_exists(self):
         from core.node_registry import NodeRegistry
 
-        registry = NodeRegistry.__new__(NodeRegistry)
+        registry = object.__new__(NodeRegistry)
         registry._initialized = False
         registry.__init__()
         self.assertTrue(hasattr(registry, "_failover_call"))

--- a/tests/test_capability_full_unification.py
+++ b/tests/test_capability_full_unification.py
@@ -103,17 +103,19 @@ async def test_android_capability_report_writes_directly_to_canonical_capability
     from core.capability_runtime.capability_state import CapabilityAvailability
     from core.unified.capability_resolver import get_capability_resolver
     from galaxy_gateway.android.handlers.capability_report import handle_capability_report
+    from galaxy_gateway.android.models import AndroidDevice
 
     _reset_capability_state()
-    bridge = SimpleNamespace(
-        _lock=asyncio.Lock(),
-        _devices={
-            "android-test-02": SimpleNamespace(
-                supported_actions=[],
-                last_heartbeat=0.0,
-            )
-        },
+    # 用真的 AndroidDevice,不要拿 SimpleNamespace 捏一个「看起来像」的。
+    # 这里原先是 SimpleNamespace(supported_actions=[], last_heartbeat=0.0) —— 那是
+    # handler 还在直接给字段赋值那个年代的形状。字段写入后来收口成
+    # AndroidDevice.update_supported_actions(),假对象却没跟着改,于是这条测试一直
+    # 挂在 AttributeError 上、**根本走不到它自己要断言的权威面写入那一步**。
+    # 假对象只在它跟真实现同步时才有价值,这里用真的。
+    cached = AndroidDevice.from_registration(
+        {"device_id": "android-test-02", "device_type": "android_phone", "platform": "android"}
     )
+    bridge = SimpleNamespace(_lock=asyncio.Lock(), _devices={"android-test-02": cached})
 
     response = await handle_capability_report(
         bridge,
@@ -147,6 +149,50 @@ async def test_android_capability_report_writes_directly_to_canonical_capability
     assert record.mutation_source == "android.capability_report"
     assert record.parameters["properties"]["x"]["type"] == "number"
     assert record.returns == {"type": "object"}
+    # transport cache 那条腿也得真的写进去了 —— 上面把假对象换成真 AndroidDevice
+    # 之后,这条才有意义:否则「缓存没写」和「缓存写了」在断言上没有区别。
+    assert cached.supported_actions == ["tap"]
+
+
+@pytest.mark.asyncio
+async def test_capability_authority_is_written_even_if_transport_cache_write_blows_up():
+    """非权威的 transport cache 写失败,不该把权威能力面的写一起吞掉。
+
+    ``_devices`` 在代码里被反复声明为 transport/session operational cache、**不是**事实
+    来源(SSOT 在 UDM / capability authority)。但这条缓存写此前是整个 handler 里唯一
+    没有 try 兜的一步,而且排在最前面 —— 缓存一抛异常,后面的权威面同步、语义吸收、
+    ACK 全部不执行,调用方只看到一个异常,**看不出权威面压根没被写**。设备的能力于是
+    在权威面上「不存在」,而它明明成功上报了。
+
+    这里用一个写入即抛的设备条目把那条腿打断,断言权威面照写、ACK 照常 accepted。
+    """
+    from core.unified.capability_resolver import get_capability_resolver
+    from galaxy_gateway.android.handlers.capability_report import handle_capability_report
+
+    _reset_capability_state()
+
+    class _ExplodingDevice:
+        def update_supported_actions(self, actions):
+            raise RuntimeError("transport cache 炸了")
+
+    bridge = SimpleNamespace(_lock=asyncio.Lock(), _devices={"android-test-03": _ExplodingDevice()})
+
+    response = await handle_capability_report(
+        bridge,
+        websocket=object(),
+        message={
+            "type": "capability_report",
+            "device_id": "android-test-03",
+            "platform": "android",
+            "version": "4.0",
+            "supported_actions": ["swipe"],
+        },
+    )
+
+    assert response["accepted"] is True, f"缓存写失败不该让整个能力上报失败: {response}"
+    record = get_capability_resolver().resolve_record("gateway__android-test-03__swipe")
+    assert record is not None, "transport cache 写失败把权威能力面的写一起吞掉了 —— 设备能力在权威面上不存在"
+    assert record.provider_id == "android-test-03"
 
 
 @pytest.mark.asyncio

--- a/tests/test_desktop_existence_surface.py
+++ b/tests/test_desktop_existence_surface.py
@@ -24,6 +24,60 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
+# 静默基线:presence_verdict 是【五个】状态族共同推导出来的
+# ---------------------------------------------------------------------------
+
+
+def _quiescent_builder(builder, **overrides):
+    """把 builder 的五个族读取器全部按住成静默默认值,只放开指定的那一族。
+
+    为什么需要它
+    ------------
+    ``presence_verdict`` 不是某一族的函数,而是五族联合推导:
+
+        expressing : fam1.dominant_tristate=="manifest" 或 fam2.shell_state=="fullagent"
+        active     : fam1=="liminal" / fam2=="sidesheet" / fam4.manifest_pressure>0.4 / fam3 相位非 passive
+        background : fam4.is_running / fam5.local_loop_ready_count>0 / fam2=="island" / fam4.tick_count>0
+        dormant    : 以上都不成立
+
+    E02/E03/E05 原先只 patch 了**自己那一族**,却断言基线必须是 "dormant" —— 而其余四族
+    读的是真实单例。全量套件里前面的测试只要启动过认知场(fam4.is_running / tick_count>0)、
+    注册过安卓设备(fam5.local_loop_ready_count>0)或改过 shell 状态,基线就变成
+    "background",断言随之假红。单跑绿、合并跑红的差别全在这里。
+
+    佐证:结构完全相同的 E04 **没有**红 —— 因为它恰好 patch 的就是 fam4。这正好指认
+    污染落在认知场那一族。
+
+    五个 Snapshot 的 dataclass 默认值本来就是静默的(silent / dormant / "" / 0.0 / False /
+    0),所以无参构造即是"什么都没发生"的基线。这样每条测试才真的只在验证它自己声称的
+    那件事:**改这一族**会不会改变 verdict。
+    """
+    import contextlib
+
+    from core.desktop_existence_surface import (
+        AndroidPresenceSignals,
+        CognitiveFieldSnapshot,
+        ContinuumPostureSnapshot,
+        ShellClothingSnapshot,
+        SubjectLifecycleSnapshot,
+    )
+
+    defaults = {
+        "_read_subject_lifecycle": SubjectLifecycleSnapshot(),
+        "_read_shell_clothing": ShellClothingSnapshot(),
+        "_read_continuum_posture": ContinuumPostureSnapshot(),
+        "_read_cognitive_field": CognitiveFieldSnapshot(),
+        "_read_android_signals": AndroidPresenceSignals(),
+    }
+    defaults.update(overrides)
+
+    stack = contextlib.ExitStack()
+    for name, value in defaults.items():
+        stack.enter_context(patch.object(builder, name, return_value=value))
+    return stack
+
+
+# ---------------------------------------------------------------------------
 # A. Payload model — structure & serialisation
 # ---------------------------------------------------------------------------
 
@@ -579,10 +633,10 @@ class TestRegressionSafety(unittest.TestCase):
         silent_snap = SubjectLifecycleSnapshot(dominant_tristate="silent", active_session_count=0)
         manifest_snap = SubjectLifecycleSnapshot(dominant_tristate="manifest", active_session_count=1)
 
-        with patch.object(builder, "_read_subject_lifecycle", return_value=silent_snap):
+        with _quiescent_builder(builder, _read_subject_lifecycle=silent_snap):
             dormant_result = builder.build()
 
-        with patch.object(builder, "_read_subject_lifecycle", return_value=manifest_snap):
+        with _quiescent_builder(builder, _read_subject_lifecycle=manifest_snap):
             expressing_result = builder.build()
 
         self.assertEqual(dormant_result.existence_projection.presence_verdict, "dormant")
@@ -600,10 +654,10 @@ class TestRegressionSafety(unittest.TestCase):
         dormant_snap = ShellClothingSnapshot(shell_state="dormant")
         fullagent_snap = ShellClothingSnapshot(shell_state="fullagent")
 
-        with patch.object(builder, "_read_shell_clothing", return_value=dormant_snap):
+        with _quiescent_builder(builder, _read_shell_clothing=dormant_snap):
             dormant_result = builder.build()
 
-        with patch.object(builder, "_read_shell_clothing", return_value=fullagent_snap):
+        with _quiescent_builder(builder, _read_shell_clothing=fullagent_snap):
             expressing_result = builder.build()
 
         self.assertEqual(dormant_result.existence_projection.presence_verdict, "dormant")
@@ -621,10 +675,10 @@ class TestRegressionSafety(unittest.TestCase):
         stopped_snap = CognitiveFieldSnapshot(is_running=False, tick_count=0)
         running_snap = CognitiveFieldSnapshot(is_running=True, tick_count=10)
 
-        with patch.object(builder, "_read_cognitive_field", return_value=stopped_snap):
+        with _quiescent_builder(builder, _read_cognitive_field=stopped_snap):
             stopped_result = builder.build()
 
-        with patch.object(builder, "_read_cognitive_field", return_value=running_snap):
+        with _quiescent_builder(builder, _read_cognitive_field=running_snap):
             running_result = builder.build()
 
         self.assertEqual(stopped_result.existence_projection.presence_verdict, "dormant")
@@ -642,10 +696,10 @@ class TestRegressionSafety(unittest.TestCase):
         no_android = AndroidPresenceSignals(total_devices_with_snapshot=0, local_loop_ready_count=0)
         android_ready = AndroidPresenceSignals(total_devices_with_snapshot=1, local_loop_ready_count=1)
 
-        with patch.object(builder, "_read_android_signals", return_value=no_android):
+        with _quiescent_builder(builder, _read_android_signals=no_android):
             no_android_result = builder.build()
 
-        with patch.object(builder, "_read_android_signals", return_value=android_ready):
+        with _quiescent_builder(builder, _read_android_signals=android_ready):
             android_result = builder.build()
 
         self.assertEqual(no_android_result.existence_projection.presence_verdict, "dormant")

--- a/tests/test_final_e2e.py
+++ b/tests/test_final_e2e.py
@@ -83,11 +83,26 @@ def test_ui_files():
 
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-    # 服务端 Dashboard UI
-    dashboard_ui = os.path.join(project_root, "dashboard", "frontend", "public", "index.html")
-    assert os.path.exists(dashboard_ui), "服务端 Dashboard UI: 不存在"
-    size = os.path.getsize(dashboard_ui)
-    print(f"✅ 服务端 Dashboard UI: {size} 字节")
+    # 桌面 UI 产物。
+    #
+    # 这里原先断言的是 dashboard/frontend/public/index.html —— 那个目录早在
+    # "dashboard 整体退役删除" 那次提交里就被删光了,断言却留着,于是这条测试成了
+    # 一条**必然失败**的死断言。它之所以没在本地被发现,是因为文件顶上的
+    # pytest.importorskip("sklearn") 在没装 sklearn 的机器上把整个文件跳过了 ——
+    # CI 装了 sklearn,才真跑起来并撞上它。
+    #
+    # 改成断言**现在真实存在的**两个产物,而不是删掉了事:
+    #   * electron/renderer/index.html            —— 桌面覆盖层
+    #   * electron/renderer/panel/dist/index.html —— 面板的构建产物
+    # 后者尤其值得守:Electron 主进程是从 dist/ 加载面板的(不是从 src/),这份构建
+    # 产物是 git 跟踪的 —— 漏提交它,面板就会静默停在旧版本上,没有任何报错。
+    ui_artifacts = [
+        ("桌面覆盖层", os.path.join(project_root, "electron", "renderer", "index.html")),
+        ("面板构建产物", os.path.join(project_root, "electron", "renderer", "panel", "dist", "index.html")),
+    ]
+    for label, path in ui_artifacts:
+        assert os.path.exists(path), f"{label}: 不存在 ({os.path.relpath(path, project_root)})"
+        print(f"✅ {label}: {os.path.getsize(path)} 字节")
 
     # 安卓端 UI (optional - may not exist in this repo)
     android_root = os.path.abspath(os.path.join(project_root, "..", "galaxy-android"))

--- a/tests/test_hang_guard_is_configured.py
+++ b/tests/test_hang_guard_is_configured.py
@@ -1,0 +1,174 @@
+"""挂死的测试必须会被中止 —— 否则整轮 CI 一个结论都拿不到。
+
+被修的问题
+----------
+仓库此前没有 ``pytest-timeout``,``pytest.ini`` 里也没有任何超时设置。于是**一条挂住的
+测试会永久挂住**:pytest 不会中止它,整个作业只能等 runner 超时被回收。
+
+实测后果(GitHub Actions ``test`` 作业,连续多次):
+
+    14:59:43  ...test_returns_only_device_kind_entries            PASSED [99%]
+    15:04:02  ...test_capability_filter_applied_to_device_entries PASSED       ← 隔 4 分 19 秒
+    15:23:56  ...test_returns_empty_when_no_device_entries                     ← 开始,再无输出
+    15:23:55  ##[error] The runner has received a shutdown signal
+
+整轮 4 万多条测试**一个结论都没有**:没有失败清单,也没有任何线索指出卡在哪。同一个测试
+类单独跑只要 4.32 秒、5 条全过 —— 说明不是这些用例本身有 bug,而是跑到全量套件尾部时才
+出现的累积性挂起。main 自己也有同样签名(某次 test 作业卡 64 分钟被杀,同 run 其它 16 个
+作业全绿),所以这不是某个 PR 引入的。
+
+为什么这条测试值得存在
+----------------------
+超时配置是那种"配上了就没人再想起、被删掉也不会有人立刻发现"的东西 —— 而它一旦失效,
+症状就是**再次退回到"整轮没有结论"**,排查成本极高(这次前后耗掉了一个多小时才定位)。
+所以把三件事钉住:插件在、阈值在、方式是 signal。
+"""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def ini() -> configparser.ConfigParser:
+    cfg = configparser.ConfigParser()
+    cfg.read(REPO_ROOT / "pytest.ini", encoding="utf-8")
+    return cfg
+
+
+class TestTimeoutIsConfigured:
+    def test_plugin_is_installed(self):
+        """没装插件的话,下面那些 ini 键只是几行注释而已 —— 一点作用都没有。"""
+        pytest.importorskip("pytest_timeout", reason="pytest-timeout 未安装 —— 挂死的测试将永不中止")
+
+    def test_plugin_is_declared_in_dev_requirements(self):
+        """CI 靠 requirements-dev.txt 装它。本机碰巧装了不算数。"""
+        req = (REPO_ROOT / "requirements-dev.txt").read_text(encoding="utf-8")
+        assert "pytest-timeout" in req, "pytest-timeout 不在 requirements-dev.txt 里,CI 上等于没有"
+
+    def test_timeout_value_is_set_and_sane(self, ini):
+        raw = ini.get("pytest", "timeout", fallback="")
+        assert raw, "pytest.ini 里没有 timeout —— 挂死的测试将永不中止"
+        value = int(raw)
+        # 下限:实测仓库最慢的真实用例是 30.11s(test_dispatch_task_uses_websocket_from_local_cache),
+        # 阈值必须留足余量,否则会把正常的慢测试误判成超时。
+        assert value >= 90, f"timeout={value}s 太紧,最慢的真实用例已有 30s,会误伤"
+        # 上限:太宽就抓不住异常者了 —— CI 上那个病态用例耗了 4 分 19 秒(259s)。
+        assert value <= 240, f"timeout={value}s 太宽,抓不住 CI 上那个 259s 的异常用例"
+
+    def test_method_is_signal_not_thread(self, ini):
+        """这个选择是实测出来的,不是偏好。
+
+        * ``signal`` —— 打断那一条并如实报成 failure,**整轮继续跑完**,拿得到完整失败清单;
+        * ``thread`` —— dump 所有线程栈后**直接杀进程**,整轮中止,还是拿不到清单。
+
+        我们要的正是"完整清单 + 指出卡在哪",所以只能是 signal。
+        """
+        method = ini.get("pytest", "timeout_method", fallback="")
+        assert method == "signal", (
+            f"timeout_method={method!r} —— thread 方式会杀掉整个进程," "又回到「整轮没有结论」那个老问题上;应为 signal"
+        )
+
+    def test_not_hidden_in_addopts(self, ini):
+        """必须是 ini 选项,不能塞进 addopts。
+
+        没装 pytest-timeout 的环境下:ini 里的未知键只产生一条 PytestConfigWarning(exit 0),
+        而 addopts 里的 ``--timeout`` 会让 pytest 直接报错、连测试都跑不起来。已实测。
+        """
+        addopts = ini.get("pytest", "addopts", fallback="")
+        assert "--timeout" not in addopts, "--timeout 写进 addopts 会让没装插件的环境直接跑不起来"
+
+
+#: 丢给子进程去跑的迷你套件:两种真实挂法,前后各夹一条正常用例。
+#: 用它来证明「挂住的那条被打断」且「整轮继续跑完」。
+_HANG_SUITE = """
+import threading, time
+
+def test_before():
+    assert True
+
+def test_hangs_on_a_lock():
+    lock = threading.Lock()
+    lock.acquire()
+    lock.acquire()          # 永久阻塞
+
+def test_hangs_on_sleep():
+    time.sleep(3600)
+
+def test_after():
+    assert True
+"""
+
+
+class TestItActuallyInterruptsAHang:
+    """光有配置不够 —— 得证明它真的能打断挂住的测试,而且不掐掉整轮。
+
+    为什么必须用子进程
+    ------------------
+    我第一版是在**本进程内**写两条会挂的用例,再用 ``pytest.raises`` 去接。那是错的:
+    pytest-timeout 抛的 ``_pytest.outcomes.Failed`` 继承自 ``BaseException``,
+    ``pytest.raises(Exception)`` 根本抓不住;更根本的是**超时本身就是这条用例的失败**,
+    不存在"在用例内部捕获它"这回事 —— 那一版直接把自己写成了 2 failed。
+
+    正确的验法是把挂法丢进**子进程**的 pytest 里,再检查它的输出与退出行为。
+    """
+
+    @staticmethod
+    def _run(tmp_path, method: str):
+        import subprocess
+        import sys
+
+        (tmp_path / "test_hang_demo.py").write_text(_HANG_SUITE, encoding="utf-8")
+        (tmp_path / "pytest.ini").write_text(f"[pytest]\ntimeout = 3\ntimeout_method = {method}\n", encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", "-v", str(tmp_path)],
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            timeout=90,  # 若超时机制彻底失效,子进程会挂住 —— 这里兜住,不拖垮本轮
+        )
+
+    def test_a_hang_is_interrupted_and_reported(self, tmp_path):
+        pytest.importorskip("pytest_timeout")
+        r = self._run(tmp_path, "signal")
+        assert "Timeout" in r.stdout, f"挂住的用例没有被超时打断:\n{r.stdout[-2000:]}"
+        assert "test_hangs_on_a_lock" in r.stdout
+        assert "test_hangs_on_sleep" in r.stdout
+
+    def test_the_run_continues_past_the_hang(self, tmp_path):
+        """这正是选 signal 而非 thread 的全部理由 —— 挂住之后**后面的用例还得跑**。
+
+        thread 方式会 dump 线程栈然后杀掉整个进程,``test_after`` 根本不会被执行,于是
+        又回到「整轮拿不到完整清单」那个老问题上。
+        """
+        pytest.importorskip("pytest_timeout")
+        r = self._run(tmp_path, "signal")
+        assert "test_after" in r.stdout, f"超时之后整轮被掐断了,后续用例没跑:\n{r.stdout[-2000:]}"
+        assert (
+            "2 failed" in r.stdout and "2 passed" in r.stdout
+        ), f"期望恰好 2 挂 2 过(前后两条正常用例都要跑到):\n{r.stdout[-2000:]}"
+
+    def test_without_the_timeout_it_would_hang_forever(self, tmp_path):
+        """反证:关掉超时,同一份套件会挂到子进程超时为止。
+
+        没有这条,上面两条只能说明"现在能中止",无法说明"以前会挂死"—— 而"会挂死"正是
+        这次要修的东西。
+        """
+        import subprocess
+        import sys
+
+        (tmp_path / "test_hang_demo.py").write_text(_HANG_SUITE, encoding="utf-8")
+        (tmp_path / "pytest.ini").write_text("[pytest]\n", encoding="utf-8")  # 不设超时
+        with pytest.raises(subprocess.TimeoutExpired):
+            subprocess.run(
+                [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", "-q", str(tmp_path)],
+                cwd=str(tmp_path),
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )

--- a/tests/test_hang_guard_is_configured.py
+++ b/tests/test_hang_guard_is_configured.py
@@ -74,6 +74,35 @@ class TestTimeoutIsConfigured:
             f"timeout_method={method!r} —— thread 方式会杀掉整个进程," "又回到「整轮没有结论」那个老问题上;应为 signal"
         )
 
+    def test_faulthandler_backstop_is_set(self, ini):
+        """不依赖信号的兜底诊断。
+
+        per-test 超时**本地实测有效**,但在 CI 上没救回来:作业仍挂死在 92%,日志逐字节停住
+        四十多分钟,**一条 Timeout 行都没有**。原因可能是挂点不在 pytest_runtest_protocol
+        覆盖范围内(pytest-timeout 只挂这一个钩子),也可能卡在不响应信号递送的 C 调用里。
+
+        faulthandler 走独立看门狗线程、不经过信号,所以上面那条不管为什么失灵,它都照样能打出
+        **每个线程**的完整堆栈(实测精确到文件与行号)。它只 dump 不终止 —— 终止由作业级
+        timeout-minutes 负责。
+        """
+        raw = ini.get("pytest", "faulthandler_timeout", fallback="")
+        assert raw, "没有 faulthandler_timeout —— per-test 超时一旦失灵就再没有任何线索"
+        assert int(raw) >= 60, f"faulthandler_timeout={raw}s 太紧,会在正常慢用例上刷无用堆栈"
+
+    def test_ci_test_job_has_a_hard_ceiling(self):
+        """作业级硬上限:挂死时至少得到一个明确的「作业超时」。
+
+        没有它,挂死的作业会一直耗到 runner 被回收(实测有 64 分钟的),GitHub 只丢下一句
+        "The runner has received a shutdown signal" —— 既没有失败清单,也没有任何线索。
+        """
+        import yaml
+
+        ci = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
+        job = ci["jobs"]["test"]
+        assert "timeout-minutes" in job, "test 作业没有 timeout-minutes,挂死时会耗到 runner 被回收"
+        # 正常全量约 20 分钟;上限要留足余量,但不能大到失去意义。
+        assert 30 <= int(job["timeout-minutes"]) <= 90, f"timeout-minutes={job['timeout-minutes']} 不在合理区间"
+
     def test_not_hidden_in_addopts(self, ini):
         """必须是 ini 选项,不能塞进 addopts。
 

--- a/tests/test_llm_tools_failover.py
+++ b/tests/test_llm_tools_failover.py
@@ -28,7 +28,7 @@ class _FakeTelemetry:
 
 def _router(backend_chat):
     """构造一个只挂了必要桩的 UnifiedLLMRouter,避开 __init__ 的后端加载/网络探测。"""
-    r = UnifiedLLMRouter.__new__(UnifiedLLMRouter)
+    r = object.__new__(UnifiedLLMRouter)
 
     class _B:
         async def chat(self, **kwargs):

--- a/tests/test_mesh_worker_panel_toggle.py
+++ b/tests/test_mesh_worker_panel_toggle.py
@@ -24,14 +24,47 @@ from fastapi.testclient import TestClient
 
 @pytest.fixture()
 def client():
+    """必须用 ``with TestClient(...)``,不能是裸的 ``TestClient(app)``。
+
+    这条被验证的行为是「fire-and-forget:端点立刻返回,真正的启动在后台任务里跑」,
+    所以断言全都落在**后台任务跑完之后**的 running/starting/last_error 上。而裸构造的
+    TestClient 是**每次请求现开一个 anyio portal**,请求一结束 portal 就关,
+    ``asyncio.create_task()`` 起的后台任务**当场被取消**。实测两种用法的差别:
+
+        TestClient(app)        POST 0.36s / 6.58s(不稳定)  task cancelled=True   last_error=None
+        with TestClient(app)   POST 0.01s                   task cancelled=False  last_error='nats_unavailable'
+
+    两种失败形态都出自这一个原因:portal 退出时有时会等后台任务走到取消点,于是
+    「端点必须秒回」那条耗时断言被记到 6.58s 上;有时干脆取消得干净利落,于是
+    last_error 永远等不到。生产侧(uvicorn 长生命周期事件循环)没有这个问题 ——
+    这纯粹是验证方式不成立,不是被测代码的毛病。上下文管理器让 portal 覆盖整个
+    client 生命周期,后台任务才真的能跑完。
+    """
     from core.routes.hybrid import create_router
     from core.worker_runtime import reset_worker_runtime
 
     reset_worker_runtime()
     app = FastAPI()
     app.include_router(create_router())
-    yield TestClient(app)
+    with TestClient(app) as c:
+        yield c
     reset_worker_runtime()
+
+
+def _wait_until(predicate, *, budget_s: float = 30.0, tick_s: float = 0.05) -> bool:
+    """轮询等一个条件成立,返回是否等到。
+
+    预算刻意给到 30s(原先是 50×0.05 = **2.5s**)。真实的冷启动链路要走完 NATS 连接
+    失败 → 嵌入式服务器拉起尝试 → 落地 last_error,本机实测就要 ~6.5s,CI 上只会更慢
+    —— 2.5s 根本等不到后台任务收尾,断言拿到的是**中途状态**。这不是"放宽标准":
+    「端点必须秒回」由 POST 自己的耗时断言把关,和这里等后台跑完是两件事。
+    """
+    deadline = time.monotonic() + budget_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(tick_s)
+    return predicate()
 
 
 class TestWorkerStatusEndpoint:
@@ -70,10 +103,7 @@ class TestWorkerToggleEndpoint:
         assert elapsed < 1.0, f"toggle 端点耗时 {elapsed:.2f}s——是否又变回同步阻塞了?"
 
         # 等后台任务跑完(本机没有 nats-server,预期最终失败并落地 last_error)。
-        for _ in range(50):
-            if not get_worker_runtime().starting:
-                break
-            time.sleep(0.05)
+        assert _wait_until(lambda: not get_worker_runtime().starting), "后台启动任务在预算内没有收尾"
         wr = get_worker_runtime()
         assert wr.running is False
         assert wr.starting is False
@@ -96,10 +126,7 @@ class TestWorkerToggleEndpoint:
         assert body["started"] is False
 
         # 等后台任务把 mock bus 的连接/订阅链路真正跑完。
-        for _ in range(50):
-            if get_worker_runtime().running:
-                break
-            time.sleep(0.05)
+        assert _wait_until(lambda: get_worker_runtime().running), "后台启动任务在预算内没有把 worker 拉起来"
         wr = get_worker_runtime()
         assert wr.running is True
         assert wr.starting is False
@@ -115,11 +142,14 @@ class TestWorkerToggleEndpoint:
     def test_toggle_while_already_starting_does_not_spawn_duplicate_task(self):
         """连点两下(第二次请求在第一次的后台任务还没跑完时打进来)不应重复发起启动。
 
-        注意:这里不用共享的 ``client`` fixture——它不是以 context manager 方式
-        使用 TestClient,Starlette 因而给【每次请求各开一个独立事件循环】,一次
-        request 内起的后台任务会在该请求返回前就被那个临时循环跑到底,天然测不出
-        "第二次请求打进来时第一个后台任务仍在飞"这个场景。本测试用 `with TestClient(...)`
-        换成【一个跨请求持久的事件循环】,才能真正制造出两次 POST 之间的重叠窗口。
+        这里自建 client 而不复用共享 fixture,是因为要往 runtime 里塞一个**故意慢的**
+        mock bus,得在第一次 POST **之前**装好——共享 fixture 在 yield 之前就 reset 过
+        runtime,拿不到这个插入点。
+
+        (历史注记:这段原先解释的是"共享 fixture 没用 context manager,所以每请求一个
+        临时事件循环,造不出重叠窗口"。那个观察是对的,但当时只在这一条测试里就地绕过去了,
+        没回头修夹具 —— 于是同一个坑继续把 ``test_enable_returns_immediately_with_starting_true``
+        坑在 CI 上。夹具现已统一改成 ``with TestClient(...)``,那条描述不再成立。)
         """
         import asyncio
 
@@ -153,10 +183,7 @@ class TestWorkerToggleEndpoint:
                 assert body2.get("already_starting") is True
 
                 wr = get_worker_runtime()
-                for _ in range(50):
-                    if not wr.starting:
-                        break
-                    time.sleep(0.05)
+                _wait_until(lambda: not wr.starting)
                 # 无论最终成功与否,只应该有一个后台任务在跑过——这里只断言状态收敛,
                 # 没有遗留的"starting 永远 True"这类卡死态。
                 assert wr.starting is False

--- a/tests/test_no_test_hijacks_a_singleton.py
+++ b/tests/test_no_test_hijacks_a_singleton.py
@@ -1,0 +1,122 @@
+"""测试不得用 ``Cls.__new__(Cls)`` 去"造一个新实例" —— 单例类会把真身交给你。
+
+被修的问题
+----------
+仓库里有一批类用 ``__new__`` 实现进程级单例::
+
+    class UnifiedLLMRouter:
+        _instance: Optional["UnifiedLLMRouter"] = None
+
+        def __new__(cls) -> "UnifiedLLMRouter":
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._initialized = False
+            return cls._instance
+
+于是 ``UnifiedLLMRouter.__new__(UnifiedLLMRouter)`` **返回的是那个单例本身**,不是新
+对象。测试里这么写通常带着"绕开 ``__init__`` 的后端加载/网络探测,造一个只挂了必要桩
+的实例"的注释 —— 意图是对的,手段拿错了:接下来给它挂的每一个桩,都**永久改写了整个
+进程的单例**,而且从不还原。
+
+实测到的两处真实后果(都在 CI 的 `test` 作业里红过):
+
+* ``tests/test_llm_tools_failover.py`` 给单例挂上 ``_FakeTelemetry`` 与桩掉的
+  ``_get_provider_order``。此后 ``GET /api/v1/operator/llm`` 走到
+  ``UnifiedLLMRouter.get_status()`` 里的 ``self._telemetry.get_metrics()``,
+  ``_FakeTelemetry`` 没有这个方法 → 500。三条 operator 用例一起红,而它们自己毫无问题;
+* ``UnifiedConfig`` 同款:``cfg = UnifiedConfig.__new__(UnifiedConfig)`` 拿到真单例后
+  一句 ``cfg._config = {}`` 就把**真实配置整个清空**,再灌进一套假 API Key。此后
+  ``_get_key()`` 第 1 层查到的全是假值,别的文件里"占位符不该被当成真密钥"之类的断言
+  随之假红(单跑绿、合并跑红)。
+
+正确写法是 ``object.__new__(Cls)`` —— 它跳过类自己的 ``__new__``,给出一个货真价实的
+新实例,既避开了 ``__init__``,又碰不到 ``_instance``。
+
+为什么要有这条测试
+------------------
+这类污染的症状**永远出现在别人身上**:报错的是 operator/panel 的用例,根因却在一个
+名字毫不相干的文件里,而且单跑一律全绿。排查成本极高。与其等下一次再花几小时,不如
+在写下的那一刻就拦住。
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+#: 扫这些目录找单例类定义。
+_SOURCE_DIRS = ("core", "galaxy_gateway", "enhancements", "contracts")
+
+
+def _singleton_classes() -> Dict[str, str]:
+    """返回 ``{类名: 定义它的文件}``,只收「自定义 ``__new__`` 且缓存实例」的类。
+
+    判据刻意保守:必须**自己**定义了 ``__new__``,且函数体里出现 ``_instance`` /
+    ``_singleton``。这样不会把普通类误伤成单例。
+    """
+    found: Dict[str, str] = {}
+    paths: List[Path] = [p for d in _SOURCE_DIRS for p in (REPO_ROOT / d).rglob("*.py")]
+    paths += list(REPO_ROOT.glob("*.py"))
+    for path in paths:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "__new__":
+                    body = ast.unparse(item)
+                    if "_instance" in body or "_singleton" in body:
+                        found.setdefault(node.name, str(path.relative_to(REPO_ROOT)))
+    return found
+
+
+#: ``X.__new__(`` 或 ``mod.X.__new__(``,但不含 ``object.__new__(``(那正是正确写法)。
+_NEW_CALL = re.compile(r"(?<![\w.])(?:\w+\.)?([A-Z]\w*)\.__new__\(")
+
+
+def _offending_sites() -> List[Tuple[str, int, str]]:
+    singles = _singleton_classes()
+    hits: List[Tuple[str, int, str]] = []
+    for path in TESTS_DIR.rglob("*.py"):
+        if path.name == Path(__file__).name:
+            continue  # 本文件自己会提到这些名字
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for m in _NEW_CALL.finditer(text):
+            cls = m.group(1)
+            if cls in singles:
+                line = text[: m.start()].count("\n") + 1
+                hits.append((str(path.relative_to(REPO_ROOT)), line, cls))
+    return hits
+
+
+class TestNoSingletonHijack:
+    def test_detector_actually_finds_the_known_singletons(self):
+        """先证明探测器本身有效 —— 否则下面那条可以靠"什么都没找到"轻松通过。"""
+        singles = _singleton_classes()
+        for expected in ("UnifiedLLMRouter", "UnifiedConfig", "RoutingTelemetry"):
+            assert expected in singles, f"探测器没认出已知的单例类 {expected!r},它的判据已经失效"
+
+    def test_detector_recognises_the_offending_pattern(self):
+        """再证明匹配规则确实抓得住那个写法,且**不会**误伤正确写法。"""
+        assert _NEW_CALL.search("r = UnifiedLLMRouter.__new__(UnifiedLLMRouter)")
+        assert _NEW_CALL.search("cfg = uc.UnifiedConfig.__new__(uc.UnifiedConfig)")
+        assert not _NEW_CALL.search("r = object.__new__(UnifiedLLMRouter)"), "正确写法被误判成违规"
+
+    def test_no_test_bypasses_a_singleton_new(self):
+        sites = _offending_sites()
+        assert (
+            not sites
+        ), "这些测试用 Cls.__new__(Cls) 拿到的是**进程级单例本身**,给它挂的桩会污染整个测试会话;" "改用 object.__new__(Cls):\n" + "\n".join(
+            f"    {p}:{ln}  ->  {cls}.__new__({cls})" for p, ln, cls in sites
+        )

--- a/tests/test_panel_apikey_placeholder_detection.py
+++ b/tests/test_panel_apikey_placeholder_detection.py
@@ -56,8 +56,43 @@ class TestIsConfiguredRecognizesUnderscorePlaceholder:
         assert data["configured"]["OPENAI_API_KEY"] is True
 
 
+@pytest.fixture()
+def only_env_layer(monkeypatch):
+    """把 ``_get_key()`` 三层解析链的前两层清空,只留环境变量那一层。
+
+    ``MultiLLMRouter._get_key()`` 的优先级是 **面板/UnifiedConfig > CredentialVault >
+    环境变量**。这条测试要断言的是"环境变量里的占位符不会被当成真密钥",但它此前
+    只 monkeypatch 了环境变量,前两层原样留着 —— 于是在任何配了真 DeepSeek key 的
+    机器上(以及本仓库的 ``runtime/secrets.env`` 存在时)它都会假红:
+
+        _get_key('deepseek') -> 'sk-test-galaxy-...'   # 来自第 1 层,行为完全正确
+
+    那不是被测代码有问题,是断言只控制了链的最后一环、却对整条链的结果下判断。
+    这里连前两层一起隔离,测试才名副其实。
+
+    第 1 层的存储形态要留意:``.env`` / ``runtime/secrets.env`` 经 ``_load_env()``
+    是按**扁平小写**键存进 ``_config`` 的(``DEEPSEEK_API_KEY`` → ``deepseek_api_key``),
+    ``get("api_keys.DEEPSEEK_API_KEY")`` 靠"取最后一段"的兜底才命中 —— 所以要清的是
+    那个扁平键,清 ``api_keys`` 子字典没有用。
+    """
+    from core.credential_vault import reset_vault
+    from core.unified_config import config as uc
+
+    backing = uc._backend._config
+    removed = {}
+    for k in list(backing):
+        if k.lower() in {"deepseek_api_key", "deepseek"}:
+            removed[k] = backing.pop(k)
+    reset_vault()
+    try:
+        yield
+    finally:
+        backing.update(removed)
+        reset_vault()
+
+
 class TestMultiLLMRouterRejectsUnderscorePlaceholder:
-    def test_get_key_rejects_underscore_placeholder_from_env(self, monkeypatch):
+    def test_get_key_rejects_underscore_placeholder_from_env(self, monkeypatch, only_env_layer):
         from core.multi_llm_router import MultiLLMRouter
 
         monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
@@ -68,6 +103,95 @@ class TestMultiLLMRouterRejectsUnderscorePlaceholder:
             f"路由器把未编辑的占位符 'your_deepseek_api_key_here' 当成真实密钥返回: {val!r}——"
             "provider 会被注册并真的拿这串模板文字去发请求"
         )
+
+    def test_a_real_key_in_env_still_comes_through(self, monkeypatch, only_env_layer):
+        """反面:隔离前两层之后,真 key 必须照样取得到。
+
+        没有这条,上面那条可以靠"把整层弄坏、什么都取不到"通过 —— 那是"因为错误的
+        理由而通过"。
+        """
+        from core.multi_llm_router import MultiLLMRouter
+
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-real-looking-deepseek-key-0987654321")
+        assert MultiLLMRouter()._get_key("deepseek") == "sk-real-looking-deepseek-key-0987654321"
+
+
+@pytest.fixture()
+def isolated_vault(monkeypatch):
+    """一个空 vault,且把它的环境变量兜底层也清掉。
+
+    ``get_credential()`` 在内存层拿到占位符时会**继续往下找**(占位符不该盖住真值),
+    所以只清 vault 是不够的:全量套件里别的测试会把 ``runtime/secrets.env`` 灌进
+    ``os.environ``,于是这里断言"应为 None"时会拿到环境变量里那个真 key。单跑绿、
+    合并跑红的差别就出在这。三层一起隔离,断言才稳定。
+    """
+    from core.credential_vault import _ENV_MAPPING, get_vault, reset_vault
+
+    reset_vault()
+    monkeypatch.delenv(_ENV_MAPPING.get("deepseek", "DEEPSEEK_API_KEY"), raising=False)
+    try:
+        yield get_vault()
+    finally:
+        reset_vault()
+
+
+class TestCredentialVaultRejectsPlaceholders:
+    """CredentialVault 是三层解析链里唯一没过占位符的一层(修复前)。
+
+    ``_get_key()`` 的第 1 层(面板/UnifiedConfig)和第 3 层(环境变量)都拿
+    ``PLACEHOLDER_PREFIXES`` 过滤过,唯独中间的 vault 层是 ``if val: return val``。
+    而 ``POST /api/v1/vault/credentials`` 会把请求体里的任意 value 原样
+    ``set_credential()`` 进去 —— 于是把示例文件里的 ``your_deepseek_api_key_here``
+    存进 vault 之后,它会**盖过**第 3 层的过滤被当成真密钥返回,provider 被注册成
+    "可用",面板显示"已连接",真实调用必然 401。这正是本文件开头写的那个真机反馈
+    (「还是不能正常地保存和使用」)在剩下那一层上的同一个 bug。
+    """
+
+    def test_placeholder_stored_in_vault_is_not_served_as_a_credential(self, isolated_vault):
+        isolated_vault.set_credential("deepseek", "your_deepseek_api_key_here")
+        assert isolated_vault.get_credential("deepseek") is None, "vault 把未编辑的模板值当成真凭证发了出去"
+
+    def test_placeholder_in_vault_is_not_listed_as_configured(self, isolated_vault):
+        isolated_vault.set_credential("deepseek", "your_deepseek_api_key_here")
+        assert "deepseek" not in isolated_vault.list_credential_keys(), (
+            "占位符被列进已配置键名——面板会据此显示'已连接',而 get_credential() " "对同一个键返回 None,两边自相矛盾"
+        )
+
+    def test_a_real_credential_is_still_served_and_listed(self, isolated_vault):
+        """反面:过滤不能把真凭证一起误伤。"""
+        isolated_vault.set_credential("deepseek", "sk-real-looking-key-13579")
+        assert isolated_vault.get_credential("deepseek") == "sk-real-looking-key-13579"
+        assert "deepseek" in isolated_vault.list_credential_keys()
+
+    def test_router_layer2_no_longer_leaks_a_placeholder(self, monkeypatch, only_env_layer, isolated_vault):
+        """端到端:占位符存在 vault 里,``_get_key()`` 也不该拿它去注册 provider。"""
+        from core.multi_llm_router import MultiLLMRouter
+
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        isolated_vault.set_credential("deepseek", "your_deepseek_api_key_here")
+        val = MultiLLMRouter()._get_key("deepseek")
+        assert val in (None, ""), f"vault 层把占位符漏成了真密钥: {val!r}"
+
+    def test_write_endpoint_rejects_a_placeholder_instead_of_pretending_to_save(self, isolated_vault):
+        """写入口当场退回,而不是收下再说。
+
+        收下的话,调用方拿到 success=True、面板显示"已保存",但读出来是 None、
+        真实调用一路 401 —— 用户完全看不出问题出在"粘的是模板文字"。
+        """
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from core.routes.vault import create_router
+
+        app = FastAPI()
+        app.include_router(create_router())
+        with TestClient(app) as c:
+            r = c.post(
+                "/api/v1/vault/credentials",
+                json={"key_name": "deepseek", "value": "your_deepseek_api_key_here"},
+            )
+            assert r.status_code == 400, f"占位符被收下了(status={r.status_code}): {r.text}"
+            assert "deepseek" not in isolated_vault.list_credential_keys()
 
 
 class TestOneApiFallbackRejectsUnderscorePlaceholder:

--- a/tests/test_panel_apikey_placeholder_detection.py
+++ b/tests/test_panel_apikey_placeholder_detection.py
@@ -74,18 +74,33 @@ def only_env_layer(monkeypatch):
     是按**扁平小写**键存进 ``_config`` 的(``DEEPSEEK_API_KEY`` → ``deepseek_api_key``),
     ``get("api_keys.DEEPSEEK_API_KEY")`` 靠"取最后一段"的兜底才命中 —— 所以要清的是
     那个扁平键,清 ``api_keys`` 子字典没有用。
+
+    做成**工厂**而不是写死 deepseek:同一个坑不止一处。CI 上不止一个测试文件会把假
+    Key 灌进那份 ``_config`` 缓存(实测同一轮里同时看得到 ``sk-ant-already-persisted``、
+    ``sk-fallback``、``sk-oneapi-x`` 这些来自不同文件的值)。与其逐个去追污染源、
+    追漏一个就再红一次,不如让**每一条依赖解析链的断言自己隔离自己的那几层** ——
+    这样不管谁污染都不受影响。
     """
     from core.credential_vault import reset_vault
     from core.unified_config import config as uc
 
     backing = uc._backend._config
     removed = {}
-    for k in list(backing):
-        if k.lower() in {"deepseek_api_key", "deepseek"}:
-            removed[k] = backing.pop(k)
-    reset_vault()
+
+    def _isolate(*providers: str) -> None:
+        """清掉这些 provider 在第 1 层的所有键形,并清空第 2 层。"""
+        wanted = set()
+        for p in providers:
+            low = p.lower()
+            wanted |= {low, f"{low}_api_key", f"{low}_url", f"{low}_base_url"}
+        for k in list(backing):
+            if k.lower() in wanted:
+                removed[k] = backing.pop(k)
+        reset_vault()
+
+    _isolate("deepseek")  # 默认隔离 deepseek(多数用例用它);需要别的就再调一次
     try:
-        yield
+        yield _isolate
     finally:
         backing.update(removed)
         reset_vault()
@@ -201,7 +216,12 @@ class TestOneApiFallbackRejectsUnderscorePlaceholder:
     'your_oneapi_api_key_here',这里锁定它不会被注册成"可用 provider"。
     """
 
-    def test_underscore_placeholder_env_fallback_not_registered(self, monkeypatch):
+    def test_underscore_placeholder_env_fallback_not_registered(self, monkeypatch, only_env_layer):
+        # 前两层必须一起隔离。CI 上实测:别的测试文件会把 'sk-oneapi-x' 灌进
+        # UnifiedConfig 的 _config 缓存(那层还原不了 os.environ 的快照),于是
+        # _get_key("oneapi") 在第 1 层就命中真值、压根走不到这条要测的 env 兜底,
+        # 断言假红。单跑绿、合并跑红的差别全在这里。
+        only_env_layer("oneapi")
         from core.multi_llm_router import MultiLLMRouter
 
         monkeypatch.delenv("ONEAPI_API_KEY", raising=False)
@@ -213,7 +233,8 @@ class TestOneApiFallbackRejectsUnderscorePlaceholder:
             "未编辑的占位符 'your_oneapi_api_key_here' 被当成真实密钥," "OneAPI provider 被错误注册"
         )
 
-    def test_real_looking_env_fallback_still_registers(self, monkeypatch):
+    def test_real_looking_env_fallback_still_registers(self, monkeypatch, only_env_layer):
+        only_env_layer("oneapi")
         from core.multi_llm_router import MultiLLMRouter
 
         monkeypatch.delenv("ONEAPI_API_KEY", raising=False)

--- a/tests/test_prB_legacy_ingress_dispatch_convergence.py
+++ b/tests/test_prB_legacy_ingress_dispatch_convergence.py
@@ -111,7 +111,7 @@ class TestDeviceOrchestratorSpineRouting(unittest.TestCase):
     def _make_orchestrator(self):
         from core.device_orchestrator import DeviceOrchestrator
 
-        orch = DeviceOrchestrator.__new__(DeviceOrchestrator)
+        orch = object.__new__(DeviceOrchestrator)
         return orch
 
     def test_09_send_command_calls_route_envelope_when_router_available(self):

--- a/tests/test_presence_bridge_functions.py
+++ b/tests/test_presence_bridge_functions.py
@@ -24,6 +24,31 @@ from core.lumiv_websocket_bridge import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _restore_bridge_singleton():
+    """跑完把 ``GalaxyPresenceBridge`` 单例还原掉 —— 本文件会往它身上挂桩。
+
+    ``_fresh()`` 每次都重建单例,所以**本文件内部**互不干扰;问题出在**跑完之后**:
+    单例停在最后一条用例留下的那个实例上,而它的 ``_try_ipc_http`` / ``_ws_broadcast``
+    已经被换成了写进**局部 list** 的 lambda。下一个文件 ``get_instance()`` 拿到的就是它,
+    于是它的每一次广播都掉进一个再也没人看的列表里。
+
+    实测受害者:``tests/test_tts_speaking_overlay_sync.py`` 的
+    ``test_speak_response_toggles_overlay_speaking_during_playback`` ——
+    ``覆盖层应先后收到 speaking=True/False; got [False]``。那唯一的 ``False`` 帧是
+    ``register_client()`` 里 ``_send_to()`` **直接**发的,没走 ``_ws_broadcast``;真正
+    要验的 ``True`` 脉冲则全被泄漏的 lambda 吞掉。它单跑一直是绿的,只在全量套件里红。
+
+    置 ``_instance = None`` 而不是逐个恢复方法:下一个使用者会拿到一个干净新建的实例,
+    不必去猜本文件到底挂了哪几个桩。
+    """
+    GalaxyPresenceBridge._instance = None
+    try:
+        yield
+    finally:
+        GalaxyPresenceBridge._instance = None
+
+
 def _fresh():
     GalaxyPresenceBridge._instance = None
     b = GalaxyPresenceBridge.get_instance()

--- a/tests/test_round2_fix_behaviors.py
+++ b/tests/test_round2_fix_behaviors.py
@@ -98,7 +98,7 @@ class TestEnvOverridesFileForAllProviders:
             "QWEN_API_KEY=FROM_FILE_STALE\nOPENAI_API_KEY=FROM_FILE\nZHIPU_API_KEY=FILE_ONLY\n",
             encoding="utf-8",
         )
-        cfg = uc.UnifiedConfig.__new__(uc.UnifiedConfig)
+        cfg = object.__new__(uc.UnifiedConfig)
         cfg._config = {}
         cfg.env_file = env_file
         cfg._load_env()

--- a/tests/test_tts_speaking_overlay_sync.py
+++ b/tests/test_tts_speaking_overlay_sync.py
@@ -61,6 +61,13 @@ async def test_speak_response_toggles_overlay_speaking_during_playback(monkeypat
     import core.speech_output as so
     from core.lumiv_websocket_bridge import GalaxyPresenceBridge
 
+    # 从一个**干净新建**的 bridge 开始,不接手别人留下的那个。
+    # 这条断言验的是"广播真的到达了覆盖层",而 bridge 是进程级单例 —— 别的测试文件
+    # 会往它身上挂桩(实测 tests/test_presence_bridge_functions.py 把 _ws_broadcast 换成
+    # 写进局部 list 的 lambda 且不还原),接手它就等于把 True 脉冲广播进一个没人看的
+    # 列表,只剩 register_client() 里 _send_to() 直接发的那一帧 False —— 正是
+    # "got [False]" 的由来。那边已加还原,这里再自保一次:两头都不依赖对方守规矩。
+    GalaxyPresenceBridge._instance = None
     bridge = GalaxyPresenceBridge.get_instance()
     bridge._loop = asyncio.get_running_loop()
     ws = _FakeWS()

--- a/tests/test_unified_config_env_key_lookup.py
+++ b/tests/test_unified_config_env_key_lookup.py
@@ -51,7 +51,7 @@ def _isolate_os_environ():
 def _make_cfg(env_content: str, tmp_path: Path) -> UnifiedConfig:
     env_file = tmp_path / ".env"
     env_file.write_text(env_content, encoding="utf-8")
-    cfg = UnifiedConfig.__new__(UnifiedConfig)
+    cfg = object.__new__(UnifiedConfig)
     cfg._config = {}
     cfg._callbacks = {}
     cfg.project_root = tmp_path

--- a/tests/test_unified_config_manager_reload_secrets.py
+++ b/tests/test_unified_config_manager_reload_secrets.py
@@ -28,7 +28,7 @@ def test_reload_calls_load_from_config_store():
         def _load_env(self):
             calls.append("_load_env")
 
-    mgr = UnifiedConfigManager.__new__(UnifiedConfigManager)
+    mgr = object.__new__(UnifiedConfigManager)
     mgr._backend = _FakeBackend()
 
     mgr.reload()
@@ -65,7 +65,7 @@ def test_reload_actually_refreshes_secret_from_config_store(tmp_path, monkeypatc
     # 覆盖掉刚从隔离 ConfigStore 里读到的 "sk-real-saved-key"。
     monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
 
-    backend = UnifiedConfig.__new__(UnifiedConfig)
+    backend = object.__new__(UnifiedConfig)
     backend._config = {}
     backend.project_root = tmp_path
     backend.config_file = tmp_path / "config.json.static"
@@ -73,7 +73,7 @@ def test_reload_actually_refreshes_secret_from_config_store(tmp_path, monkeypatc
     backend._callbacks = {}
     backend._initialized = True
 
-    mgr = UnifiedConfigManager.__new__(UnifiedConfigManager)
+    mgr = object.__new__(UnifiedConfigManager)
     mgr._backend = backend
 
     assert mgr.get("deepseek_api_key", "") == ""


### PR DESCRIPTION
> **范围说明(诚实交代)**:这个 PR 原本只做「给测试加超时」一件事。加完之后 `test` 作业第一次跑完整轮、露出了 **14 条基线失败**,后面三个 commit 修的就是这 14 条。两部分共用同一条指定开发分支,所以落在同一个 PR 里 —— 不是范围蔓延,是**因果相连**:没有第一部分,第二部分根本看不见。

---

## 第一部分:让挂死可见(commit 1-2)

### 问题

仓库没有 `pytest-timeout`,`pytest.ini` 里也没有任何超时设置。于是**一条挂住的测试会永久挂住** —— pytest 不会中止它,整个作业只能等 runner 超时被回收。

实测(GitHub Actions `test` 作业,连续多次):

```
14:59:43  ...test_returns_only_device_kind_entries            PASSED [99%]
15:04:02  ...test_capability_filter_applied_to_device_entries PASSED       ← 隔 4 分 19 秒
15:23:56  ...test_returns_empty_when_no_device_entries                     ← 开始,再无输出
15:23:55  ##[error] The runner has received a shutdown signal
```

整轮 4 万多条测试**一个结论都没有**。已核实:同一测试类**单独跑 4.32 秒、5 条全过**;**main 自己也有同样签名**(某次 test 作业卡 64 分钟被杀,同 run 其它 16 个作业全绿)。

### 改动

`requirements-dev.txt` 加 `pytest-timeout>=2.3.0`;`pytest.ini` 加 `timeout = 120` / `timeout_method = signal` / `faulthandler_timeout = 120`;CI 的 `test` 作业加 `timeout-minutes: 60`。

三个选择都是**实测定的**:**120s** —— 最慢的真实用例 30.11s,留 4 倍余量,又抓得住 CI 上那个 259s 的异常者;**signal 而非 thread** —— signal 打断那一条并如实报成 failure、**整轮继续跑完**,thread 会 dump 线程栈后直接杀进程;**ini 而非 addopts** —— 没装插件时 ini 里的未知键只产生一条 `PytestConfigWarning`(exit 0),addopts 里的 `--timeout` 会让 pytest 直接报错。

### 一处自查更正

我曾据一份「逐字节停住四十多分钟」的日志断言 per-test 超时在 CI 上没生效,并据此加了 faulthandler 兜底。后来那一轮**跑完了**,证明当时看到的是 **GitHub 日志流卡住**,不是套件挂住 —— commit 1 可能已经够了。faulthandler 与 `timeout-minutes` 建立在那个误读上,但两者无害(faulthandler 只在真挂满 120s 时才动,60 分钟是实测 21m45s 的约 3 倍),作为将来的诊断手段保留。

### 结果

`test` 作业**第一次跑完整轮**:`= 14 failed, 43315 passed, 105 skipped, ... in 1305.84s =`。从「整轮没有结论」变成「一份完整清单」。下面三部分就是拿这份清单做的。

---

## 第二部分:本地可复现的 5 条(commit 3) — CI 已确认 14 → 9

### 一、生产缺陷:`registration.py` 里 `device` 变量被重绑定

`handle_device_register()` 第 874 行在 `bridge._lock` 内建出本次注册的 `AndroidDevice`,第 936 行却在一个 `try/except: pass` 里写 `device = bridge._devices.get(device_id)`。Python 没有块级作用域,这个重绑定**泄漏到函数剩下的三百行**:能力同化(`device.capabilities`)、角色分配(`device.platform`)、注册日志(`device.model`)、跨设备相位推送(`device.websocket.send_json`)。

- 取不到时返回 `None`,`device.model` 那行**没有 try 兜着**,把整个注册打成 `success=False` —— 而 UDM 的规范写入在第 870 行**已经成功了**,设备状态就此撕裂;
- 第 874-876 行在锁内,这里的读**不在锁内**,同一 `device_id` 的重复 register(弱网重连的典型形态)会在两者之间替换缓存条目,于是相位会被 `send_json` 到**另一条 websocket**。

改用独立局部名 `_cached_device`。另一条注册路径查过,干净。

### 二、生产缺陷:非权威的缓存写给权威写当了门槛

`handle_capability_report()` 每条腿都包了 try/except 记非致命,**唯独 transport cache 那条没包,而且排在最前面**。它一抛异常,后面的权威能力面同步、语义吸收、ACK 全部不执行 —— 设备能力在权威面上「不存在」,调用方却只看到一个异常。改成非致命并记 warning。

### 三、生产缺陷:CredentialVault 是解析链上唯一不过占位符的一层

`_get_key()` 优先级是 **面板/UnifiedConfig > CredentialVault > 环境变量**。第 1、3 层都拿 `PLACEHOLDER_PREFIXES` 过滤过,**中间的 vault 层是 `if val: return val`**。而 `POST /api/v1/vault/credentials` 会把请求体里的任意 value 原样存进去 —— 于是 `your_deepseek_api_key_here` 会**盖过**第 3 层的过滤被当成真密钥返回,provider 注册成「可用」、面板显示「已连接」、真实调用必然 401。这正是真机反馈(「还是不能正常地保存和使用」)在剩下那一层上的同一个 bug。

判据收口成 `is_placeholder()`;三层一律过滤(内存层命中占位符时**继续往下找** —— 占位符不该盖住真值);`list_credential_keys()` 补齐过滤;写入口当场退 400 并说明原因。

### 四、验证方式不成立:worker toggle 那条

断言「端点必须秒回」实测记到 6.58s,但端点本身 **0.01s** 返回、后台任务也没卡住事件循环。根因是 fixture 用了裸的 `TestClient(app)`:starlette **每次请求现开一个 anyio portal**,请求一结束就把后台任务取消掉。

| 用法 | POST 耗时 | 后台任务 | last_error |
|---|---|---|---|
| `TestClient(app)` | 0.36s / 6.58s **不稳定** | **被取消** | `None` |
| `with TestClient(app)` | 0.01s | 正常跑完 | `'nats_unavailable'` |

改用上下文管理器,轮询预算从 **2.5s** 提到 30s(真实冷启动本机就要 ~6.5s)。

### 五、测试污染:假 Key 被烤进 UnifiedConfig 缓存

`test_all_provider_api_keys_survive_restart.py` 的 fixture 对 `os.environ` 做了快照/还原,但**那不够**:期间只要有代码触发真正的 `UnifiedConfig` 单例的 `_load_env()`,假 Key 就被烤进它的 `_config` 缓存 —— 那是独立于 `os.environ` 的另一层。补上 `_backend._config` 的快照/还原。

---

## 第三部分:一个根因带走 4 条(commit 4)

### `__new__` 是单例工厂,不是构造器

仓库里有 **32 个类**用 `__new__` 实现进程级单例。于是 `UnifiedLLMRouter.__new__(UnifiedLLMRouter)` **返回的是那个单例本身**。测试里这么写通常还带着「绕开 `__init__` 的后端加载/网络探测」的注释 —— 意图对,手段错:接下来挂的每一个桩都**永久改写了整个进程的单例**,而且从不还原。

AST 扫描找出 **12 处(8 个文件、7 个单例类)**。两条已实测的后果:

- `test_llm_tools_failover.py` 给单例挂上 `_FakeTelemetry` 与桩掉的 `_get_provider_order`。此后 `GET /api/v1/operator/llm` 走到 `UnifiedLLMRouter.get_status()` 里的 `self._telemetry.get_metrics()` → 500。CI 上**三条 operator 用例**一起红,而它们自己毫无问题;
- `UnifiedConfig` 同款:`cfg = UnifiedConfig.__new__(UnifiedConfig)` 拿到真单例后,一句 `cfg._config = {}` 就把**真实配置整个清空**再灌进假 Key —— 这正是第二部分里我按症状修掉的那个污染的机制,现在把源头一起断了。

全部改成 `object.__new__(Cls)`。反证:修复后单例**根本没被创建**;改回去立刻出现 `telemetry=_FakeTelemetry, has get_metrics=False`,`_get_provider_order` 被换成桩函数。

### 新增守卫 `tests/test_no_test_hijacks_a_singleton.py`

这类污染的症状**永远出现在别人身上** —— 报错的是 operator/panel 的用例,根因却在一个名字毫不相干的文件里,而且单跑一律全绿。所以把它变成写下的那一刻就会红:AST 扫出全仓库的单例类,再扫 `tests/` 里对它们的 `__new__` 绕过。三条里有两条在证明探测器本身有效,否则「什么都没找到」也能让主断言轻松通过。

### 顺带:`test_ui_files` 的死断言

它断言 `dashboard/frontend/public/index.html` 存在 —— 那个目录早在「dashboard 整体退役删除」那次提交里就删光了,断言却留着,是一条**必然失败**的死断言。它没在本地被发现,是因为文件顶上的 `pytest.importorskip("sklearn")` 在没装 sklearn 的机器上把整个文件跳过了。

改成断言现在真实存在的两个产物,而不是删掉了事:`electron/renderer/index.html`(覆盖层)与 `electron/renderer/panel/dist/index.html`(面板构建产物)。后者尤其值得守:Electron 主进程是从 `dist/` 加载面板的,这份产物是 git 跟踪的 —— 漏提交它,面板会静默停在旧版本上,没有任何报错。

---

## 第四部分:最后两组顺序污染(commit 5)

### 一、`presence_verdict` 由五族联合推导,测试只按住了一族

E02/E03/E05 各自只 patch 了**自己那一族**,却断言基线必须是 `"dormant"` —— 其余四族读的是真实单例。全量套件里前面的测试只要启动过认知场、注册过安卓设备或改过 shell 状态,基线就变成 `"background"`。

指认根因的关键佐证:结构**完全相同**的 **E04 没有红** —— 因为它恰好 patch 的就是 fam4。污染就落在认知场那一族。

加了 `_quiescent_builder(builder, **overrides)`:把五族读取器全部按住成静默默认值,只放开被测的那一族。反证:模拟该污染后,撤掉修复**精确复现 E02/E03/E05 三条**(E04 照常绿),与 CI 报的完全一致。

### 二、单例被挂桩之后没还原

`test_presence_bridge_functions.py` 把 `GalaxyPresenceBridge` 单例的 `_ws_broadcast` 换成写进**局部 list** 的 lambda。它的 `_fresh()` 每次重建单例,所以**文件内部**互不干扰 —— 问题出在**跑完之后**:单例停在最后一条用例留下的那个实例上,此后每一次广播都掉进一个再也没人看的列表里。

受害者症状 `got [False]` 里那唯一的 `False`,是 `register_client()` 里 `_send_to()` **直接**发的,没走 `_ws_broadcast`;真正要验的 `True` 脉冲全被泄漏的 lambda 吞掉。

两头都修(污染源加 autouse fixture 前后置 `_instance = None`;受害者也从新建 bridge 开始)。反证四种组合:

| 组合 | 结果 |
|---|---|
| 两边都修 | 13 passed |
| 只修污染源 | 13 passed |
| 只修受害者 | 13 passed |
| **两边都撤** | **1 failed —— 精确复现 `got [False]`** |

即两半各自都足以修好,合起来是「两头都不依赖对方守规矩」。

---

## 验证

第一部分新增 `tests/test_hang_guard_is_configured.py`(8 条),含**子进程实证**(两种真实挂法被打断、后续用例仍执行、恰好 2 挂 2 过)与**反证**(关掉超时会一直挂到子进程 `TimeoutExpired`)。

后三部分新增/改写的每一条**都做了反证** —— 撤掉对应修复后必须变红,且**只**复现原症状:

- 缓存写炸掉时权威能力面照写 —— 撤掉后精确红在预期那行;
- vault 四条(不得被当凭证发出 / 不得列进已配置 / 端到端不得漏进 `_get_key` / 写入口退 400)—— 撤掉后 4 条全红;
- 真凭证必须照样取得到、照样列出 —— 两种状态都绿,证明过滤没有误伤;
- 单例劫持 —— 探针实测修复后单例根本没被创建,改回去立刻被污染;
- 五族静默基线 —— 模拟污染后撤掉修复,精确复现 E02/E03/E05。

局部:9 个基线文件 202 passed(原 190 + 5 failed);凭证相关 12 文件 306 passed(原 2 failed + 298);单例改动涉及的 9 文件 195 passed;最后一批受影响的 13 文件 218 passed / 1 skipped。

lint:`flake8 core/ --max-line-length=120` = 0、`black --check core/ tests/`、`isort --check-only core/ tests/` 全过。

## 两处自查更正(第二/三部分)

1. 改 `list_credential_keys()` 时我把非空判断一起去掉了 —— `is_placeholder("")` 是 `False`(空值不是占位符),那会把「环境变量存在但为空」也列成已配置。已补回并在注释里写明原因。
2. 第二部分我只断了一个 UnifiedConfig 污染源,CI 证明还有别的(同一轮里同时看得到 `sk-ant-already-persisted`、`sk-fallback`、`sk-oneapi-x` 这些来自不同文件的值)。追污染源是打地鼠,所以把 `only_env_layer` 改成可指定 provider 的工厂,让**依赖解析链的断言自己隔离自己那几层**;第三部分再把机制本身(`__new__` 劫持)断掉。

## 一个未处理的独立问题

跑测试会写脏 `config/capabilities.json` 与 `knowledge_db/knowledge_entries.json` 这两个**被 git 跟踪**的文件。本次每轮都已还原、未提交。测试改写仓库跟踪文件本身是个独立问题,不在这个 PR 里处理。

## 已知的 CI 状态

`File Complexity Budget` 是既有的系统性门 —— 26 个阻塞文件与 main 完全一致,逐个核对过,**本 PR 改的文件一个都不在里面**。
