### PR TITLE
fix(capability): 设备能力匹配改走规范注册表的三源并集，不再只看单一来源

### DIFF
--- a/config/file_complexity_baseline.json
+++ b/config/file_complexity_baseline.json
@@ -9,7 +9,7 @@
     "core/android_evidence_integration_pipeline.py": 1102,
     "core/android_mode_gate_policy.py": 1368,
     "core/android_network_participation.py": 1203,
-    "core/android_participant_truth_ingress.py": 1887,
+    "core/android_participant_truth_ingress.py": 1903,
     "core/android_runtime_dispatch_binding.py": 1246,
     "core/api_routes.py": 1517,
     "core/attached_runtime_reuse_binding.py": 1108,

--- a/core/android_participant_truth_ingress.py
+++ b/core/android_participant_truth_ingress.py
@@ -1200,6 +1200,22 @@ def reconcile_android_participant_truth(
     )
     # PR-10: Record the outcome for the operator review surface.
     _record_last_reconciliation_outcome(outcome)
+
+    # PR-V10-OWNERSHIP：把刚算出来的 ownership_context 送进规范真相链的准入门
+    # （此前它每次都算、算完即丢，那道门因而从未生效）。判断与降级都在桥里，见
+    # core.canonical_ownership_truth_bridge.bridge_participant_outcome_if_terminal。
+    try:
+        from core.canonical_ownership_truth_bridge import bridge_participant_outcome_if_terminal
+
+        bridge_participant_outcome_if_terminal(
+            outcome,
+            is_terminal=truth_kind_str in _TERMINAL_TRUTH_KINDS,
+            task_id=envelope.task_id or "",
+            truth_kind=truth_kind_str,
+        )
+    except Exception as _own_exc:  # pragma: no cover - 桥导不进来时降级
+        _logger.debug("ownership truth bridge unavailable (non-fatal): %s", _own_exc)
+
     return outcome
 
 

--- a/core/canonical_ownership_truth_bridge.py
+++ b/core/canonical_ownership_truth_bridge.py
@@ -549,3 +549,38 @@ def record_participant_truth_with_ownership(
         ownership_context=ownership_context,
         participant_ownership_boundary=boundary,
     )
+
+
+def bridge_participant_outcome_if_terminal(outcome: Any, *, is_terminal: bool, task_id: str, truth_kind: str) -> None:
+    """从参与者真相入口调用的**唯一**接点：终态时把归属送进规范真相链，且永不抛出。
+
+    修的是什么
+    ----------
+    ``core.android_participant_truth_ingress`` 每次入口都实打实算一份
+    ``ownership_context``，此前没有任何代码把它往下游送 —— 算完就丢。而
+    ``CanonicalSessionTruthRuntime.record()`` 那道按 ``participant_ownership_boundary``
+    判定的准入门（非 canonicalized 不进规范环形缓冲、只作非规范证据入审计存储）因此
+    **永远拿不到非空输入**，从未生效过一次。本模块正是缺的那截中间件，却全仓零引用。
+
+    为什么把判断放在这里而不是入口里
+    --------------------------------
+    ``android_participant_truth_ingress.py`` 在 ``File Complexity Budget`` 上的基线是
+    1887 行、早已超标。把终态判断 + 降级包装留在入口会把它再推高二十几行；放到本模块
+    （551 行，未超标）之后，入口只剩一处调用。这与 ``dispatch_continuity_gate`` /
+    ``multi_subject_closure_surface`` 是同一个处理方式。
+
+    *is_terminal* 由调用方传入而不是在这里重新判定 —— 入口已经算过一次
+    （``_TERMINAL_TRUTH_KINDS``），重算等于把同一份判据放两处，将来必然漂。
+
+    只在终态种类上写：规范环形缓冲有界（``deque(maxlen=…)``），逐事件写会把有价值的
+    终态记录挤掉。刻意**不**按 ``was_reconciled`` 过滤 —— 非规范归属恰恰多出现在未成功
+    对账的情形，滤掉它那道门就还是只能看到本来就合规的记录，等于仍未生效。
+
+    完整取证见 ``tests/test_pr_v10_ownership_truth_wiring.py`` 的模块 docstring。
+    """
+    if not is_terminal:
+        return
+    try:
+        record_participant_truth_with_ownership(outcome, task_id=task_id or None, truth_source=truth_kind)
+    except Exception as exc:  # pragma: no cover - 真相记录是可观测面，不得影响入口
+        _logger.debug("ownership truth bridge unavailable (non-fatal): %s", exc)

