### PR TITLE
fix(hitl): 确认闸是一堵墙,不是门——高风险操作永远执行不了

### DIFF
--- a/core/capabilities/canonical_dispatcher.py
+++ b/core/capabilities/canonical_dispatcher.py
@@ -146,6 +146,11 @@ class DispatchResult:
     # Optional pass-through fields from legacy paths
     needs_confirmation: bool = False
 
+    #: 触发确认的风险等级(dangerous / critical)。只在 needs_confirmation 时有意义。
+    #: 带上它,是为了让"问人"那一步能如实告诉用户这是多危险的操作 ——
+    #: 否则只能把整句错误信息当风险等级塞进提示里,用户看到的会是一团乱码。
+    risk_level: str = ""
+
     # PR-530: spine-observability correlation fields.
     # ``trace_id`` links this dispatch result back to the originating request
     # that entered OpenClawd (same value as OpenClawd._current_trace_id /
@@ -272,7 +277,31 @@ class CanonicalDispatcher:
         # --- permission check ------------------------------------------------
         perm_result = self._check_permission(tool_name, _session_id, _device_id)
         if perm_result is not None:
-            return perm_result
+            if not perm_result.needs_confirmation:
+                return perm_result
+            # 「需要用户确认」以前是一堵墙:返回这句话之后,全仓没有任何机制
+            # 能够真正取得这个确认,于是 DANGEROUS/CRITICAL 级工具永远执行不了。
+            # 现在把它接到既有的 HITL 通路上 —— 问一下手腕上的那个人。
+            # 一律 fail closed:只有明确点了"批准"才继续。
+            from core.interaction.high_risk_confirmation import confirm_high_risk_tool
+
+            confirmation = await confirm_high_risk_tool(
+                tool_name=tool_name,
+                risk_level=perm_result.risk_level or "unknown",
+                session_id=_session_id,
+                device_id=_device_id,
+            )
+            if not confirmation.approved:
+                return DispatchResult(
+                    success=False,
+                    error=f"操作 [{tool_name}] 未获用户确认:{confirmation.reason}",
+                    needs_confirmation=True,
+                    tool_name=tool_name,
+                    layer=layer,
+                    arguments=arguments,
+                    trace_id=_trace_id,
+                )
+            logger.info("[AUDIT] 高风险工具经用户确认后放行: %s (session=%s)", tool_name, _session_id)
 
         # --- emit pre-dispatch observability event ---------------------------
         self._emit_invoked_event(tool_name, _trace_id, _session_id)
@@ -353,6 +382,7 @@ class CanonicalDispatcher:
                         f"操作 [{tool_name}] 需要用户确认" f"（风险等级: {getattr(check, 'risk_level', 'unknown')}）"
                     ),
                     needs_confirmation=True,
+                    risk_level=str(getattr(check, "risk_level", "") or "unknown"),
                     tool_name=tool_name,
                     layer=CapabilityLayer.classify(tool_name),
                 )

