### PR TITLE
perf(startup): 量出启动基线,并落实其中已验证的那一项(构建期预编译)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,24 @@ COPY --chown=galaxy:galaxy nodes/ ./nodes/
 COPY --chown=galaxy:galaxy enhancements/ ./enhancements/
 COPY --chown=galaxy:galaxy audit/ ./audit/
 
+# 构建期把应用代码编译成 .pyc。
+#
+# 为什么需要:上面(以及另外三个 Dockerfile)都设了 PYTHONDONTWRITEBYTECODE=1 ——
+# 那是容器里的常见做法(镜像干净、不留运行期写入),但它同时意味着**运行期永远
+# 不会生成 .pyc**。而构建时又没有任何预编译,于是应用代码在**每一次进程启动**
+# 都要重新编译一遍,不是只有第一次。
+#
+# 实测(隔离掉磁盘冷读与 site-packages 的影响,各跑 3 次取稳定值):
+#     应用代码无 .pyc + DONTWRITEBYTECODE   2315 / 2322 / 2384 ms
+#     构建期 compileall 之后               1919 / 1930 / 2036 ms
+# 约省 380 ms 每次启动(~16%)。不大,但它是纯收益:代码不变、行为不变,
+# 只是把一份每次都要重做的工作挪到构建期做一次。
+#
+# compileall 显式调用 py_compile,不受 PYTHONDONTWRITEBYTECODE 影响,
+# 所以运行期那个环境变量可以照旧保留。
+# -q 只报错误;失败不阻断构建(个别文件语法不兼容当前版本时,退化成运行期编译)。
+RUN python -m compileall -q core/ galaxy_gateway/ nodes/ enhancements/ contracts/ || true
+
 USER galaxy
 
 # Main API + Web UI (灵动岛 Dashboard) — single client entry port

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -44,6 +44,24 @@ COPY --chown=galaxy:galaxy galaxy_gateway/ ./galaxy_gateway/
 COPY --chown=galaxy:galaxy daemon/ ./daemon/
 COPY --chown=galaxy:galaxy requirements-core.txt .
 
+# 构建期把应用代码编译成 .pyc。
+#
+# 为什么需要:上面(以及另外三个 Dockerfile)都设了 PYTHONDONTWRITEBYTECODE=1 ——
+# 那是容器里的常见做法(镜像干净、不留运行期写入),但它同时意味着**运行期永远
+# 不会生成 .pyc**。而构建时又没有任何预编译,于是应用代码在**每一次进程启动**
+# 都要重新编译一遍,不是只有第一次。
+#
+# 实测(隔离掉磁盘冷读与 site-packages 的影响,各跑 3 次取稳定值):
+#     应用代码无 .pyc + DONTWRITEBYTECODE   2315 / 2322 / 2384 ms
+#     构建期 compileall 之后               1919 / 1930 / 2036 ms
+# 约省 380 ms 每次启动(~16%)。不大,但它是纯收益:代码不变、行为不变,
+# 只是把一份每次都要重做的工作挪到构建期做一次。
+#
+# compileall 显式调用 py_compile,不受 PYTHONDONTWRITEBYTECODE 影响,
+# 所以运行期那个环境变量可以照旧保留。
+# -q 只报错误;失败不阻断构建(个别文件语法不兼容当前版本时,退化成运行期编译)。
+RUN python -m compileall -q core/ galaxy_gateway/ nodes/ enhancements/ daemon/ || true
+
 USER galaxy
 
 EXPOSE 9000

