### PR TITLE
fix(entrypoint): import 入口脚本不再改写 os.environ —— 本机 .env 灌满整个 pytest 进程

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,35 +11,63 @@ import os
 # os.environ(而不是全部经过 core.unified_config 的间接路径)——统统读不到，
 # 表现为"存了，重启后又没了"。这里在进程最早期加载 .env，且 override=False
 # (不覆盖已存在的真实 shell/系统环境变量，尊重用户显式导出的优先级更高)。
-try:
-    from dotenv import dotenv_values
-    # 密钥库注水:设置面板把 API Key 等 secret 写进 runtime/secrets.env(而非
-    # .env,见 core/config_store.py),此前重启后无人把它注回 os.environ ——
-    # 直读 os.getenv 的路径(含面板"已配置"角标)统统看不到,表现为"Key 存了,
-    # 重启后又显示未配置"。与 .env 同一套纪律先行加载(非空、非 # 毒值、不
-    # 覆盖已存在键 —— shell 显式导出仍最高;面板保存的最新真值先到先得)。
-    _secrets_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runtime", "secrets.env")
-    for _k, _v in (dotenv_values(_secrets_path) or {}).items():
-        if _v and not _v.lstrip().startswith("#") and _k not in os.environ:
-            os.environ[_k] = _v
-    _env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
-    # 关键:不能用 load_dotenv() 整个灌进去——设置面板自动生成的 .env 会把
-    # 【全部】schema 键写成 KEY=(空值)。空字符串一旦进了 os.environ,就会把
-    # 代码里的默认值顶掉:os.environ.get("OLLAMA_URL", "http://localhost:11434")
-    # 在 OLLAMA_URL="" 存在时返回的是 ""，不是默认值!真机复现过的一整串症状
-    # 都源于此——LocalBrainManager 拿着空 URL ping Ollama(报"Request URL is
-    # missing an 'http://' or 'https://' protocol"、Ollama 明明在跑却判"服务
-    # 未响应/模型未就绪")、Redis "must specify scheme"、NATS "invalid
-    # hostname"。这里改为只加载【非空】值,空值视同未配置,让代码默认值生效。
-    # 另一类毒值:python-dotenv 会把「KEY=   # 注释」这种【空值+行内注释】整段
-    # 注释当成值(实测 1.2.2:OLLAMA_URL= # e.g. http://... → '# e.g. http://...'),
-    # 经 normalize 补协议头后变成 http://#... 的怪 URL,骗过全部 startswith 检查。
-    # 值以 # 开头一律视同未配置(合法配置值不可能以 # 开头)。
-    for _k, _v in (dotenv_values(_env_path) or {}).items():
-        if _v and not _v.lstrip().startswith("#") and _k not in os.environ:
-            os.environ[_k] = _v
-except Exception:
-    pass
+
+
+def load_env_files_into_environ(root: str = "") -> None:
+    """把 runtime/secrets.env 与 .env 的【非空、非毒值】键注入 os.environ。
+
+    只在 main.py **作为脚本运行**时调用(见下方 ``__name__`` 守卫),不在
+    ``import main`` 时执行 —— 这是刻意的:
+
+    进程级 ``os.environ`` 是全局可变状态。一旦"import 这个模块"本身就带来
+    全局副作用,任何 ``import main`` 的地方(测试里有 4 处只为读一个常量)
+    都会把开发者本机 .env 里的真实值灌满整个进程,并且**再也退不回去**
+    ——后续所有代码看到的都是被污染的环境。实测后果:跟着 INSTALL.md 走完
+    (bootstrap 会生成 .env)再跑 pytest,会多出 8 条与本次改动毫无关系的
+    失败(MEMORY_DB_PATH 指向容器路径导致建库失败 2 条;各家 API_KEY 凭空
+    出现导致"缺 key 时不应入候选池"类断言失败 6 条),且顺序依赖、难复现。
+    CI 上没有 .env 所以永远看不到 —— 只砸本机开发者。
+
+    加载纪律(三条,都是真机复现过的坑,不能放松):
+    1. **只加载非空值**。设置面板自动生成的 .env 会把【全部】schema 键写成
+       ``KEY=``(空值)。空字符串一旦进 os.environ 就会顶掉代码默认值:
+       ``os.environ.get("OLLAMA_URL", "http://localhost:11434")`` 在
+       ``OLLAMA_URL=""`` 存在时返回 ``""`` 而不是默认值。真机症状一整串都源于
+       此 —— LocalBrainManager 拿空 URL ping Ollama(报 "Request URL is missing
+       an 'http://' or 'https://' protocol"、Ollama 明明在跑却判"服务未响应/
+       模型未就绪")、Redis "must specify scheme"、NATS "invalid hostname"。
+       所以这里不能用 ``load_dotenv()`` 整个灌进去。
+    2. **值以 # 开头一律视同未配置**。python-dotenv 会把「KEY=   # 注释」这种
+       【空值 + 行内注释】整段注释当成值(实测 1.2.2:``OLLAMA_URL= # e.g.
+       http://...`` → ``'# e.g. http://...'``),经 normalize 补协议头后变成
+       ``http://#...`` 的怪 URL,骗过全部 startswith 检查。合法配置值不可能
+       以 # 开头。
+    3. **不覆盖已存在的键**。shell/系统显式导出的优先级最高;secrets.env 先于
+       .env 加载(面板保存的最新真值先到先得)。
+
+    密钥库(runtime/secrets.env)必须一起加载:设置面板把 API Key 这类 secret
+    写进它而非 .env(见 core/config_store.py),此前重启后无人把它注回
+    os.environ —— 直读 os.getenv 的路径(含面板"已配置"角标)统统看不到,
+    表现为"Key 存了,重启后又显示未配置"。
+
+    ``root`` 只为测试留的注入点(默认= main.py 所在目录,即仓库根)。生产路径
+    永远用默认值 —— 没有它就只能靠"在仓库根真造一个 .env"来验证这三条纪律,
+    那会踩到开发者自己的 .env。
+    """
+    try:
+        from dotenv import dotenv_values
+
+        _root = root or os.path.dirname(os.path.abspath(__file__))
+        for _rel in ("runtime/secrets.env", ".env"):
+            for _k, _v in (dotenv_values(os.path.join(_root, _rel)) or {}).items():
+                if _v and not _v.lstrip().startswith("#") and _k not in os.environ:
+                    os.environ[_k] = _v
+    except Exception:
+        pass
+
+
+# 调用点见下方「进程级配置的唯一调用点」—— 与 Windows 控制台、HF 端点合在
+# 一个 __main__ 守卫里,仍在其余 import 之前。
 
 # ── 第三方库的已知噪音告警降噪 ─────────────────────────────────────────────
 # 真机启动日志里有几条来自【第三方依赖】的 UserWarning,与 Galaxy 自身无关、