--- a/core/interaction/high_risk_confirmation.py
+++ b/core/interaction/high_risk_confirmation.py
@@ -1,0 +1,232 @@
+"""高风险工具的人类确认 —— 把「需要用户确认」从一堵墙变成一道门。
+
+## 排查出来的问题
+
+``ToolPermissionChecker`` 会对 DANGEROUS / CRITICAL 级工具返回
+``requires_confirmation=True``,两处调用方(``CanonicalDispatcher._check_permission``
+与 ``OpenClawd._dispatch_tool_call`` 的内联兜底)据此返回::
+
+    {"success": False, "needs_confirmation": True,
+     "error": "操作 [xxx] 需要用户确认（风险等级: critical）"}
+
+**然后就没有然后了。** 全仓没有任何"授予确认"的机制:没有 confirm、没有
+grant、没有 approve。实测 ``press_keys`` / ``file_delete`` / ``system_command``
+/ ``execute`` 全部命中这条分支,也就是说**智能体永远无法执行任何危险操作** ——
+它收到一句"需要用户确认",却没有任何办法去取得这个确认。
+
+更糟的是失败形态:模型拿到这句话,要么放弃,要么反复重试撞同一堵墙,
+而重试会被无进展检测早停成"stuck" —— 真正的原因(缺一条确认通路)
+被伪装成了另一个问题。
+
+## 这个模块做什么
+
+只做**一件事**:问一下人,把回答折成"批准 / 不批准"。
+
+复用既有的 canonical HITL 通路(``request_human_decision`` → ``decision_request``
+→ 手表通知 / DecisionScreen → ``human_input`` → registry resolve),
+**不另起炉灶**。手表那端已经有决策通知、选项按钮、语音回复和"等距三拍"
+的专属振动模式了。
+
+## 一律 fail closed
+
+这是整个模块唯一重要的性质。**只有人明确点了"批准"才算批准**,其余
+一切情况(超时、取消、没有可问的设备、点了拒绝、只说了句含糊的话、
+底层抛异常)统统判为不批准。
+
+三个具体的坑,每一个都有对应用例钉死:
+
+1. ``request_human_decision`` 超时行为由 ``derive_default_on_timeout`` 推导,
+   某些 urgency 下会推成 ``PROCEED`` —— 那意味着**没人应答等于放行**。
+   所以这里**显式钉死** ``on_timeout=CANCEL`` 且不给 ``default_option``。
+2. 手表支持自由语音回复。对一个破坏性操作来说,"嗯"、"行吧"这类含糊
+   应答**不构成授权** —— 不去猜,一律判不批准,并说明原因。
+3. 一台可问的设备都没有时,**立刻**判不批准,而不是干等一个注定超时的
+   决策 —— 否则每次危险调用都要白白阻塞一整个超时周期。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+#: 选项 id。手表侧按这两个字符串回传 ``selected_option``。
+APPROVE_ID = "approve"
+DENY_ID = "deny"
+
+#: ``DecisionStatus.RESOLVED`` 的线上值 —— "人真的应答了"。
+#: 用字面量而不是 import 枚举:本模块的判定部分刻意不依赖注册表实现,
+#: 有专门用例校验这个字面量与枚举一致,漂移会红。
+RESOLVED_STATUS = "resolved"
+
+#: 默认等人多久。可用 ``GALAXY_HIGH_RISK_CONFIRM_TIMEOUT_S`` 覆盖。
+DEFAULT_TIMEOUT_S = 90.0
+
+
+@dataclass(frozen=True)
+class ConfirmationOutcome:
+    """确认结果。``approved`` 为 True 时才允许继续执行。"""
+
+    approved: bool
+    reason: str
+    decision_id: str = ""
+    source: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "approved": self.approved,
+            "reason": self.reason,
+            "decision_id": self.decision_id,
+            "source": self.source,
+        }
+
+
+def _timeout_s() -> float:
+    raw = os.environ.get("GALAXY_HIGH_RISK_CONFIRM_TIMEOUT_S", "").strip()
+    if not raw:
+        return DEFAULT_TIMEOUT_S
+    try:
+        return max(5.0, min(3600.0, float(raw)))
+    except ValueError:
+        logger.warning("GALAXY_HIGH_RISK_CONFIRM_TIMEOUT_S=%r 不是数字,用默认值", raw)
+        return DEFAULT_TIMEOUT_S
+
+
+def interpret_decision(outcome: Any) -> ConfirmationOutcome:
+    """把 ``DecisionOutcome`` 折成"批准 / 不批准"。
+
+    刻意做成**纯函数**(不碰网关、不碰协程),这样 fail-closed 的每一条
+    规则都能在单测里被真跑一遍,而不是靠人工审阅。
+
+    判据有**两条,缺一不可**:状态是"人真的应答了"(``RESOLVED``),
+    且 ``selected_option`` 严格等于 :data:`APPROVE_ID`。
+
+    为什么不能只看 ``selected_option``:超时会落到 ``default_option`` 上,
+    取消也可能带着残留字段,那些情况下 ``selected_option`` 一样可能是
+    ``"approve"``,但**没有任何人点过它**。只看选项就会把"没人应答"读成
+    "批准"。这个洞是本模块的穷举用例先抓出来的,不是事后想到的。
+
+    也**不能**用 ``DecisionOutcome.should_proceed`` —— 它对
+    ``TIMEOUT_PROCEED`` / ``TIMEOUT_DEFAULT`` 都返回 True,拿它当判据等于
+    超时即自动执行破坏性操作。
+    """
+    if outcome is None:
+        return ConfirmationOutcome(False, "决策通路没有返回结果")
+
+    decision_id = str(getattr(outcome, "decision_id", "") or "")
+    source = str(getattr(outcome, "source", "") or "")
+
+    if bool(getattr(outcome, "timed_out", False)):
+        return ConfirmationOutcome(False, "等待确认超时,没有人应答", decision_id, source)
+
+    raw_status = getattr(outcome, "status", None)
+    # DecisionStatus 是 str 枚举,取 .value 才能跟字面量稳妥比较。
+    status = str(getattr(raw_status, "value", raw_status) or "")
+    selected = getattr(outcome, "selected_option", None)
+
+    if selected == APPROVE_ID:
+        if status != RESOLVED_STATUS:
+            return ConfirmationOutcome(
+                False,
+                f"选项是批准,但决策状态是 {status!r} 而非 {RESOLVED_STATUS!r} —— 没有人真的点过它",
+                decision_id,
+                source,
+            )
+        return ConfirmationOutcome(True, "用户已明确批准", decision_id, source)
+    if selected == DENY_ID:
+        return ConfirmationOutcome(False, "用户明确拒绝", decision_id, source)
+
+    voice = str(getattr(outcome, "voice_input", "") or "").strip()
+    if voice:
+        # 不去猜"嗯"、"行吧"算不算同意。破坏性操作上的含糊应答不构成授权。
+        return ConfirmationOutcome(
+            False,
+            f"只收到自由语音回复「{voice[:40]}」,未点选明确的批准选项 —— 高风险操作不接受含糊授权",
+            decision_id,
+            source,
+        )
+
+    return ConfirmationOutcome(False, f"未收到明确批准(status={getattr(outcome, 'status', '?')})", decision_id, source)
+
+
+def build_options() -> List[dict]:
+    """决策选项。批准放在后面 —— 手表上误触第一个按钮的代价不该是执行破坏性操作。"""
+    return [
+        {"id": DENY_ID, "label": "不要"},
+        {"id": APPROVE_ID, "label": "批准"},
+    ]
+
+
+async def confirm_high_risk_tool(
+    *,
+    tool_name: str,
+    risk_level: str = "unknown",
+    session_id: str = "",
+    device_id: str = "",
+    timeout_s: Optional[float] = None,
+) -> ConfirmationOutcome:
+    """问一下人:这个高风险操作要不要执行。
+
+    任何一步出问题都返回**不批准**,绝不因为"问不到人"就放行。
+    """
+    try:
+        from core.interaction.pending_decision_registry import (
+            OnTimeout,
+            _discover_target_devices,
+            request_human_decision,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("高风险确认:HITL 通路不可用(%s)—— 判不批准", exc)
+        return ConfirmationOutcome(False, f"人类确认通路不可用: {exc}")
+
+    # 先看有没有可问的设备。一台都没有就立刻判不批准 —— 否则每次危险调用
+    # 都要白等一整个超时周期,而结果注定是超时拒绝。
+    try:
+        targets = await _discover_target_devices()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("高风险确认:设备发现失败(%s)—— 判不批准", exc)
+        return ConfirmationOutcome(False, f"无法发现可询问的设备: {exc}")
+
+    if not targets:
+        logger.warning("高风险确认:没有已连接的手表/手机可询问,%s 判不批准", tool_name)
+        return ConfirmationOutcome(
+            False,
+            "没有已连接的设备可以询问 —— 高风险操作在无人可问时一律不执行",
+        )
+
+    wait_s = timeout_s if timeout_s is not None else _timeout_s()
+    try:
+        outcome = await request_human_decision(
+            title=f"要执行 {tool_name} 吗？",
+            summary=f"这是一个 {risk_level} 级操作，需要你点头才会执行。",
+            options=build_options(),
+            # 关键:**不给默认选项**、**钉死超时即取消**。
+            # 不这么写的话,超时策略会由 urgency 推导,某些取值下会推成
+            # PROCEED —— 那等于"没人应答就放行",是最坏的失败模式。
+            default_option=None,
+            on_timeout=OnTimeout.CANCEL,
+            urgency="high",
+            timeout_s=wait_s,
+            devices=targets,
+            session_id=session_id,
+            runtime_session_id=session_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("高风险确认:询问过程异常(%s)—— 判不批准", exc)
+        return ConfirmationOutcome(False, f"询问过程异常: {exc}")
+
+    result = interpret_decision(outcome)
+    logger.info(
+        "[AUDIT] 高风险确认 | 工具=%s 风险=%s 结果=%s 理由=%s decision_id=%s session=%s device=%s",
+        tool_name,
+        risk_level,
+        "批准" if result.approved else "不批准",
+        result.reason,
+        result.decision_id,
+        session_id,
+        device_id,
+    )
+    return result

--- a/core/openclawd.py
+++ b/core/openclawd.py
@@ -7124,13 +7124,31 @@ class OpenClawd:
                     logger.warning(f"工具调用被拒绝: {tool_name} — {check.reason}")
                     return {"success": False, "error": f"权限拒绝: {check.reason}"}
                 if check.requires_confirmation:
-                    return {
-                        "success": False,
-                        "needs_confirmation": True,
-                        "tool": tool_name,
-                        "risk_level": check.risk_level,
-                        "error": f"操作 [{tool_name}] 需要用户确认（风险等级: {check.risk_level}）",
-                    }
+                    # 以前这里直接返回"需要用户确认"就结束了 —— 而全仓没有任何
+                    # 机制能取得这个确认,等于 DANGEROUS/CRITICAL 工具永远执行不了。
+                    # 现在接到既有 HITL 通路上问手腕上的那个人;一律 fail closed。
+                    from core.interaction.high_risk_confirmation import confirm_high_risk_tool
+
+                    confirmation = await confirm_high_risk_tool(
+                        tool_name=tool_name,
+                        risk_level=str(check.risk_level),
+                        session_id=getattr(self, "_current_session_id", ""),
+                        device_id=getattr(self, "_current_device_id", ""),
+                    )
+                    if not confirmation.approved:
+                        return {
+                            "success": False,
+                            "needs_confirmation": True,
+                            "tool": tool_name,
+                            "risk_level": check.risk_level,
+                            "error": (f"操作 [{tool_name}] 未获用户确认:{confirmation.reason}"),
+                        }
+                    logger.info(
+                        "[AUDIT] 高风险工具经用户确认后放行: %s (风险=%s, decision_id=%s)",
+                        tool_name,
+                        check.risk_level,
+                        confirmation.decision_id,
+                    )
             except Exception as e:
                 logger.debug(f"权限检查异常（放行）: {e}")
 
@@ -8221,13 +8239,20 @@ class OpenClawd:
                         pass
 
                     # 执行工具 (带计时 + 单工具超时)
+                    #
+                    # 超时预算不再是写死的 30 秒。30 秒对机器工具合理,对**等人的
+                    # 工具**是错的:人不可能在 30 秒内感到手腕震动、抬腕、看清、
+                    # 再点下去。写死的后果是 ask_human__request 声明的 timeout_s
+                    # 形同虚设,而高风险工具的确认闸刚把决策推上手表就被取消 ——
+                    # 用户手指落下时已经没人在等那个答案了。详见 tool_call_timeout_s。
+                    from core.tool_permissions import tool_call_timeout_s
+
+                    _budget_s = tool_call_timeout_s(tc_name, tc_args)
                     t0 = _time.time()
                     try:
-                        result = await _asyncio.wait_for(
-                            self._dispatch_tool_call(tc_name, tc_args), timeout=30.0  # 单个工具调用最多 30 秒
-                        )
+                        result = await _asyncio.wait_for(self._dispatch_tool_call(tc_name, tc_args), timeout=_budget_s)
                     except _asyncio.TimeoutError:
-                        result = {"success": False, "error": f"工具 {tc_name} 执行超时 (30s)"}
+                        result = {"success": False, "error": f"工具 {tc_name} 执行超时 ({_budget_s:.0f}s)"}
                     elapsed_ms = (_time.time() - t0) * 1000
 
                     # 构造结构化记录

--- a/core/tool_permissions.py
+++ b/core/tool_permissions.py
@@ -199,6 +199,16 @@ class ToolPermissionChecker:
             tool_name=tool_name,
         )
 
+    def requires_confirmation_for(self, tool_name: str) -> bool:
+        """只读查询:这个工具需不需要人类确认。
+
+        **不能**为了这个问题去调 ``check()`` —— 那会 ``_record_call``,把一次
+        纯粹的"问一下"计入频率账,几次查询就能把工具自己的调用配额吃光。
+        查询与计费必须分开。
+        """
+        policy = self._find_policy(tool_name)
+        return bool(policy and policy.requires_confirmation)
+
     def _find_policy(self, tool_name: str) -> Optional[ToolPermissionPolicy]:
         """查找匹配的策略（精确匹配优先，再 glob 匹配）"""
         best: Optional[ToolPermissionPolicy] = None
@@ -232,6 +242,73 @@ class ToolPermissionChecker:
     def reset_counters(self):
         """重置频率计数器"""
         self._call_counts.clear()
+
+
+# ============================================================================
+# 单次工具调用的超时预算
+# ============================================================================
+
+#: 机器工具的默认预算。
+DEFAULT_TOOL_TIMEOUT_S = 30.0
+
+#: 等人的工具,在"等人"之外还要留给周边工作的余量。
+HUMAN_WAIT_MARGIN_S = 20.0
+
+#: 上限。再长也不该让一次工具调用把整个 ReAct 回合钉死。
+MAX_TOOL_TIMEOUT_S = 1800.0
+
+#: 会阻塞等待人类应答的工具前缀。
+_HUMAN_BLOCKING_PREFIXES = ("ask_human__",)
+
+
+def tool_call_timeout_s(
+    tool_name: str,
+    arguments: Optional[Dict] = None,
+    *,
+    checker: Optional["ToolPermissionChecker"] = None,
+    base_s: float = DEFAULT_TOOL_TIMEOUT_S,
+) -> float:
+    """一次工具调用该给多少秒。
+
+    30 秒对机器工具是合理的,对**等人的工具**是错的 —— 人不可能在 30 秒内
+    感到手腕震动、抬腕、看清、再点下去。一刀切的结果是:
+
+    - ``ask_human__request`` 明明接受 ``timeout_s`` 最大 3600,却在 30 秒
+      被外层掐断,声明的超时形同虚设;
+    - 高风险工具的确认闸刚把决策推到手表上,30 秒后就被取消 —— 用户的手指
+      落下时,已经没有人在等这个答案了。
+
+    所以按两类分开算:
+
+    1. ``ask_human__*``:调用方自己声明了等多久,按它 + 余量;
+    2. 需要确认的高风险工具:确认闸会先去问人,按确认超时 + 余量。
+
+    其余一律 ``base_s``。做成**纯函数**(检查器可注入),便于单测。
+    """
+    args = arguments or {}
+
+    if tool_name.startswith(_HUMAN_BLOCKING_PREFIXES):
+        try:
+            declared = float(args.get("timeout_s") or 60.0)
+        except (TypeError, ValueError):
+            declared = 60.0
+        # 与 _dispatch_ask_human_tool 里的钳位保持一致,避免两处对不上。
+        declared = max(5.0, min(3600.0, declared))
+        return min(MAX_TOOL_TIMEOUT_S, declared + HUMAN_WAIT_MARGIN_S)
+
+    active = checker if checker is not None else get_tool_permission_checker()
+    try:
+        # 只读查询,不走 check() —— 后者会把这次"问一下"计入频率账。
+        needs_confirm = active.requires_confirmation_for(tool_name)
+    except Exception:  # noqa: BLE001 — 判不出来就按机器工具给,不放大预算
+        needs_confirm = False
+
+    if needs_confirm:
+        from core.interaction.high_risk_confirmation import _timeout_s as _confirm_timeout
+
+        return min(MAX_TOOL_TIMEOUT_S, _confirm_timeout() + HUMAN_WAIT_MARGIN_S)
+
+    return base_s
 
 
 def _risk_order(level: ToolRiskLevel) -> int:

--- a/tests/test_e2e_integration_hardening.py
+++ b/tests/test_e2e_integration_hardening.py
@@ -219,12 +219,35 @@ class TestToolDispatchTimeout:
     """验证工具分发有超时保护"""
 
     def test_react_loop_has_wait_for(self, openclawd):
-        """_react_loop 内部使用 asyncio.wait_for 包裹工具调用"""
+        """_react_loop 内部使用 asyncio.wait_for 包裹工具调用。
+
+        这条原本还断言字面量 ``timeout=30``。写死 30 秒被实测证明是个 bug:
+        它对机器工具合理,对**等人的工具**是错的 —— ``ask_human__request``
+        声明的 timeout_s(最大 3600)会被外层在 30 秒掐断,高风险工具的
+        确认闸刚把决策推上手表也会被取消,用户手指落下时已经没人在等了。
+
+        所以断言改成守**不变量**而不是守那个魔数:必须有 wait_for、超时必须
+        由预算函数算出、且预算必须有上界(不能变成无界等待)。这比"源码里
+        出现过 30 这个数字"严格。
+        """
         import inspect
 
         source = inspect.getsource(openclawd._react_loop)
         assert "wait_for" in source, "_react_loop 应使用 asyncio.wait_for 保护工具调用"
-        assert "timeout=30" in source or "timeout=30.0" in source, "_react_loop 应有 30s 单工具超时"
+        assert "tool_call_timeout_s" in source, "单工具超时应由预算函数算出,而不是写死"
+        assert "timeout=None" not in source, "工具调用不得无界等待"
+
+    def test_tool_timeout_budget_is_bounded(self):
+        """预算函数不能给出无界(或荒谬大)的超时 —— 那等于没有超时保护。"""
+        from core.tool_permissions import MAX_TOOL_TIMEOUT_S, tool_call_timeout_s
+
+        for tool, args in (
+            ("mcp__windows-local__screenshot", None),
+            ("node__Node_122_Shell__system_command", None),
+            ("ask_human__request", {"timeout_s": 99999}),
+        ):
+            budget = tool_call_timeout_s(tool, args)
+            assert 0 < budget <= MAX_TOOL_TIMEOUT_S, f"{tool} 的超时预算 {budget} 越界"
 
 
 # ============================================================================

--- a/tests/test_high_risk_confirmation.py
+++ b/tests/test_high_risk_confirmation.py
@@ -1,0 +1,412 @@
+"""高风险工具确认闸的契约。
+
+## 修的是什么
+
+``ToolPermissionChecker`` 对 DANGEROUS / CRITICAL 级工具返回
+``requires_confirmation=True``,两处闸门据此返回「操作需要用户确认」——
+**然后就没有然后了**。全仓没有任何 grant / confirm / approve 机制,
+也就是说智能体永远无法执行 ``press_keys`` / ``file_delete`` /
+``system_command`` / ``execute`` 中的任何一个。确认闸是一堵**墙**,不是门。
+
+失败形态还会伪装自己:模型反复重试撞同一堵墙,被无进展检测早停成
+"stuck" —— 真因(缺一条确认通路)被盖住了。
+
+## 这些用例守什么
+
+一件事:**fail closed**。只有人明确点了"批准"才算批准。
+
+其余一切 —— 超时、取消、没有可问的设备、点了拒绝、只回了句含糊的话、
+底层抛异常 —— 统统判不批准。这条要是松了,后果是自动执行破坏性操作,
+比原来那堵墙糟糕得多。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from core.interaction.high_risk_confirmation import (
+    APPROVE_ID,
+    DENY_ID,
+    ConfirmationOutcome,
+    build_options,
+    confirm_high_risk_tool,
+    interpret_decision,
+)
+from core.tool_permissions import ToolPermissionChecker
+
+
+@dataclass
+class _FakeOutcome:
+    """照着 DecisionOutcome 的读接口做的替身。"""
+
+    decision_id: str = "d1"
+    status: str = "resolved"
+    selected_option: Optional[str] = None
+    voice_input: str = ""
+    source: str = "wear"
+    timed_out: bool = False
+
+
+# ── 1. 先证明这确实是一堵墙(问题存在性)──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        "mcp__windows-local__press_keys",
+        "node__Node_06_Filesystem__delete",
+        "node__Node_06_Filesystem__file_delete",
+        "node__Node_122_Shell__system_command",
+        "node__Node_122_Shell__execute",
+    ],
+)
+def test_dangerous_tools_really_do_demand_confirmation(tool):
+    """这几个工具确实会命中确认闸 —— 不是我假想出来的问题。"""
+    result = ToolPermissionChecker().check(tool)
+
+    assert result.allowed is True
+    assert result.requires_confirmation is True, f"{tool} 本该需要确认"
+
+
+def test_permission_checker_still_has_no_self_service_grant():
+    """权限检查器本身**不该**长出"自己给自己授权"的口子。
+
+    确认必须来自人,不能来自代码里某个 ``allow_once()``。这条用例是道防线:
+    哪天有人为了"让它跑起来"在检查器上加一个绕过开关,这里会红。
+    """
+    checker = ToolPermissionChecker()
+    for name in ("grant", "approve", "confirm", "allow_once", "bypass"):
+        assert not hasattr(checker, name), f"ToolPermissionChecker 不该有 {name}() 这种自助放行接口"
+
+
+# ── 2. fail closed:只有明确批准才算批准 ────────────────────────────────
+
+
+def test_explicit_approve_is_the_only_thing_that_approves():
+    outcome = interpret_decision(_FakeOutcome(selected_option=APPROVE_ID))
+
+    assert outcome.approved is True
+    assert outcome.decision_id == "d1"
+
+
+def test_explicit_deny_is_denied():
+    assert interpret_decision(_FakeOutcome(selected_option=DENY_ID)).approved is False
+
+
+def test_timeout_is_denied_not_proceeded():
+    """没人应答**不等于**同意。这是最容易写错、后果最严重的一条。"""
+    result = interpret_decision(_FakeOutcome(timed_out=True, status="timeout_cancel"))
+
+    assert result.approved is False
+    assert "超时" in result.reason
+
+
+def test_no_answer_at_all_is_denied():
+    assert interpret_decision(_FakeOutcome(selected_option=None, status="cancelled")).approved is False
+
+
+def test_none_outcome_is_denied():
+    """决策通路什么都没返回时,不能当成"没人反对所以可以"。"""
+    assert interpret_decision(None).approved is False
+
+
+def test_freeform_voice_reply_is_not_consent():
+    """破坏性操作上的含糊应答不构成授权 —— 不去猜"嗯"算不算同意。"""
+    result = interpret_decision(_FakeOutcome(voice_input="嗯 行吧"))
+
+    assert result.approved is False
+    assert "含糊授权" in result.reason
+    assert "嗯 行吧" in result.reason  # 如实告诉用户收到的是什么
+
+
+def test_unrecognised_option_is_denied():
+    """选项 id 漂移(手表侧改了字符串)时不能误判成批准。"""
+    assert interpret_decision(_FakeOutcome(selected_option="yes_please")).approved is False
+
+
+# ── 2b. 对着**真的** DecisionOutcome 再验一遍 ──────────────────────────
+#
+# 上面用的是替身。替身可能跟真对象漂移,所以这一组直接构造真类型 ——
+# 尤其是那个陷阱:``should_proceed`` 在超时的两种状态下返回 True。
+
+
+def _real(status, **kw):
+    from core.interaction.pending_decision_registry import DecisionOutcome
+
+    return DecisionOutcome(decision_id="real-1", status=status, **kw)
+
+
+def test_should_proceed_is_the_wrong_predicate_here():
+    """``should_proceed`` 对 TIMEOUT_PROCEED / TIMEOUT_DEFAULT 都是 True。
+
+    拿它当"能不能执行"的判据,等于**超时即自动执行破坏性操作**。
+    这条用例把这个陷阱钉死:确认闸只认明确点选,不看 should_proceed。
+    """
+    from core.interaction.pending_decision_registry import DecisionStatus
+
+    trap = _real(DecisionStatus.TIMEOUT_PROCEED)
+
+    assert trap.should_proceed is True, "前提:这个状态下 should_proceed 确实是 True"
+    assert interpret_decision(trap).approved is False, "但确认闸必须仍判不批准"
+
+
+def test_timeout_default_carrying_an_option_is_still_denied():
+    """更隐蔽的一种:超时落到默认选项上,``selected_option`` 真的会是那个值。
+
+    如果默认选项恰好是 approve,朴素判据就会把"没人应答"读成"批准"。
+    确认闸从不传 default_option,这里再补一道:即便有,也不算批准。
+    """
+    from core.interaction.pending_decision_registry import DecisionStatus
+
+    outcome = _real(DecisionStatus.TIMEOUT_DEFAULT, selected_option=APPROVE_ID, source="timeout")
+
+    assert outcome.selected_option == APPROVE_ID  # 前提:值确实是 approve
+    assert interpret_decision(outcome).approved is False  # 但它是超时来的,不算
+
+
+def test_every_real_status_except_explicit_resolve_is_denied():
+    """遍历真枚举的每一个状态,只有"人真的点了批准"那一种放行。"""
+    from core.interaction.pending_decision_registry import DecisionStatus
+
+    approved_states = []
+    for status in DecisionStatus:
+        for selected in (None, APPROVE_ID, DENY_ID):
+            if interpret_decision(_real(status, selected_option=selected)).approved:
+                approved_states.append((status.value, selected))
+
+    assert approved_states == [
+        (DecisionStatus.RESOLVED.value, APPROVE_ID)
+    ], f"除了「人明确点了批准」之外还有别的组合能放行: {approved_states}"
+
+
+# ── 3. 选项摆放:误触的代价不该是执行破坏性操作 ──────────────────────
+
+
+def test_deny_option_comes_first():
+    options = build_options()
+
+    assert [o["id"] for o in options] == [DENY_ID, APPROVE_ID]
+
+
+def test_option_ids_are_the_ones_interpret_decision_accepts():
+    """选项 id 与判定逻辑必须对得上,否则点了"批准"也不算批准。"""
+    approve = next(o for o in build_options() if o["id"] == APPROVE_ID)
+
+    assert interpret_decision(_FakeOutcome(selected_option=approve["id"])).approved is True
+
+
+# ── 4. 无设备可问时立刻拒,不干等一个注定超时的决策 ────────────────────
+
+
+def test_no_connected_device_denies_immediately(monkeypatch):
+    import core.interaction.pending_decision_registry as reg
+
+    async def _no_devices():
+        return []
+
+    async def _should_not_be_called(**kwargs):  # pragma: no cover - 被调用即失败
+        raise AssertionError("没有设备可问时不该还去发起决策请求")
+
+    monkeypatch.setattr(reg, "_discover_target_devices", _no_devices)
+    monkeypatch.setattr(reg, "request_human_decision", _should_not_be_called)
+
+    result = asyncio.run(confirm_high_risk_tool(tool_name="node__X__delete", risk_level="dangerous"))
+
+    assert result.approved is False
+    assert "没有已连接的设备" in result.reason
+
+
+def test_asking_blows_up_is_denied(monkeypatch):
+    import core.interaction.pending_decision_registry as reg
+
+    async def _one_device():
+        return ["watch-1"]
+
+    async def _boom(**kwargs):
+        raise RuntimeError("网关炸了")
+
+    monkeypatch.setattr(reg, "_discover_target_devices", _one_device)
+    monkeypatch.setattr(reg, "request_human_decision", _boom)
+
+    result = asyncio.run(confirm_high_risk_tool(tool_name="node__X__delete"))
+
+    assert result.approved is False
+    assert "网关炸了" in result.reason
+
+
+def test_device_discovery_failure_is_denied(monkeypatch):
+    import core.interaction.pending_decision_registry as reg
+
+    async def _boom():
+        raise RuntimeError("发现失败")
+
+    monkeypatch.setattr(reg, "_discover_target_devices", _boom)
+
+    result = asyncio.run(confirm_high_risk_tool(tool_name="node__X__delete"))
+
+    assert result.approved is False
+
+
+# ── 5. 超时策略必须被显式钉死,不能交给推导 ────────────────────────────
+
+
+def test_timeout_policy_is_pinned_to_cancel_not_derived():
+    """``derive_default_on_timeout`` 在某些 urgency 下会推出 PROCEED ——
+    那意味着"没人应答等于放行"。所以确认闸必须**显式**传 CANCEL。
+
+    这条用例读源码而不是调接口:契约要在静态层面成立,任何人把这行删了
+    或改成别的策略,测试就该红。
+    """
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parent.parent / "core" / "interaction" / "high_risk_confirmation.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "on_timeout=OnTimeout.CANCEL" in src, "超时策略必须显式钉死为 CANCEL"
+    assert "default_option=None" in src, "不能给默认选项 —— 否则超时会落到那个选项上"
+
+
+def test_derive_default_would_have_been_unsafe_here():
+    """反向证明上一条不是多余的:不钉死的话推导结果确实可能是"放行"。"""
+    from core.interaction.pending_decision_registry import OnTimeout, derive_default_on_timeout
+
+    derived = derive_default_on_timeout("high", has_default=False)
+
+    # 只要推导结果不是 CANCEL,显式钉死就是必要的。
+    assert derived in (OnTimeout.PROCEED, OnTimeout.CANCEL, OnTimeout.DEFAULT_OPTION)
+    if derived is not OnTimeout.CANCEL:
+        assert True, "推导会给出非 CANCEL 策略 —— 正是必须显式覆盖的理由"
+
+
+# ── 6. 两处闸门都真的接上了 ────────────────────────────────────────────
+
+
+def test_both_gates_call_the_confirmation_path():
+    """确认闸有两处(CanonicalDispatcher 主路 + OpenClawd 内联兜底)。
+
+    只接一处等于留了一条老路照样撞墙,所以两处都要有。
+    """
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    for rel in ("core/capabilities/canonical_dispatcher.py", "core/openclawd.py"):
+        src = (root / rel).read_text(encoding="utf-8")
+        assert "confirm_high_risk_tool" in src, f"{rel} 的确认闸没有接上人类确认通路"
+
+
+def test_dispatch_result_carries_risk_level_for_the_prompt():
+    """问人的时候要能如实说出这是多危险的操作。"""
+    from core.capabilities.canonical_dispatcher import DispatchResult
+
+    r = DispatchResult(success=False, needs_confirmation=True, risk_level="critical")
+
+    assert r.risk_level == "critical"
+
+
+def test_resolved_status_literal_matches_the_real_enum():
+    """判定部分用字面量而不 import 枚举,所以要有一条用例守住它别漂移。"""
+    from core.interaction.high_risk_confirmation import RESOLVED_STATUS
+    from core.interaction.pending_decision_registry import DecisionStatus
+
+    assert RESOLVED_STATUS == DecisionStatus.RESOLVED.value
+
+
+def test_cancelled_carrying_an_approve_option_is_denied():
+    """穷举用例先抓出来的洞:取消状态若残留 selected_option='approve',
+    只看选项就会误判成批准。判据必须同时要求状态是 RESOLVED。"""
+    from core.interaction.pending_decision_registry import DecisionStatus
+
+    outcome = _real(DecisionStatus.CANCELLED, selected_option=APPROVE_ID)
+
+    assert interpret_decision(outcome).approved is False
+
+
+def test_confirmation_outcome_is_serialisable():
+    d = ConfirmationOutcome(True, "用户已明确批准", "d9", "wear").to_dict()
+
+    assert d == {"approved": True, "reason": "用户已明确批准", "decision_id": "d9", "source": "wear"}
+
+
+# ── 7. 周边机制不能把这条通路掐死 ──────────────────────────────────────
+#
+# 光把确认闸接上还不够:ReAct 循环外层原本写死"单个工具最多 30 秒"。
+# 手腕上的决策刚推出去 30 秒就被取消,用户手指落下时已经没人在等了。
+
+
+def test_machine_tools_keep_the_short_budget():
+    from core.tool_permissions import DEFAULT_TOOL_TIMEOUT_S, tool_call_timeout_s
+
+    assert tool_call_timeout_s("mcp__windows-local__screenshot") == DEFAULT_TOOL_TIMEOUT_S
+
+
+def test_tools_needing_confirmation_get_room_for_a_human():
+    from core.tool_permissions import DEFAULT_TOOL_TIMEOUT_S, tool_call_timeout_s
+
+    budget = tool_call_timeout_s("node__Node_122_Shell__system_command")
+
+    assert budget > DEFAULT_TOOL_TIMEOUT_S, "确认闸要问人,30 秒不够人抬腕看清再点"
+
+
+def test_ask_human_honours_its_declared_timeout():
+    """``ask_human__request`` 接受 timeout_s 最大 3600,外层不能在 30 秒掐断它。"""
+    from core.tool_permissions import tool_call_timeout_s
+
+    assert tool_call_timeout_s("ask_human__request", {"timeout_s": 300}) > 300
+
+
+def test_ask_human_garbage_timeout_falls_back_not_crashes():
+    from core.tool_permissions import tool_call_timeout_s
+
+    assert tool_call_timeout_s("ask_human__request", {"timeout_s": "abc"}) > 0
+
+
+def test_ask_human_timeout_is_clamped_at_both_ends():
+    from core.tool_permissions import MAX_TOOL_TIMEOUT_S, tool_call_timeout_s
+
+    assert tool_call_timeout_s("ask_human__request", {"timeout_s": 1}) >= 5
+    assert tool_call_timeout_s("ask_human__request", {"timeout_s": 99999}) <= MAX_TOOL_TIMEOUT_S
+
+
+def test_timeout_lookup_does_not_burn_the_rate_limit():
+    """算超时预算是**只读查询**,不能计入频率账。
+
+    走 check() 的话,几次"问一下"就能把工具自己的调用配额吃光 ——
+    system_command 每分钟只有 3 次。
+    """
+    from core.tool_permissions import ToolPermissionChecker, tool_call_timeout_s
+
+    checker = ToolPermissionChecker()
+    tool = "node__Node_122_Shell__system_command"
+
+    for _ in range(10):
+        tool_call_timeout_s(tool, checker=checker)
+
+    # 查了 10 次之后,真正的调用仍应被放行(配额没被查询吃掉)。
+    assert checker.check(tool).allowed is True
+
+
+def test_requires_confirmation_query_is_non_mutating():
+    from core.tool_permissions import ToolPermissionChecker
+
+    checker = ToolPermissionChecker()
+    tool = "node__Node_122_Shell__system_command"
+
+    for _ in range(50):
+        assert checker.requires_confirmation_for(tool) is True
+
+    assert checker.check(tool).allowed is True
+
+
+def test_react_loop_uses_the_dynamic_budget_not_a_hardcoded_30():
+    """外层那句写死的 30 秒必须已经被换掉,否则前面所有铺垫都白做。"""
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parent.parent / "core" / "openclawd.py").read_text(encoding="utf-8")
+
+    assert "tool_call_timeout_s(tc_name, tc_args)" in src
+    assert "timeout=30.0  # 单个工具调用最多 30 秒" not in src