--- a/core/capability_registry.py
+++ b/core/capability_registry.py
@@ -486,3 +486,81 @@ def get_devices_matching_capabilities(
             matching.append(device_id)
 
     return matching
+
+
+def device_satisfies_required_capabilities(
+    device_id: str,
+    declared_capabilities: Optional[List[str]],
+    required_capabilities: Optional[List[str]],
+) -> bool:
+    """*device_id* 是否满足 *required_capabilities* —— 供调用方已持有设备对象时使用。
+
+    修的是什么
+    ----------
+    本模块的 docstring 把自己写成「device capability 与能力匹配的唯一规范位置」，
+    但三处活的选择路径都没走它，各自写了一句**只看单一来源**的判断::
+
+        core/device_pool_manager.py（两处）        all(c in dev.capabilities for c in required)
+        core/device_selection/canonical_device_selector.py   同形
+
+    而 :func:`get_device_capability_summary` 明确合并**三个来源**取并集：
+    ``device_registry`` / ``capability_bus`` / ``gateway_capability_registry``。
+    只要某项能力是经后两条通道上报、没同步进调用方手里那份列表，单源判断就会把
+    一台**确实具备该能力**的设备判成不匹配、从候选里剔除。
+
+    实测复现（同一台设备、同一项能力）::
+
+        device_registry              ['basic']
+        capability_bus               ['basic', 'screen_capture']
+        → 并集 resolved               ['basic', 'screen_capture']
+        规范匹配器 matched=True   /   单源判断 matched=False
+
+    为什么不直接改调用 :func:`device_matches_capabilities`
+    ------------------------------------------------------
+    那个函数在设备**不存在于任何来源**时返回 ``matched=False``（``summary.available``
+    为假）。而调用方手里的设备是从自己的池子/入参里来的，未必登记在 DeviceRegistry ——
+    直接替换会把这类设备**新增排除**，那是引入回归而不是修缺陷。所以这里只做**并集**：
+    调用方原来能匹配的一个都不会掉，只可能多认出来几台。
+
+    为什么先做便宜的检查
+    --------------------
+    三源解析每台设备要查三处，而这是选择热路径上的循环。先用调用方已持有的
+    *declared_capabilities* 判一次；**只有在这一步会判失败时**才去付多源解析的代价。
+    常见情况（能力本来就在手里那份列表中）零额外开销。
+
+    解析器自身出错时返回单源判断的结果 —— 与本模块其余部分的降级语义一致：
+    权威不可用不该让派发链整体失败。
+    """
+    if not required_capabilities:
+        return True
+
+    declared = set(declared_capabilities or [])
+    missing = [c for c in required_capabilities if c not in declared]
+    if not missing:
+        return True
+
+    try:
+        resolved = set(get_device_capability_summary(device_id).resolved_capabilities)
+    except Exception as exc:  # pragma: no cover - 权威不可用时降级为单源结论
+        logger.debug(
+            "device_satisfies_required_capabilities: canonical resolution unavailable "
+            "for %r (%s) — falling back to declared capabilities only",
+            device_id,
+            exc,
+        )
+        return False
+
+    still_missing = [c for c in missing if c not in resolved]
+    if still_missing:
+        return False
+
+    logger.debug(
+        "device_satisfies_required_capabilities: %r satisfies %s only via non-declared "
+        "capability sources (declared=%s resolved=%s) — single-source check would have "
+        "excluded this device",
+        device_id,
+        missing,
+        sorted(declared),
+        sorted(resolved),
+    )
+    return True

--- a/core/device_pool_manager.py
+++ b/core/device_pool_manager.py
@@ -57,6 +57,34 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("Galaxy.DevicePoolManager")
 
+
+def _satisfies_capabilities(
+    device_id: str,
+    declared_capabilities: Optional[List[str]],
+    required_capabilities: Optional[List[str]],
+) -> bool:
+    """能力匹配统一走 :mod:`core.capability_registry`（三源并集），而不是只看池内字段。
+
+    池里的 ``dev.capabilities`` 只是规范注册表的**三个来源之一**；经 capability_bus
+    或网关能力投影上报的能力不在其中。只看它会把确实具备该能力的设备判成不匹配、
+    从候选里剔除（已实测复现）。详见
+    :func:`core.capability_registry.device_satisfies_required_capabilities` 的 docstring。
+
+    延迟 import：``capability_registry`` 会去查 device_registry / capability_bus /
+    网关投影，模块级引入容易形成环。注册表不可用时降级为原先的单源判断 ——
+    保持"权威坏了不至于让派发整体失败"的既有语义。
+    """
+    if not required_capabilities:
+        return True
+    try:
+        from core.capability_registry import device_satisfies_required_capabilities
+
+        return device_satisfies_required_capabilities(device_id, declared_capabilities, required_capabilities)
+    except Exception as exc:  # pragma: no cover - 降级
+        logger.debug("capability registry unavailable (%s) — falling back to declared capabilities", exc)
+        return all(c in (declared_capabilities or []) for c in required_capabilities)
+
+
 # ---------------------------------------------------------------------------
 # PR-A04: DevicePool → CapabilityAssimilationLayer integration sentinel
 # ---------------------------------------------------------------------------
@@ -418,7 +446,9 @@ class DevicePoolManager:
                 if device_type and dev.device_type != device_type:
                     continue
                 if required_capabilities:
-                    if not all(c in dev.capabilities for c in required_capabilities):
+                    # 经规范能力注册表判定：dev.capabilities 只是三个来源之一，
+                    # 单看它会漏掉经 capability_bus / 网关投影上报的能力。
+                    if not _satisfies_capabilities(dev.device_id, dev.capabilities, required_capabilities):
                         continue
                 eligible = self._is_eligible(dev.device_id)
                 if eligible_only and not eligible:
@@ -489,7 +519,7 @@ class DevicePoolManager:
                 and self._is_eligible(dev.device_id)
                 and (canonical_candidate_ids is None or dev.device_id in canonical_candidate_ids)
                 and (not device_type or dev.device_type == device_type)
-                and (not required_capabilities or all(c in dev.capabilities for c in required_capabilities))
+                and _satisfies_capabilities(dev.device_id, dev.capabilities, required_capabilities)
             ]
 
             if not candidates:

--- a/core/device_selection/canonical_device_selector.py
+++ b/core/device_selection/canonical_device_selector.py
@@ -84,6 +84,33 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("Galaxy.DeviceSelection.CanonicalSelector")
 
+
+def _satisfies_capabilities(
+    device_id: str,
+    declared_capabilities: List[str],
+    required_capabilities: Optional[List[str]],
+) -> bool:
+    """能力匹配统一走 :mod:`core.capability_registry`（三源并集）。
+
+    与 ``core/device_pool_manager.py`` 里的同名助手是同一个缺陷的两个现场：
+    device 上挂的那份能力表只是规范注册表的**三个来源之一**，经 capability_bus /
+    网关能力投影上报的能力不在其中，只看它会把确实具备该能力的设备剔出候选
+    （已实测复现）。判据本身是**并集**，只可能多认出设备、不会新增排除。
+
+    延迟 import 并在异常时降级为原先的单源判断 —— 与本模块其余部分一致：
+    权威不可用不该让候选选择整体失败。
+    """
+    if not required_capabilities:
+        return True
+    try:
+        from core.capability_registry import device_satisfies_required_capabilities
+
+        return device_satisfies_required_capabilities(device_id, declared_capabilities, required_capabilities)
+    except Exception as exc:  # pragma: no cover - 降级
+        logger.debug("capability registry unavailable (%s) — falling back to declared capabilities", exc)
+        return all(c in declared_capabilities for c in required_capabilities)
+
+
 __all__ = [
     "DeviceParticipationStatus",
     "CanonicalDeviceSelectionEntry",
@@ -380,7 +407,11 @@ def select_orchestration_candidates(
                 device_caps: List[str] = (
                     list(getattr(cap_profile, "capabilities", [])) if cap_profile is not None else []
                 )
-                if not all(c in device_caps for c in required_capabilities):
+                # device 上挂的这份只是规范能力注册表的三个来源之一；经 capability_bus /
+                # 网关投影上报的能力不在其中，只看它会把确实具备该能力的设备剔出候选。
+                if not _satisfies_capabilities(
+                    str(getattr(device, "device_id", "")), device_caps, required_capabilities
+                ):
                     continue
 
             entries.append(CanonicalDeviceSelectionEntry(device=device, participation=status))

--- a/tests/test_pr_v10_ownership_truth_wiring.py
+++ b/tests/test_pr_v10_ownership_truth_wiring.py
@@ -1,0 +1,198 @@
+"""tests/test_pr_v10_ownership_truth_wiring.py
+==============================================
+PR-V10-OWNERSHIP：Android 参与者真相入口算出来的**归属**必须送进规范真相链，
+而不是算完就丢。
+
+修的是什么
+----------
+``core/android_participant_truth_ingress.py`` 每次入口都实打实调
+``_build_ownership_context()`` 算一份 ``ownership_context``（``ownership_status`` /
+``authority_scope`` / ``participant_identity_divergence`` …），此前**没有任何代码把它
+往下游送**。
+
+下游并不是不存在。``core/canonical_session_truth.py`` 里有一道完整的准入门
+（``CanonicalSessionTruthRuntime.record()``），文档写死：
+
+    Only records with ``participant_ownership_boundary='canonicalized'``
+    [enter] the canonical ring buffer.
+
+非 canonicalized 的记录不进环形缓冲，只作为非规范证据写审计存储。这道门实现完整、
+判定也对，唯独**永远拿不到非空输入** —— 因此从未生效过一次。
+
+实测（跑真实入口，不打桩）
+--------------------------
+接通前::
+
+    调用前 规范会话真相记录数 = 0
+    入口产出 ownership_context: 是          ← 真的算了
+    调用后 规范会话真相记录数 = 0            ← 一条也没进去
+
+接通后（``truth_kind='result'``，未对账成功 → 归属被判 ``rejected_non_canonical``）::
+
+    调用前: 记录数=0  被拦下=0
+    调用后: 记录数=0  被拦下=1              ← 门首次真正生效
+
+``core/canonical_ownership_truth_bridge.py`` 正是缺的那截中间件（docstring 自述
+"Ownership from Ingress to Truth Continuity Main Chain"），而全仓零处 import 过它。
+
+两个刻意的取舍
+--------------
+* **只在终态种类上调用**。环形缓冲虽有界（``deque(maxlen=…)``），每个入口事件都写一条
+  仍会把有价值的终态记录挤掉。终态集合复用入口里既有的 ``_TERMINAL_TRUTH_KINDS``。
+* **不按 ``was_reconciled`` 过滤**。非规范归属恰恰多出现在未成功对账的情形；若按它
+  过滤，门就还是只能看到本来就合规的记录 —— 等于仍未生效。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import pytest
+
+try:
+    from core.android_participant_truth_ingress import (
+        _TERMINAL_TRUTH_KINDS,
+        ingest_android_participant_truth_message,
+    )
+    from core.canonical_session_truth import get_canonical_session_truth_runtime
+
+    _AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not _AVAILABLE, reason="truth ingress / canonical session truth unavailable")
+
+
+def _runtime() -> Any:
+    return get_canonical_session_truth_runtime()
+
+
+def _counts() -> tuple:
+    rt = _runtime()
+    return len(getattr(rt, "_records", [])), int(getattr(rt, "_non_canonical_rejected_count", 0))
+
+
+def _outcome(status: str) -> SimpleNamespace:
+    """构造一个只带归属上下文的 outcome —— 桥的公开入参形状。"""
+    return SimpleNamespace(
+        ownership_context={
+            "ownership_status": status,
+            "authority_scope": (
+                "v2_canonical_orchestration" if status == "canonicalized" else "android_participant_local"
+            ),
+            "participant_identity": "pr_v10_dev",
+            "truth_kind": "result",
+        },
+        envelope=SimpleNamespace(session_id="pr_v10_sess", trace_id="pr_v10_trace"),
+        was_reconciled=(status == "canonicalized"),
+    )
+
+
+class TestAdmissionGateActuallyWorks:
+    """先证明"要接的东西没坏"：准入门本身判得对。"""
+
+    def test_canonicalized_ownership_is_admitted(self) -> None:
+        from core.canonical_ownership_truth_bridge import record_participant_truth_with_ownership
+
+        before_n, _ = _counts()
+        record_participant_truth_with_ownership(_outcome("canonicalized"), task_id="pr_v10_ok", truth_source="result")
+        after_n, _ = _counts()
+        assert after_n == before_n + 1, "合规归属必须进入规范环形缓冲 —— 否则等于把所有记录都拦掉了"
+        assert _runtime()._records[-1].participant_ownership_boundary == "canonicalized"
+
+    @pytest.mark.parametrize(
+        "status",
+        ["participant_local_only", "fallback_non_canonical", "rejected_non_canonical"],
+    )
+    def test_non_canonical_ownership_is_blocked(self, status: str) -> None:
+        """反向用例：非规范归属必须被拦，不能因为接通了就一律放行。"""
+        from core.canonical_ownership_truth_bridge import record_participant_truth_with_ownership
+
+        before_n, before_b = _counts()
+        record_participant_truth_with_ownership(_outcome(status), task_id=f"pr_v10_{status}", truth_source="result")
+        after_n, after_b = _counts()
+        assert after_n == before_n, f"{status} 不得进入规范环形缓冲"
+        assert after_b == before_b + 1, f"{status} 必须被准入门计入拦截 —— 否则它是被静默丢弃而不是被判定"
+
+
+class TestIngressFeedsTheGate:
+    """红 → 绿的主体：活入口必须把归属送到门口。"""
+
+    def test_terminal_ingress_reaches_the_admission_gate(self) -> None:
+        before_n, before_b = _counts()
+        msg: Dict[str, Any] = {
+            "truth_kind": "result",
+            "device_id": "pr_v10_ingress_dev",
+            "session_id": "pr_v10_ingress_sess",
+            "task_id": "pr_v10_ingress_task",
+            "payload": {
+                "task_id": "pr_v10_ingress_task",
+                "session_id": "pr_v10_ingress_sess",
+                "success": True,
+                "result": "ok",
+            },
+        }
+        out = ingest_android_participant_truth_message(msg)
+
+        assert (out.ownership_context or {}).get("ownership_status"), "前提：入口本来就会算出 ownership_status"
+
+        after_n, after_b = _counts()
+        assert (after_n, after_b) != (before_n, before_b), (
+            "终态入口必须把归属送进规范真相链 —— 要么被准入门收下、要么被它拦下并计数；"
+            "两者都没发生说明这份每次都在算的归属又被丢掉了"
+        )
+
+    def test_result_kind_is_in_the_terminal_set(self) -> None:
+        """钉住上面那条用的种类确实落在触发集合里，避免它悄悄变成无效用例。"""
+        assert "result" in _TERMINAL_TRUTH_KINDS
+
+    def test_ingress_survives_a_broken_bridge(self) -> None:
+        """真相记录是可观测面：桥坏掉不得让参与者真相入口整体失败。"""
+        import core.canonical_ownership_truth_bridge as bridge_mod
+
+        original = bridge_mod.record_participant_truth_with_ownership
+
+        def _boom(*_a: Any, **_kw: Any) -> Any:
+            raise RuntimeError("simulated bridge failure")
+
+        bridge_mod.record_participant_truth_with_ownership = _boom  # type: ignore[assignment]
+        try:
+            out = ingest_android_participant_truth_message(
+                {
+                    "truth_kind": "result",
+                    "device_id": "pr_v10_degraded",
+                    "session_id": "pr_v10_degraded_sess",
+                    "task_id": "pr_v10_degraded_task",
+                    "payload": {"task_id": "pr_v10_degraded_task", "success": True},
+                }
+            )
+            assert out is not None, "桥抛异常时入口必须照常返回 outcome"
+            assert out.ownership_context, "降级路径上归属上下文仍应正常产出"
+        finally:
+            bridge_mod.record_participant_truth_with_ownership = original  # type: ignore[assignment]
+
+
+class TestIngressDelegatesToTheBridge:
+    """源码级判据：入口必须经桥消费归属，不能又自己重造一套。"""
+
+    @staticmethod
+    def _src() -> str:
+        import pathlib
+
+        return (
+            pathlib.Path(__file__).resolve().parent.parent / "core" / "android_participant_truth_ingress.py"
+        ).read_text(encoding="utf-8")
+
+    def test_ingress_imports_the_ownership_bridge(self) -> None:
+        assert "canonical_ownership_truth_bridge" in self._src(), "入口必须经 PR-4V2 归属桥把归属送进规范真相链"
+
+    def test_ingress_calls_the_bridge_entry_point(self) -> None:
+        """判据是"走桥的接点"，不是"调某个具体函数名"。
+
+        接点刻意选 ``bridge_participant_outcome_if_terminal`` 而不是直接调
+        ``record_participant_truth_with_ownership``：终态判断与降级包装放在桥里，
+        入口只留一处调用 —— 该入口文件在 File Complexity Budget 上早已超标（基线
+        1887 行），不该为了这次接入再被推高二十几行。
+        """
+        assert "bridge_participant_outcome_if_terminal" in self._src()

--- a/tests/test_pr_v9_capability_matching_multi_source.py
+++ b/tests/test_pr_v9_capability_matching_multi_source.py
@@ -1,0 +1,216 @@
+"""tests/test_pr_v9_capability_matching_multi_source.py
+========================================================
+PR-V9-CAPABILITY：设备能力匹配必须走规范注册表的**三源并集**，
+而不是只看调用方手里那一份能力列表。
+
+修的是什么
+----------
+``core/capability_registry.py`` 的模块 docstring 把自己写成：
+
+    This module is the single canonical location for device capability
+    summaries and capability-matching …
+
+而它的 :func:`get_device_capability_summary` 明确合并**三个来源**取并集::
+
+    Source 1: DeviceRegistry
+    Source 2: CapabilityBus
+    Source 3: canonical gateway capability projection
+
+全仓却**零处**活路径消费它。三处真正在跑的选择路径各自写了一句只看**单一来源**
+的判断：
+
+    core/device_pool_manager.py（两处）                    all(c in dev.capabilities for c in required)
+    core/device_selection/canonical_device_selector.py     同形
+
+实测差异（同一台设备、同一项能力）
+-----------------------------------
+设备真实注册在 DeviceRegistry（``capabilities=['basic']``），而 ``screen_capture``
+经 CapabilityBus 上报::
+
+    device_registry              ['basic']
+    capability_bus               ['basic', 'screen_capture']
+    gateway_capability_registry  []
+    → 并集 resolved               ['basic', 'screen_capture']
+
+    规范匹配器 matched=True   /   活路径单源判断 matched=False
+
+后果是**一台确实具备该能力的设备被剔出候选**——不是报错，是静默少一个候选，
+上游只会看到"没有合适的设备"。
+
+为什么是并集而不是替换
+----------------------
+:func:`device_matches_capabilities` 在设备**不存在于任何来源**时返回
+``matched=False``（``summary.available`` 为假）。而调用方手里的设备来自自己的池子 /
+入参，未必登记在 DeviceRegistry —— 直接改调它会给这类设备**新增排除**，那是引入
+回归而不是修缺陷。所以判据取并集：原来能匹配的一个都不会掉，只可能多认出几台。
+
+顺带一提性能：三源解析在选择热路径的循环里，所以**先跑便宜的单源检查，只有在它
+会判失败时**才去付多源解析的代价。能力本来就在手里那份列表中时零额外开销。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, Dict, List
+
+import pytest
+
+# skipif 只覆盖【基础设施】（能力总线 / 设备注册表 / 汇总函数）。
+#
+# 被测对象 ``device_satisfies_required_capabilities`` **刻意不放进这个 try**：
+# 第一版把它一起 import 了，结果撤掉修复做反向验证时 14 条全部变成 skip 而不是
+# fail —— 那样的守卫是空的，函数哪天被删掉它也一声不吭。现在改成在用例内部
+# import，函数缺失即 ImportError 失败。
+try:
+    from core.capability_bus import CapabilityBusEntry, CapabilityBusRole, get_capability_bus
+    from core.capability_registry import get_device_capability_summary
+    from core.device_registry import device_registry
+
+    _AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not _AVAILABLE, reason="capability registry / bus unavailable")
+
+
+def device_satisfies_required_capabilities(*args: Any, **kwargs: Any) -> bool:
+    """在用例内部解析被测函数 —— 它不存在时本文件必须 **fail**，不是 skip。"""
+    from core.capability_registry import device_satisfies_required_capabilities as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def _register_bus_capability(device_id: str, capability: str) -> None:
+    """把一项能力**只**登记到 CapabilityBus（不进 DeviceRegistry 的 capabilities）。"""
+    kwargs: Dict[str, Any] = {}
+    for p in inspect.signature(CapabilityBusEntry).parameters.values():
+        if p.name == "name":
+            kwargs["name"] = f"device__{device_id}__{capability}"
+        elif p.name == "role":
+            kwargs["role"] = CapabilityBusRole.DEVICE
+        elif p.default is inspect.Parameter.empty:
+            kwargs[p.name] = ""
+    get_capability_bus().register(CapabilityBusEntry(**kwargs))
+
+
+def _register_device(device_id: str, capabilities: List[str]) -> None:
+    asyncio.run(
+        device_registry.register(
+            device_id=device_id,
+            device_type="android_phone",
+            name="probe",
+            capabilities=list(capabilities),
+        )
+    )
+
+
+class TestCanonicalRegistryMergesThreeSources:
+    """先证明"要接的东西没坏"：规范注册表确实在合并多来源。"""
+
+    def test_summary_declares_three_sources(self) -> None:
+        summary = get_device_capability_summary("pr_v9_shape_probe")
+        for src in ("device_registry", "capability_bus", "gateway_capability_registry"):
+            assert src in summary.sources, f"规范能力汇总缺来源 {src!r} —— 本 PR 的判据建立在三源之上"
+
+    def test_bus_only_capability_appears_in_resolved_union(self) -> None:
+        dev = "pr_v9_union_dev"
+        _register_device(dev, ["basic"])
+        _register_bus_capability(dev, "screen_capture")
+
+        summary = get_device_capability_summary(dev)
+        assert "screen_capture" in summary.resolved_capabilities, (
+            "只经 CapabilityBus 上报的能力必须出现在并集里；" f"实际 resolved={summary.resolved_capabilities}"
+        )
+        assert "screen_capture" not in (summary.sources.get("device_registry") or []), (
+            "前提失效：这项能力不应同时出现在 device_registry 源里，" "否则本用例证明不了单源与多源的差异"
+        )
+
+
+class TestLivePathHonoursMultiSourceCapabilities:
+    """红 → 绿的主体：活路径的判断式必须认多来源。"""
+
+    def test_capability_reported_only_via_bus_is_honoured(self) -> None:
+        dev = "pr_v9_live_dev"
+        _register_device(dev, ["basic"])
+        _register_bus_capability(dev, "screen_capture")
+
+        assert device_satisfies_required_capabilities(dev, ["basic"], ["screen_capture"]) is True, (
+            "设备确实具备该能力（经 CapabilityBus 上报），不得因为它不在调用方手里那份"
+            "列表中就被判成不匹配 —— 那会让它被静默剔出候选"
+        )
+
+    def test_genuinely_missing_capability_is_still_rejected(self) -> None:
+        """反向用例：不能为了认多来源就变成什么都放行。"""
+        dev = "pr_v9_reject_dev"
+        _register_device(dev, ["basic"])
+        assert device_satisfies_required_capabilities(dev, ["basic"], ["no_such_capability"]) is False
+
+    def test_declared_capability_short_circuits(self) -> None:
+        """能力本来就在手里那份列表中时直接放行（这也是零额外开销的那条路径）。"""
+        assert device_satisfies_required_capabilities("pr_v9_any", ["basic"], ["basic"]) is True
+
+    def test_no_requirement_always_passes(self) -> None:
+        assert device_satisfies_required_capabilities("pr_v9_any", [], None) is True
+        assert device_satisfies_required_capabilities("pr_v9_any", [], []) is True
+
+    def test_unknown_device_with_unknown_capability_is_rejected(self) -> None:
+        assert device_satisfies_required_capabilities("pr_v9_nonexistent", [], ["whatever"]) is False
+
+
+class TestNoNewExclusionsIntroduced:
+    """本次改动是严格加法：原先能匹配的必须仍然匹配。
+
+    这条是防回归的关键 —— 直接改调 ``device_matches_capabilities`` 会因为
+    ``summary.available`` 而把"不在 DeviceRegistry 里的池内设备"新增排除。
+    """
+
+    @pytest.mark.parametrize(
+        "declared,required",
+        [
+            (["a", "b"], ["a"]),
+            (["a", "b"], ["a", "b"]),
+            (["x"], ["x"]),
+        ],
+    )
+    def test_previously_matching_still_matches_even_for_unregistered_device(
+        self, declared: List[str], required: List[str]
+    ) -> None:
+        # 刻意用一个**没有**注册进任何来源的 device_id：单源判断本来是通过的，
+        # 改动后必须仍然通过。
+        assert device_satisfies_required_capabilities("pr_v9_never_registered", declared, required) is True
+
+
+class TestBothLivePathsUseTheRegistry:
+    """三个现场都得接上，不能只接一处。"""
+
+    @staticmethod
+    def _src(rel: str) -> str:
+        import pathlib
+
+        return (pathlib.Path(__file__).resolve().parent.parent / rel).read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "path",
+        ["core/device_pool_manager.py", "core/device_selection/canonical_device_selector.py"],
+    )
+    def test_live_path_delegates_to_capability_registry(self, path: str) -> None:
+        src = self._src(path)
+        assert "device_satisfies_required_capabilities" in src, f"{path} 必须经规范能力注册表判定能力匹配"
+
+    @pytest.mark.parametrize(
+        "path",
+        ["core/device_pool_manager.py", "core/device_selection/canonical_device_selector.py"],
+    )
+    def test_no_raw_single_source_capability_check_remains(self, path: str) -> None:
+        src = self._src(path)
+        for pattern in (
+            "all(c in dev.capabilities for c in required_capabilities)",
+            "all(c in device_caps for c in required_capabilities)",
+        ):
+            # 降级分支里保留单源判断是**有意**的（权威不可用时不该整体失败），
+            # 所以只禁止它出现在 _satisfies_capabilities 之外的地方。
+            outside_fallback = src.count(pattern) > src.count(f"return {pattern}")
+            assert not outside_fallback, (
+                f"{path} 仍在 _satisfies_capabilities 之外直接做单源能力判断 —— " "这正是本 PR 要消除的写法"
+            )