--- a/docs/startup_performance_baseline.md
+++ b/docs/startup_performance_baseline.md
@@ -1,0 +1,98 @@
+# 启动性能基线（权威 API 层）
+
+这份文件记的是**测量结果**，不是优化方案。写下来是因为"提速"这件事最容易的失败方式，
+是在没有基线的情况下动手——改完之后没人说得清快了多少，甚至说不清原来慢在哪。
+
+复现方式在每一节里，数字可以随时重测。
+
+## 一、总量
+
+冷/热差异极大，而**差的那一部分不是字节码编译，是磁盘冷读**——这一点我一开始判断错了，
+记在这里免得下一个人重走：
+
+| 场景 | 组装耗时 |
+|---|---|
+| 进程第一次跑（文件系统冷） | ~10.8 s |
+| 文件系统热之后 | ~2.06 s |
+
+所以任何"启动很慢"的观察，第一件事是确认它是不是只是第一次。
+
+## 二、字节码编译到底值多少
+
+用独立缓存目录隔离，每组跑 3 次：
+
+```bash
+M='import time; t=time.perf_counter()
+import fastapi, core.api_routes as ar
+app=fastapi.FastAPI(); app.include_router(ar.create_api_routes(service_manager=None, config=None)); app.openapi()
+print(f"{(time.perf_counter()-t)*1000:.0f}")'
+
+# 每次全新空缓存目录（保证不复用 .pyc）
+for i in 1 2 3; do d=$(mktemp -d); PYTHONPYCACHEPREFIX=$d python3 -c "$M"; done
+# 复用同一个已预热的缓存目录
+d=$(mktemp -d); PYTHONPYCACHEPREFIX=$d python3 -c "$M" >/dev/null
+for i in 1 2 3; do PYTHONPYCACHEPREFIX=$d python3 -c "$M"; done
+```
+
+| 场景 | 三次测量 |
+|---|---|
+| 无 .pyc 复用 | 4362 / 3703 / 4153 ms |
+| 有 .pyc 复用 | 1814 / 1887 / 1902 ms |
+
+差约 **2.2 s**——但那是把 site-packages 也算进去了。真实容器里 pip 装依赖时已经
+编译过 site-packages，**只有应用代码没有**。隔离之后：
+
+| 场景 | 三次测量 |
+|---|---|
+| 应用代码无 .pyc + `PYTHONDONTWRITEBYTECODE=1` | 2315 / 2322 / 2384 ms |
+| 构建期 `compileall` 之后 | 1919 / 1930 / 2036 ms |
+
+**约 380 ms 每次启动（~16%）**。已在 `Dockerfile` 与 `Dockerfile.gateway` 里落实。
+
+> 为什么这在容器里是**每次**而不是首次：四个 Dockerfile 都设了
+> `PYTHONDONTWRITEBYTECODE=1`（容器常见做法），于是运行期永远不写 .pyc；
+> 而构建时又没有预编译，所以每一次进程启动都要重编译一遍应用代码。
+
+`Dockerfile.node` 与 `Dockerfile.agentcpm` **没有动**：它们跑单个节点，import 图
+与这里测的完全不同，没测过就不该套用一个未验证的收益。
+
+## 三、剩下的时间花在哪（这一节推翻了任务标题的前提）
+
+任务原本叫"FastAPI 整合与提速"，隐含前提是 FastAPI 的路由装配慢。**实测不是。**
+
+给 `APIRouter.include_router` 打点，统计 `create_api_routes()` 内部：
+
+```
+create_api_routes() 合计 867 ms · include_router 调用 49 次
+其中 include_router 累计 1 ms      ← 路由装配总共 1 毫秒
+```
+
+也就是说那 867 ms 几乎全是**函数体里那些 `from core.routes import X` 触发的模块导入**，
+与 FastAPI 无关。`python -X importtime` 的前几名：
+
+```
+431.9 ms  core.api_routes
+226.9 ms    fastapi
+133.9 ms    core.routes._models
+107.1 ms      core.schemas.multimodal
+ 61.3 ms    core
+ 53.1 ms    core.node_protocol
+```
+
+**结论：要提速就得减少/推迟 import，而不是动 FastAPI 的装配方式。**
+
+## 四、一个不该算进启动成本的数字
+
+`app.openapi()` 首次生成要 ~580 ms。但 `unified_launcher.py` 与 `core/api_routes.py`
+里**没有任何地方主动调用它**——FastAPI 是惰性生成的，这 580 ms 只在第一次有人访问
+`/openapi.json` 或 `/docs` 时才付。
+
+早期把它算进"启动耗时"会让总数虚高约三分之一。测量时要注意自己有没有替生产
+多做一件它不做的事。
+
+## 五、还没做的
+
+* **减少启动期 import**：这是剩下 ~1.9 s 里的主要部分，但要动 `core/api_routes.py`
+  里几十处顶层导入，风险与收益都需要逐个模块评估，不是一次性改动。
+* **节点镜像**：见上，未测量。
+* **请求延迟**：这份文件只测了启动，没测运行期。两者的瓶颈未必是同一个。


