### PR TITLE
fix(compat-freeze): 修复 main 上的红灯 — legacy 路径冻结预算随删除棘轮下调 82 → 81

### DIFF
--- a/core/compat_freeze_enforcement.py
+++ b/core/compat_freeze_enforcement.py
@@ -31,7 +31,11 @@ COMPAT_SURFACES_REQUIRE_CANONICAL_REPLACEMENT_POLICY = (
 )
 
 FROZEN_COMPAT_SURFACE_BUDGET = 10
-FROZEN_LEGACY_PATH_BUDGET = 82
+# 82 → 81：``core.api_manager.APIManager._validate_oneapi`` 那条 legacy 路径随模块
+# 一并删除后，注册表真实条目数少了一条。这道门的判定是**上限**（``count > budget``
+# 才算违规），所以不下调也不会红；但冻结预算的意义是「钉住当前值、只准降不准升」，
+# 留在 82 等于白送一个额度给将来新增的 legacy 路径。棘轮下调才是这道门该有的行为。
+FROZEN_LEGACY_PATH_BUDGET = 81
 FROZEN_PRODUCTION_BASELINE_LEGACY_BUDGET = 2
 
 


### PR DESCRIPTION
## ⚠️ 这是修 main 上的红灯，我造成的

#1562 删掉 `core/api_manager.py` 时一并移除了 `LEGACY_PATH_REGISTRY` 里 `core.api_manager.APIManager._validate_oneapi` 那条登记，注册表真实条目数 82 → 81。而 `FROZEN_LEGACY_PATH_BUDGET` 仍是 82，于是在**合并后的 main** 上：

```
tests/test_pr11_compat_freeze_enforcement.py::test_default_snapshot_matches_frozen_budgets
    assert 81 == 82
```

已在合并后的 main 上直接核实：**不带本修复 1 红 3 绿，带上后 4 绿。**

### 我的疏漏在哪

#1562 提交前我跑的是**受影响区域的定向测试**（3113 passed），四分片全量回归是在开 PR **之后**才跑的——这条恰好落在 shard 2，等它报出来时 PR 已经被合并了。

删除类改动本该在提交前就跑完全量，而不是边跑边提。定向测试选不中这种「远处的计数门」，正是全量回归存在的意义。

## 为什么是下调预算，不是改断言

这道门的**执行**逻辑用的是上限语义：

```python
if legacy_path_count > FROZEN_LEGACY_PATH_BUDGET:
    violations.append(...)
```

所以 81 本来就不违规，不动它 CI 也不会因为门**本身**而红——红的只是那条精确相等的断言。

但冻结预算的意义是「钉住当前值、只准降不准升」。**留在 82 等于白送一个额度给将来新增的 legacy 路径**：下次有人加一条，count 回到 82，门照样绿——而那正是这道门要拦的事。

真的少了一条 legacy 路径就把预算跟着降，才是棘轮该有的行为。改断言去迁就一个虚高的预算是反的。

## 同批删除的其它登记，已逐个核对无同类风险

#1562 还移除了两条登记，我把「有没有对应的计数门」这件事一次扫清了：

| 移除的登记 | 是否有计数门 | 核对结果 |
|---|---|---|
| `LEGACY_PATH_REGISTRY` 的 api_manager 条目 | **有** | 本 PR 修复 |
| diagnostics 的 `post_closure_dual_repo_reassessment` surface | 否 | `total_surfaces == 10` 是测试自造的**合成快照**，不由真实列表推导 |
| node surface boundary 的 `node_deps_helpers` 条目 | 否 | `tests/test_pr13_node_final_boundary_enforcement.py` **70 passed** |

## 核对

- `tests/test_pr11_compat_freeze_enforcement.py` 4 项全绿；撤掉本修复 1 红 3 绿（已实测双向）
- `flake8` 0 条
- 改动仅 1 个文件、5 行（含 4 行说明注释）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lbru1abjxfbWA6kxx4Y7L5)_