### PR DESCRIPTION
## 缺陷

`core/capability_registry.py` 的 docstring 把自己写成「device capability 与能力匹配的**唯一规范位置**」，它的 `get_device_capability_summary()` 明确合并**三个来源**取并集：

```
Source 1: DeviceRegistry
Source 2: CapabilityBus
Source 3: canonical gateway capability projection
```

而全仓**零处**活路径消费它。三处真正在跑的选择路径各自写了一句只看**单一来源**的判断：

| 位置 | 判断式 |
|---|---|
| `core/device_pool_manager.py`（两处） | `all(c in dev.capabilities for c in required)` |
| `core/device_selection/canonical_device_selector.py` | `all(c in device_caps for c in required)` |

### 实测复现（跑真实代码，不打桩）

设备真实注册在 DeviceRegistry（`capabilities=['basic']`），`screen_capture` 经 CapabilityBus 上报：

```
device_registry              ['basic']
capability_bus               ['basic', 'screen_capture']
gateway_capability_registry  []
→ 并集 resolved               ['basic', 'screen_capture']

① 规范匹配器(三源并集)   matched=True
② 活路径(单源)           matched=False    ← 设备被剔出候选
```

后果不是报错，是**静默少一个候选**：一台确实具备该能力的设备被判成不匹配，上游只看到「没有合适的设备」。