### PR DESCRIPTION
任务原本叫"FastAPI 整合与提速"。**先量，不先改**——结果推翻了任务标题的前提。

## 一、FastAPI 的路由装配不慢

给 `APIRouter.include_router` 打点统计 `create_api_routes()` 内部：

```
create_api_routes() 合计 867 ms · include_router 调用 49 次
其中 include_router 累计 1 ms      ← 路由装配总共 1 毫秒
```

那 867 ms 几乎全是函数体里 `from core.routes import X` 触发的**模块导入**，与 FastAPI 无关。`importtime` 前几名：`core.api_routes` 432ms、`fastapi` 227ms、`core.routes._models` 134ms。

**要提速就得减少/推迟 import，而不是动装配方式。**

## 二、一个不该算进启动成本的数字

`app.openapi()` 首次生成 ~580 ms，但 `unified_launcher` 与 `core/api_routes` 里**没有任何地方主动调它**——FastAPI 惰性生成，这 580ms 只在第一次访问 `/docs` 或 `/openapi.json` 时才付。把它算进启动耗时会让总数虚高约三分之一。

## 三、我一开始判断错了一次，记下来

冷跑 10.8s、热跑 2.06s，我先假设那 8.7s 是字节码编译。做对照实验后发现**不是**——是文件系统冷读。第一版实验还因为 `PYTHONPYCACHEPREFIX` 把 site-packages 的缓存一并重定向了，导致"compileall 之后没有改善"这个**看起来很像结论的假象**。

隔离干净之后（每组 3 次）：

| 场景 | 三次测量 |
|---|---|
| 无 .pyc 复用 | 4362 / 3703 / 4153 ms |
| 有 .pyc 复用 | 1814 / 1887 / 1902 ms |

再排掉 site-packages（真实容器里 pip 装时已编译，只有应用代码没有）：

| 场景 | 三次测量 |
|---|---|
| 应用代码无 .pyc + `PYTHONDONTWRITEBYTECODE=1` | 2315 / 2322 / 2384 ms |
| 构建期 `compileall` 之后 | 1919 / 1930 / 2036 ms |

## 四、落实的那一项

四个 Dockerfile 都设了 `PYTHONDONTWRITEBYTECODE=1`（容器常见做法），而构建时没有任何预编译——于是应用代码在**每一次进程启动**都要重编译，不是只有第一次。

在 `Dockerfile` 与 `Dockerfile.gateway` 加构建期 `compileall`：**约省 380 ms/次启动（~16%）**。纯收益，代码与行为都不变，只是把一份每次重做的工作挪到构建期做一次。`compileall` 显式调 `py_compile`，不受 `DONTWRITEBYTECODE` 影响，运行期那个变量照旧保留。

`Dockerfile.node` 与 `Dockerfile.agentcpm` **没动**：它们跑单个节点，import 图与这里测的完全不同——没测过就不该套用一个未验证的收益。

## 五、基线写进 `docs/startup_performance_baseline.md`

含复现命令。"提速"最容易的失败方式是没有基线就动手：改完之后没人说得清快了多少，甚至说不清原来慢在哪。

**如实记为未做**：剩下的 ~1.9s 主要是启动期 import，那要动几十处顶层导入，风险与收益需逐模块评估，不是一次性改动；节点镜像未测量；请求延迟未测——这份只测了启动，两者的瓶颈未必相同。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_