@@ -55,7 +83,14 @@ try:
 except Exception:
     pass
 
-if sys.platform == "win32":
+def configure_windows_console() -> None:
+    """Windows 控制台 UTF-8 + 进程优先级。
+
+    与 .env 加载同理,只在**作为脚本运行**时调用:被 import 时重写调用方的
+    sys.stdout/sys.stderr、抬高整个进程的调度优先级,都是越权行为。
+    """
+    if sys.platform != "win32":
+        return
     # Set console to UTF-8 mode (Python 3.7+)
     try:
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -82,22 +117,42 @@ if sys.platform == "win32":
     except Exception:
         pass
 
-# ── HuggingFace 下载:必须在任何 HF 库(transformers/sentence_transformers/
-#    huggingface_hub/faster_whisper)被 import 之前设置,否则 HF_ENDPOINT 被库缓存,
-#    镜像不生效 → 退回 huggingface.co,在国内被墙 → 每个文件 5 次重试 ×指数退避 →
-#    嵌入器/Whisper 加载能卡 4 分钟,把 /chat/stream 拖到 270s(实测)。
-# 这里在进程最早期把端点指向国内镜像并把超时/重试压到最小,让"连不上"秒失败降级,
-# 而不是卡几分钟。可用 GALAXY_HF_MIRROR=0 关闭镜像。
-try:
-    os.environ.setdefault("HF_ENDPOINT", os.environ.get("GALAXY_HF_ENDPOINT", "https://hf-mirror.com"))
-    if os.environ.get("GALAXY_HF_MIRROR", "1").strip().lower() in ("0", "false", "no", "off"):
-        os.environ.pop("HF_ENDPOINT", None)
-    # 快速失败:单次 etag/连接超时压到 3s,避免默认 10s×5 次重试的长时间阻塞。
-    os.environ.setdefault("HF_HUB_ETAG_TIMEOUT", "3")
-    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "10")
-    os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
-except Exception:
-    pass
+
+def configure_huggingface_endpoint() -> None:
+    """把 HF 端点指向国内镜像,并把超时/重试压到最小。
+
+    **必须在任何 HF 库(transformers/sentence_transformers/huggingface_hub/
+    faster_whisper)被 import 之前设置**,否则 HF_ENDPOINT 被库缓存、镜像不生效
+    → 退回 huggingface.co,在国内被墙 → 每个文件 5 次重试 × 指数退避 → 嵌入器/
+    Whisper 加载能卡 4 分钟,把 /chat/stream 拖到 270s(实测)。所以调用点仍在
+    本文件最顶端、其余 import 之前 —— 只是加了 ``__main__`` 守卫。
+
+    守卫的理由与 .env 那处相同:``import main`` 不该把**整个进程**的 HuggingFace
+    端点悄悄改掉。测试进程里尤其不该 —— 一次无关的 import 就让后续所有用例对着
+    一个镜像站解析下载地址,而且退不回去。
+
+    可用 GALAXY_HF_MIRROR=0 关闭镜像。
+    """
+    try:
+        os.environ.setdefault("HF_ENDPOINT", os.environ.get("GALAXY_HF_ENDPOINT", "https://hf-mirror.com"))
+        if os.environ.get("GALAXY_HF_MIRROR", "1").strip().lower() in ("0", "false", "no", "off"):
+            os.environ.pop("HF_ENDPOINT", None)
+        # 快速失败:单次 etag/连接超时压到 3s,避免默认 10s×5 次重试的长时间阻塞。
+        os.environ.setdefault("HF_HUB_ETAG_TIMEOUT", "3")
+        os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "10")
+        os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
+    except Exception:
+        pass
+
+
+# ── 进程级配置的唯一调用点 ────────────────────────────────────────────────
+# 三件事都必须发生在其余 import 之前(.env 要早于任何读 os.environ 的代码,
+# HF 端点要早于任何 HF 库),所以调用点只能待在文件顶端。守卫保证它们只在
+# `python main.py` 时发生 —— `import main` 不产生任何全局副作用。
+if __name__ == "__main__":
+    load_env_files_into_environ()
+    configure_windows_console()
+    configure_huggingface_endpoint()
 
 """
 Galaxy-Nexus 星枢 — System Orchestrator

--- a/tests/test_entrypoint_import_has_no_env_side_effects.py
+++ b/tests/test_entrypoint_import_has_no_env_side_effects.py
@@ -1,0 +1,325 @@
+"""入口脚本的 ``import`` 不得改写 ``os.environ``。
+
+## 修的是什么
+
+`main.py` 与 `unified_launcher.py` 顶部各有一段模块级代码,把 `.env` 和
+`runtime/secrets.env` 里的值灌进 `os.environ`。作为**脚本运行**时这是对的
+——它们就该在其它 import 读环境变量之前把配置装好。
+
+问题在于这段代码是**无条件的模块级副作用**:任何一次 `import main` 都会执行
+它。测试里有 4 处 `import main`(其中 3 处只为读一个哨兵常量),于是:
+
+    tests/integration/test_integration_review_runtime_paths.py::…
+        import main as _main            # 只想确认 SYSTEM_ORCHESTRATOR_AUTHORITY 存在
+            ↓ main.py 模块级
+        把本机 .env 的全部非空值灌进 os.environ
+            ↓ 此后整个 pytest 进程都带着,退不回去
+        MEMORY_DB_PATH=/app/data/…      → Node_100 建库失败(2 条)
+        DEEPSEEK_API_KEY=… 等凭空出现   → "缺 key 时不该入候选池"类断言失败(6 条)
+
+实测:跟着 INSTALL.md 走完(bootstrap 会生成 .env)再跑全量,多出 8 条与改动
+毫无关系的失败;把 .env 移开,同一批用例 197 passed。**CI 上没有 .env,所以
+这 8 条永远不会在 CI 上出现 —— 只砸本机开发者**,而且顺序依赖、极难归因。
+
+## 修法
+
+把加载逻辑收进函数,调用点放在 ``if __name__ == "__main__":`` 守卫下。
+`python main.py` / `python unified_launcher.py` 行为逐字节不变(守卫为真、
+仍在其余 import 之前);`import main` 变成无副作用。
+
+## 这里守什么
+
+三层,缺一层都能被绕过:
+
+1. **结构层(AST)**:模块级不得有任何写 `os.environ` 的语句 —— 这条最硬,
+   不依赖跑测试的机器上有没有 .env。
+2. **行为层**:加载函数本身的三条纪律(空值/# 毒值/不覆盖)必须还在 ——
+   防止有人为了"修副作用"把整段逻辑删掉了事。
+3. **端到端**:真的起一个子进程 `import main`,比对前后 `os.environ`。
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENTRYPOINTS = ["main.py", "unified_launcher.py"]
+
+
+# ── 1. 结构层:模块级不得写 os.environ ──────────────────────────────────
+
+
+def _module_level_environ_writes(source: str) -> list[int]:
+    """返回模块级(不含函数体、不含 ``if __name__ == "__main__"`` 块)里
+    所有写 ``os.environ[...]`` 的行号。
+
+    只看**顶层**语句:函数体里怎么写都行(要被显式调用才生效),
+    ``__main__`` 守卫里怎么写也行(那就是"作为脚本运行"的语义)。
+    """
+    tree = ast.parse(source)
+
+    def is_main_guard(node: ast.AST) -> bool:
+        if not isinstance(node, ast.If):
+            return False
+        return "__name__" in ast.dump(node.test) and "__main__" in ast.dump(node.test)
+
+    hits: list[int] = []
+    for top in tree.body:
+        if isinstance(top, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue  # 函数/类体内不算模块级副作用
+        if is_main_guard(top):
+            continue  # 作为脚本运行时才执行,正是我们想要的
+        for node in ast.walk(top):
+            # os.environ["X"] = ... / _os.environ[...] = ...
+            if isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Store):
+                if isinstance(node.value, ast.Attribute) and node.value.attr == "environ":
+                    hits.append(node.lineno)
+            # os.environ.update(...) / .setdefault(...)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr in {"update", "setdefault", "pop"}:
+                    tgt = node.func.value
+                    if isinstance(tgt, ast.Attribute) and tgt.attr == "environ":
+                        hits.append(node.lineno)
+    return sorted(set(hits))
+
+
+@pytest.mark.parametrize("entry", ENTRYPOINTS)
+def test_entrypoint_module_level_does_not_write_environ(entry: str) -> None:
+    src = (REPO_ROOT / entry).read_text(encoding="utf-8")
+    hits = _module_level_environ_writes(src)
+    assert not hits, (
+        f"{entry} 在模块级写了 os.environ(行 {hits})—— "
+        f"这样 `import {Path(entry).stem}` 就会把本机 .env 灌进整个进程。"
+        f'把它收进函数,调用点放到 `if __name__ == "__main__":` 下。'
+    )
+
+
+@pytest.mark.parametrize("entry", ENTRYPOINTS)
+def test_entrypoint_still_loads_env_when_run_as_script(entry: str) -> None:
+    """守卫的另一半:不能为了消副作用把加载**整个删掉**。
+
+    单独运行 `python main.py` 时 .env 必须仍然被装进 os.environ —— 那是真机
+    复现过的老 bug(「模型」tab 存的 API Key 重启后读不到)的修复所在。
+    """
+    tree = ast.parse((REPO_ROOT / entry).read_text(encoding="utf-8"))
+    guarded_calls: list[str] = []
+    for top in tree.body:
+        if not isinstance(top, ast.If):
+            continue
+        if "__name__" not in ast.dump(top.test) or "__main__" not in ast.dump(top.test):
+            continue
+        for node in ast.walk(top):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                guarded_calls.append(node.func.id)
+
+    assert any("env" in name for name in guarded_calls), (
+        f'{entry} 的 `if __name__ == "__main__"` 块里找不到 .env 加载调用'
+        f"(找到的调用:{guarded_calls})—— 作为脚本运行时 .env 必须仍被加载"
+    )
+
+
+# ── 2. 行为层:加载纪律三条 ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def clean_environ():
+    """快照 / 还原 os.environ。
+
+    被测函数直接写 os.environ,monkeypatch 追踪不到,必须自己兜。
+    """
+    snapshot = dict(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(snapshot)
+
+
+def _write_env(root: Path, env_text: str = "", store_text: str = "") -> None:
+    """写出 tmp 版的 .env 与密钥库 runtime/secrets.env。
+
+    ``store_text`` 写的就是 runtime/secrets.env。之所以形参不叫 ``secrets_text``、
+    造出来的假值一律带 ``FAKE_`` 前缀:gitleaks 的 generic-api-key 规则按
+    「关键词(secret/token/key/…)+ 赋值 + 十字符以上的值」判定,一个叫
+    ``secrets_text="…"`` 的具名实参会**如实**命中它。仓库 .gitleaks.toml 里
+    已经为测试目录留了 ``FAKE_`` / ``sk-test-`` / ``PLACEHOLDER_`` 三个白名单
+    前缀,这里照着用 —— 让扫描器继续对真泄漏敏感,而不是去放宽白名单。
+    """
+    (root / ".env").write_text(env_text, encoding="utf-8")
+    (root / "runtime").mkdir(exist_ok=True)
+    (root / "runtime" / "secrets.env").write_text(store_text, encoding="utf-8")
+
+
+def _loader():
+    import main as _main
+
+    return _main.load_env_files_into_environ
+
+
+def test_loads_real_values(tmp_path, clean_environ):
+    _write_env(tmp_path, "GALAXY_TEST_REAL=yes\n")
+    os.environ.pop("GALAXY_TEST_REAL", None)
+
+    _loader()(root=str(tmp_path))
+
+    assert os.environ.get("GALAXY_TEST_REAL") == "yes"
+
+
+def test_empty_value_is_treated_as_unconfigured(tmp_path, clean_environ):
+    """空值进 os.environ 会顶掉代码默认值。
+
+    真机症状:设置面板生成的 .env 把全部 schema 键写成 ``KEY=``,于是
+    ``os.environ.get("OLLAMA_URL", "http://localhost:11434")`` 返回 ``""``,
+    LocalBrainManager 拿空 URL 去 ping Ollama。
+    """
+    _write_env(tmp_path, "GALAXY_TEST_EMPTY=\n")
+    os.environ.pop("GALAXY_TEST_EMPTY", None)
+
+    _loader()(root=str(tmp_path))
+
+    assert "GALAXY_TEST_EMPTY" not in os.environ
+    assert os.environ.get("GALAXY_TEST_EMPTY", "fallback") == "fallback"
+
+
+def test_inline_comment_poison_value_is_rejected(tmp_path, clean_environ):
+    """python-dotenv 会把「空值 + 行内注释」整段注释当成值。
+
+    实测 1.2.2:``OLLAMA_URL= # e.g. http://...`` → ``'# e.g. http://...'``,
+    经 normalize 补协议头后变成 ``http://#...`` 的怪 URL,骗过全部 startswith
+    检查。以 # 开头的值一律视同未配置。
+    """
+    _write_env(tmp_path, "GALAXY_TEST_POISON= # e.g. http://localhost:1234\n")
+    os.environ.pop("GALAXY_TEST_POISON", None)
+
+    _loader()(root=str(tmp_path))
+
+    assert "GALAXY_TEST_POISON" not in os.environ
+
+
+def test_existing_environ_wins(tmp_path, clean_environ):
+    """shell/系统显式导出的优先级最高,不被 .env 覆盖。"""
+    _write_env(tmp_path, "GALAXY_TEST_PRIO=from_dotenv\n")
+    os.environ["GALAXY_TEST_PRIO"] = "from_shell"
+
+    _loader()(root=str(tmp_path))
+
+    assert os.environ["GALAXY_TEST_PRIO"] == "from_shell"
+
+
+def test_secrets_env_is_loaded_too(tmp_path, clean_environ):
+    """密钥库(runtime/secrets.env)必须一起加载。
+
+    设置面板把 API Key 写进它而非 .env(见 core/config_store.py);此前重启后
+    没人把它注回 os.environ,直读 os.getenv 的路径(含面板"已配置"角标)全都
+    看不到,表现为"Key 存了,重启后又显示未配置"。
+    """
+    _write_env(tmp_path, "", store_text="GALAXY_TEST_FROM_STORE=FAKE_sk-test-value\n")
+    os.environ.pop("GALAXY_TEST_FROM_STORE", None)
+
+    _loader()(root=str(tmp_path))
+
+    assert os.environ.get("GALAXY_TEST_FROM_STORE") == "FAKE_sk-test-value"
+
+
+def test_secrets_env_wins_over_dotenv(tmp_path, clean_environ):
+    """先到先得:secrets.env 先加载 = 面板保存的最新真值优先。"""
+    _write_env(
+        tmp_path,
+        "GALAXY_TEST_BOTH=FAKE_from_dotenv\n",
+        store_text="GALAXY_TEST_BOTH=FAKE_from_store\n",
+    )
+    os.environ.pop("GALAXY_TEST_BOTH", None)
+
+    _loader()(root=str(tmp_path))
+
+    assert os.environ["GALAXY_TEST_BOTH"] == "FAKE_from_store"
+
+
+def test_missing_files_are_not_an_error(tmp_path, clean_environ):
+    """全新克隆(还没跑 bootstrap)时两个文件都不存在,不能炸。"""
+    _loader()(root=str(tmp_path))  # 不抛异常即通过
+
+
+# ── 3. 端到端:子进程真 import ──────────────────────────────────────────
+
+_PROBE = r"""
+import json, os, sys
+sys.path.insert(0, {root!r})
+before = dict(os.environ)
+import {module}  # noqa: F401
+after = dict(os.environ)
+added = {{k: v for k, v in after.items() if k not in before}}
+changed = {{k for k in before if before[k] != after.get(k)}}
+print(json.dumps({{"added": sorted(added), "changed": sorted(changed)}}))
+"""
+
+
+@pytest.mark.parametrize("module", ["main", "unified_launcher"])
+def test_importing_entrypoint_changes_nothing_in_environ(module: str) -> None:
+    """真的起一个子进程 import,比对前后 os.environ。
+
+    这条是**用当前这台机器上真实存在的 .env** 来验的:CI 上没有 .env,它退化
+    成一条弱断言(仍能抓住"import 时凭空造环境变量"的其它写法);本机开发者
+    跑起来则是完整的端到端复现 —— 正好是唯一会被这个 bug 砸到的人。
+    """
+    code = _PROBE.format(root=str(REPO_ROOT), module=module)
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, f"子进程 import {module} 失败:\n{proc.stderr[-3000:]}"
+
+    result = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert not result["added"], f"`import {module}` 凭空新增了环境变量:{result['added']}"
+    assert not result["changed"], f"`import {module}` 改写了已有环境变量:{result['changed']}"
+
+
+_SCRIPT_MODE_PROBE = r"""
+import json, os, runpy, sys
+before = dict(os.environ)
+sys.argv = ["main.py", "--help"]          # argparse 打完帮助就 SystemExit(0)
+try:
+    runpy.run_path({main_py!r}, run_name="__main__")
+except SystemExit:
+    pass
+added = sorted(k for k in os.environ if k not in before)
+sys.stderr.write("PROBE=" + json.dumps(added) + "\n")
+"""
+
+
+def test_running_main_as_a_script_still_configures_the_process() -> None:
+    """守卫的反面:``python main.py`` 必须仍然做那三件进程级配置。
+
+    只把副作用挪进函数、却忘了在 ``__main__`` 下调用,会静悄悄地把一堆真机修复
+    全部废掉(.env 里的 API Key 重启后又读不到、HF 走回被墙的 huggingface.co
+    卡 4 分钟)。所以这里真的用 ``run_name="__main__"`` 跑一遍 main.py。
+
+    哨兵选 ``HF_HUB_DISABLE_TELEMETRY``:它是无条件 ``setdefault``,不依赖这台
+    机器上有没有 .env —— CI 上没有 .env 也照样是一条硬断言。
+    """
+    code = _SCRIPT_MODE_PROBE.format(main_py=str(REPO_ROOT / "main.py"))
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    probe = [ln for ln in proc.stderr.splitlines() if ln.startswith("PROBE=")]
+    assert probe, f"探针没跑到底(退出码 {proc.returncode}):\n{proc.stderr[-3000:]}"
+
+    added = json.loads(probe[-1][len("PROBE=") :])
+    assert "HF_HUB_DISABLE_TELEMETRY" in added, (
+        '`python main.py` 没有执行进程级配置 —— `if __name__ == "__main__"` '
+        f"守卫里大概漏了调用。本次新增的环境变量:{added}"
+    )

--- a/unified_launcher.py
+++ b/unified_launcher.py
@@ -59,7 +59,17 @@ This file retains the service orchestration surface:
 # 文档字符串移回文件头部(可执行序言之前),恢复其 docstring 身份。
 # PR-WIN-ENCODING: Inherit UTF-8 from main.py; defensive re-config if run standalone.
 import sys
-if sys.platform == "win32":
+
+
+def _configure_windows_console() -> None:
+    """Windows 控制台 UTF-8。正常路径由 main.py 先做好(同进程),这里只在本
+    文件被单独当脚本运行时兜底 —— 见下方 ``__name__`` 守卫。
+
+    以前这段是无条件模块级代码,于是 ``import unified_launcher`` 会重写调用方
+    的 sys.stdout/sys.stderr 并改写进程环境变量。import 不该有这种越权副作用。
+    """
+    if sys.platform != "win32":
+        return
     try:
         import io
         if hasattr(sys.stdout, "buffer"):
@@ -82,23 +92,41 @@ if sys.platform == "win32":
 # schema 键写成 KEY=(空值),空字符串进入 os.environ 会把代码默认值顶掉(真机
 # 复现:OLLAMA_URL="" 导致拿空 URL ping Ollama、明明在跑却判"未响应")。
 # 不覆盖已存在的真实 shell/系统环境变量。
-try:
-    from dotenv import dotenv_values as _dotenv_values
-    import os as _os
-    _root = _os.path.dirname(_os.path.abspath(__file__))
-    # 与 .env 同一套纪律加载【密钥库】runtime/secrets.env:设置面板把 API Key
-    # 这类 secret 写进它(而非 .env,见 core/config_store.py),但此前重启后
-    # 没有任何代码把它注回 os.environ —— 直接读 os.getenv 的路径(含面板的
-    # "已配置"角标 _is_configured)全都看不到,表现为"Key 存了,重启后面板
-    # 又显示未配置"。加载序 = 先到先得:secrets.env 先加载(面板保存的最新
-    # 真值优先);shell/系统显式导出的环境变量始终最高(两者都不覆盖已存在键)。
-    for _env_file in ("runtime/secrets.env", ".env"):
-        for _k, _v in (_dotenv_values(_os.path.join(_root, _env_file)) or {}).items():
-            # 值以 # 开头 = dotenv 把「空值+行内注释」整段当值(毒值),视同未配置
-            if _v and not _v.lstrip().startswith("#") and _k not in _os.environ:
-                _os.environ[_k] = _v
-except Exception:
-    pass
+def _load_env_files_into_environ() -> None:
+    """与 main.py::load_env_files_into_environ 同一套纪律的防御性加载。
+
+    **只在本文件被当作脚本直接运行时调用**(见下方 ``__name__`` 守卫)。正常
+    路径是 main.py 先加载好 .env 再 ``from unified_launcher import GalaxyUnified``
+    (同进程共享 os.environ),此时这里什么都不用做。
+
+    以前这段是无条件的模块级代码,于是"import 一下 unified_launcher"就把本机
+    .env 灌满整个进程 —— 与 main.py 那处同一个坑:测试里任何一次 import 都会
+    污染后续全部用例(MEMORY_DB_PATH 指向容器路径、各家 API_KEY 凭空出现),
+    而 CI 上没有 .env 所以永远看不到,只砸本机开发者。上面那段注释写的本来就
+    是"若本文件被单独运行,防御性地自己再加载一遍",代码只是没照着写。
+
+    加载纪律三条(都是真机复现过的坑):只加载【非空】值(空字符串会顶掉代码
+    默认值,真机症状:OLLAMA_URL="" → 拿空 URL ping Ollama、明明在跑却判
+    "未响应");值以 # 开头视同未配置(dotenv 会把「空值+行内注释」整段当值);
+    不覆盖已存在键(shell 显式导出最高,secrets.env 先于 .env 先到先得)。
+    """
+    try:
+        from dotenv import dotenv_values as _dotenv_values
+        import os as _os
+
+        _root = _os.path.dirname(_os.path.abspath(__file__))
+        for _env_file in ("runtime/secrets.env", ".env"):
+            for _k, _v in (_dotenv_values(_os.path.join(_root, _env_file)) or {}).items():
+                if _v and not _v.lstrip().startswith("#") and _k not in _os.environ:
+                    _os.environ[_k] = _v
+    except Exception:
+        pass
+
+
+# ── 单独运行时的进程级配置(正常路径由 main.py 完成,同进程共享) ──────────
+if __name__ == "__main__":
+    _configure_windows_console()
+    _load_env_files_into_environ()
 
 import os
 import sys


### PR DESCRIPTION
## 症状

跟着 `INSTALL.md` 走完(bootstrap 会生成 `.env`)再跑全量测试,会多出 **8 条与本次改动毫无关系的失败**,且顺序依赖、极难归因。

CI 上没有 `.env`,所以这 8 条在 CI 上永远不出现 —— **只砸本机开发者**,正好是最没有条件去归因的那批人。

## 根因(完整链路,已用开关实验证明)

```
tests/integration/test_integration_review_runtime_paths.py:708
    import main as _main          # 只想确认 SYSTEM_ORCHESTRATOR_AUTHORITY 存在
        ↓ main.py 模块级(无条件执行)
    把本机 .env + runtime/secrets.env 的全部非空值灌进 os.environ
        ↓ 进程级全局状态,此后所有用例都带着,退不回去
    MEMORY_DB_PATH=/app/data/…    → Node_100 建库失败(2 条)
    各家 API_KEY 凭空出现          → “缺 key 时不该入候选池”类断言失败(6 条)
```

实测灌进去的是 **120 个键**。开关实验:

| 条件 | 结果 |
| --- | --- |
| 同一批 197 个用例,有 `.env` | 6 failed / 191 passed |
| 同一批 197 个用例,`.env` 移开 | **197 passed** |
| 全量,`.env` 移开 | **43419 passed**,8 条尽数消失 |

`main.py` 那段加载逻辑**本身没错** —— 它是入口脚本,就该在其它 import 读 `os.environ` 之前把配置装好。错的是「**import 一个入口脚本会产生全局副作用**」。

## 修法

把三件进程级配置收进具名函数,调用点统一放到 `if __name__ == "__main__":` 下,位置仍在文件最顶端、其余 import 之前:

- `main.py` — `load_env_files_into_environ()` / `configure_windows_console()` / `configure_huggingface_endpoint()`
- `unified_launcher.py` — `_load_env_files_into_environ()` / `_configure_windows_console()`

`python main.py` 行为**逐字节不变**(实测用 `run_name="__main__"` 跑一遍,120 个键照旧全部注入);`import main` 变成零副作用。

顺带修掉同一类的两处越权:

1. `import` 时重写调用方的 `sys.stdout`/`sys.stderr`、抬高整个进程的调度优先级(Windows 分支);
2. 把**整个进程**的 HuggingFace 端点改指国内镜像 —— 在测试进程里意味着一次无关 import 就让后续所有用例对着镜像站解析下载地址。

`unified_launcher.py` 那处尤其值得一提:它上方的注释本来就写着「若本文件被单独运行,这里防御性地自己再加载一遍」—— **代码只是没照着注释写**,一直是无条件的。

## 守卫

新增 `tests/test_entrypoint_import_has_no_env_side_effects.py`(14 条),三层,缺一层都能被绕过:

1. **结构层(AST)** — 模块级不得有写 `os.environ` 的语句。最硬的一条:不依赖跑测试的机器上有没有 `.env`,CI 上照样是真断言。
2. **行为层** — 加载函数自身的三条纪律必须还在(空值视同未配置、`#` 开头的 dotenv 毒值视同未配置、不覆盖已存在键),防止有人为了「消副作用」把整段逻辑删了了事 —— 那会把一串真机修复一起废掉。
3. **端到端** — 起子进程真 `import`,比对前后 `os.environ`;反向再用 `run_name="__main__"` 跑一遍 `main.py`,确认脚本模式下配置照做(哨兵选无条件 `setdefault` 的 `HF_HUB_DISABLE_TELEMETRY`,不依赖 `.env` 是否存在)。

同一套 AST 规则全仓扫过一遍,自家代码只剩 `launch_desktop.py` / `system_manager.py` 两处同类(Windows 分支写 `PYTHONIOENCODING`,不涉及 `.env`),另有 4 处在 `external/` 的第三方 vendored 代码。

## 验证

- 反向验证:三处生产改动逐一还原,对应守卫逐一转红。
- 新测试文件本地 14/14 通过;`black` / `flake8` 已过。
- 全量以 CI 实测为准,不预测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJ1ZD2Vp9iveeuYSsrY7b)_