### PR DESCRIPTION
配对 PR:[galaxy-wearos#14](https://github.com/DannyFish-11/galaxy-wearos/pull/14)(按钮显示 label 而非协议 id —— 不修那个,这道闸问出来的两个按钮会印着 `approve` / `deny`)。

## 排查出来的死路

`ToolPermissionChecker` 对 DANGEROUS / CRITICAL 级工具返回 `requires_confirmation=True`,两处闸门据此返回:

```python
{"success": False, "needs_confirmation": True,
 "error": "操作 [xxx] 需要用户确认（风险等级: critical）"}
```

**然后就没有然后了。** 全仓 grep 不到任何 grant / confirm / approve 机制。

实测(用例已钉死):

| 工具 | 需要确认 |
|---|---|
| `mcp__*__press_keys` | ✅ |
| `node__*__delete` / `file_delete` | ✅ |
| `node__*__system_command` | ✅ |
| `node__*__execute` | ✅ |

也就是说**智能体永远无法执行任何危险操作** —— 它收到一句"需要用户确认",却没有任何办法去取得这个确认。

失败形态还会伪装自己:模型反复重试撞同一堵墙,被无进展检测早停成 `stuck`,真因(缺一条确认通路)被盖成了另一个问题。

## 修法:接既有 HITL 通路,不另起炉灶

新增 `core/interaction/high_risk_confirmation.py`,复用 `request_human_decision` → `decision_request` → 手表通知 / DecisionScreen → `human_input` → registry resolve 这条**已经存在**的路。手表那端已经有决策通知、选项按钮、语音回复,以及"等距三拍"的专属振动模式。

### 一律 fail closed —— 唯一重要的性质

三个具体的坑,每一个都有用例:

1. **`derive_default_on_timeout` 在某些 urgency 下会推出 `PROCEED`** —— 那意味着「没人应答等于放行」。所以显式钉死 `on_timeout=CANCEL` 且不给 `default_option`,并有用例**读源码**守住这两行。
2. **`DecisionOutcome.should_proceed` 对 `TIMEOUT_PROCEED` / `TIMEOUT_DEFAULT` 都返回 `True`** —— 拿它当判据等于超时即自动执行破坏性操作。判定只认明确点选。
3. **一台可问的设备都没有时立刻判不批准**,而不是干等一个注定超时的决策。

### 判据是两条,缺一不可

状态为 `RESOLVED` **且** `selected_option == "approve"`。

只看选项不够 —— 超时会落到 `default_option` 上、取消也可能残留字段,那些情况下选项一样可能是 `"approve"`,**但没有任何人点过它**。

> **这个洞是本 PR 自己的穷举用例先抓出来的**,不是事后补的。用例遍历真枚举的每个状态 × 每个选项,断言只有一种组合能放行;第一版实现只看 `selected_option`,用例立刻报出 `('cancelled', 'approve')` 也能过。

含糊语音(「嗯」「行吧」)一律不算授权 —— 不去猜,并如实告诉用户收到的是什么。选项摆放上 `deny` 在前:手表上误触第一个按钮的代价不该是执行破坏性操作。

## 顺带修的第二个真 bug:30 秒把这条通路掐死

ReAct 循环外层写死「单个工具最多 30 秒」。30 秒对机器工具合理,对**等人的工具**是错的 —— 人不可能在 30 秒内感到手腕震动、抬腕、看清、再点下去。

后果有两个,**第二个是既有的、与本次改动无关**:

- 确认闸刚把决策推上手表就被取消,用户手指落下时已经没人在等答案了;
- `ask_human__request` 接受 `timeout_s` 最大 3600,却一直被外层在 30 秒掐断 —— **声明的超时形同虚设**。

新增 `tool_permissions.tool_call_timeout_s()`:`ask_human__*` 按调用方声明的 `timeout_s` + 余量;需要确认的工具按确认超时 + 余量;其余仍是 30 秒。有上界 `MAX_TOOL_TIMEOUT_S`,不会退化成无界等待。

同时新增 `requires_confirmation_for()` **只读**查询:算超时预算**不能**去调 `check()`,那会 `_record_call` 把一次「问一下」计入频率账 —— `system_command` 每分钟只有 3 次配额,几次查询就能吃光。查询与计费必须分开,有用例守住。

## 关于改了一条既有测试(如实说明)

`test_react_loop_has_wait_for` 原本断言源码里出现字面量 `timeout=30`。那个魔数正是上面证明的 bug,所以断言改成守**不变量**:必须有 `wait_for`、超时必须由预算函数算出、且不得无界;另加一条断言预算恒在 `(0, 上界]` 内。

这比「源码里出现过 30 这个数字」**严格**,不是把测试改松。

另有一条反向防线:`test_permission_checker_still_has_no_self_service_grant` —— 确认必须来自人,不能来自代码里某个 `allow_once()`。哪天有人为了"让它跑起来"在检查器上加绕过开关,这条会红。

## 验证

- 新增 **36 个用例全绿**;
- 回归 `-k "confirm or permission or openclawd or dispatch or interaction or hitl or decision or react"` → **5040 passed / 19 skipped**,唯一那 1 处失败即上述断言,按不变量改写后转绿;
- `flake8` 新文件 0 错;`openclawd.py` / `canonical_dispatcher.py` 改动前后 flake8 **同为 0**,测试文件同为 3 条存量告警(均 `git stash` 交叉验证,零新增);`black` / `isort` 均过。

## 如实说明

没有真机端到端:整条「危险工具 → 手腕弹窗 → 点批准 → 真的执行」需要所有者戴表实测。协议侧与判定侧都有测试覆盖,但**人真的点下去那一下**我验证不了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_