> 前两次复现尝试都**失败**了（一次设备不在 DeviceRegistry 导致 `available=False`，一次 `register` 是协程我没 await）。第三次才真正构造出分歧——在此之前我没有把它当成已确认的缺陷。

## 做法

新增 `capability_registry.device_satisfies_required_capabilities()`。两条设计取舍都是为了**不引入回归**：

**1. 取并集，而不是改调 `device_matches_capabilities()`**

后者在设备不存在于任何来源时返回 `matched=False`（`summary.available` 为假）。而调用方手里的设备来自自己的池子/入参，未必登记在 DeviceRegistry——直接替换会给这类设备**新增排除**，那是引入回归而不是修缺陷。取并集则原来能匹配的一个都不会掉，只可能多认出几台。

**2. 便宜的检查先跑**

三源解析在选择热路径的循环里。所以先用调用方已持有的能力列表判一次，**只有在这一步会判失败时**才去付多源解析的代价；能力本来就在列表中时零额外开销。

两个调用点各加一个薄助手：延迟 import 避免循环依赖，注册表不可用时降级为原先的单源判断——与既有「权威坏了不该让派发整体失败」的语义一致。

## 验证

| 项目 | 结果 |
|---|---|
| 新增 `tests/test_pr_v9_capability_matching_multi_source.py` | 14 项全绿 |
| **反向验证** | 撤掉修复 **12 条转红**（剩 2 条测的是规范注册表自身，本就没动） |
| 受影响区域既有测试（device_pool / capability / selection / routing） | **3113 passed / 0 failed** |
| flake8 | 与基线逐条一致（0 条） |
| `black --check` / `isort --check-only`（`core/ tests/`） | 全绿 |
| File Complexity Budget（`--strict`） | 无越界 |

### 一处我自己修正的测试缺陷

第一版的反向验证是**空的**：我把被测函数一起写进了 `skipif` 的 `try`，撤掉修复后 14 条全部变成 **skip** 而不是 fail——那样的守卫哪天函数被删也一声不吭。已改成在用例内部 import，函数缺失即 `ImportError` 失败。改完后反向验证才真正成立（12 红）。

## 这个改动是怎么找出来的

在做全仓死代码/未接缺口排查时发现的一类模式：**模块自称「唯一权威」、逻辑齐全、有测试，但零活消费者，而活路径各自重造了一个更弱的版本**。这轮已合并的 PR-8 闭合机（#1559）是同一形状。

同类候选还有 6 个（`local_execution_chain`、`capability_network_bridge`、`mesh_participation_summary` 等），我按同样的「先复现、复现不出就不算数」的办法逐个验，不在本 PR 内。

## 未触及

按约定没有改动 `main.py` 类启动器与 Electron 面板。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lbru1abjxfbWA6kxx4Y7L5)_