### PR TITLE
统一版面几何与横幅渐变；启动过程首次留下结构化事实

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,9 @@ runtime/task_allocation_truth.json
 # 任何人跑一次 main.py,工作区就多一个未跟踪文件 —— 与上面那句"runtime/ 里
 # 只提交 *.example.* 模板"的既定意图矛盾。实跑一次启动才发现的。
 runtime/model_state.json
+# 每次启动重写的结构化启动记录（launcher/ui.py 的渲染器 B）。
+# 它是运行时产物,不是配置 —— 入库会让每跑一次仓库就脏。
+runtime/startup.json
 data/runtime/delegated_runtime_execution_tracker.json
 learning_data.db
 audit/wiring_report_*.json

--- a/core/ascii_art.py
+++ b/core/ascii_art.py
@@ -4,17 +4,38 @@ Galaxy ASCII 艺术字 / 统一终端输出格式
 
 单一真相来源 (single source of truth) for:
 - Galaxy 启动横幅 (GALAXY_BANNER)
-- 终端颜色 (Colors)
+- 终端颜色 (Colors) 与 24-bit 渐变 (gradient_text / gradient_rule)
+- **版面几何** (BANNER_WIDTH / CONTENT_INDENT / RULE_WIDTH / LABEL_COL / VALUE_COL)
+- 显示宽度与填充 (display_width / pad_display) —— 东亚字符算 2 格
 - 对齐的状态行 (print_status_row)
 - 章节标题 (print_section_header)
 - 横幅打印 (print_banner)
 - ANSI 支持检测 (ansi_supported)
 
 所有启动入口均应导入并使用本模块的公共接口，以保证视觉一致性。
+
+版面统一（为什么这些常量在这里）
+--------------------------------
+此前同一屏里存在**三种宽度**（横幅 60 / 章节线 60 / ``cli_render.rule`` 50）、
+**三种线条着色**（横幅 24-bit 渐变 / 章节线平 CYAN / 细线平 DIM）、以及
+**两套填充语义**（``print_status_row`` 用 ``str.ljust``、``cli_render`` 用显示宽度）。
+
+最后那条是实打实的错位：``ljust`` 按**码点**补齐，中文标签因此偏宽。实测
+``"环境检查".ljust(22)`` 的显示宽度是 **26**、``"三态覆盖层"`` 是 **27**，而
+``pad_display(..., 22)`` 恒为 22 —— 两套打印器在同一屏里各自缩进，差 2~5 列。
+
+现在几何只有一份，且**渐变是屏幕列的函数**（见 :func:`gradient_text`）：
+一条缩进 2 格的横线，其颜色是横幅在第 2..59 列的那一段，因此横线与横幅
+不只是"同款配色"，而是**同一道渐变的延续**，左右边缘都对齐。
 """
 
 import os
+import re
 import sys
+import unicodedata
+
+#: 剥 ANSI 转义序列用（算显示宽度前必须剥掉，否则颜色码会被算进列数）。
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 # ---------------------------------------------------------------------------
 # 版本 & 标语 (single source of truth)
@@ -22,6 +43,34 @@ import sys
 
 GALAXY_VERSION = "v2.3.21"
 GALAXY_TAGLINE = "L4 Autonomous Intelligence System"
+
+# ---------------------------------------------------------------------------
+# 版面几何 (canonical layout geometry) —— 全仓唯一一份
+# ---------------------------------------------------------------------------
+#
+# 一切对齐以横幅为基准。横幅占屏幕第 0..59 列（实测 12 行全部宽 60，且每个
+# 字符都是 1 显示格：框线字符 ═║╔╗╚╝ 与 █ 的 east_asian_width 均为 'A'）。
+
+#: 横幅显示宽度。所有横线、章节线的右边缘都对齐到这一列。
+BANNER_WIDTH = 60
+
+#: 内容左缩进（格）。``print_status_row`` 与 ``cli_render.phase`` 都用它。
+CONTENT_INDENT = 2
+
+#: 横线宽度 = 横幅宽度 − 缩进，使横线右边缘与横幅右边框同列。
+#: 此前 ``cli_render.RULE_WIDTH`` 是 50，比横幅短 10 列、右边缘悬空。
+RULE_WIDTH = BANNER_WIDTH - CONTENT_INDENT
+
+#: 图标列宽（格）：1 格图标 + 1 格间隔。图标统一为 1 显示格的文本符号
+#: （不用 ✅/⚠️ 这类带变体选择符、多数终端渲染成 2 格的 emoji）。
+ICON_COL = 2
+
+#: 标签列宽（格）。中英混排在此列内按**显示宽度**左对齐。
+LABEL_COL = 22
+
+#: 值列起始屏幕列 = 缩进 + 图标 + 标签 + 2 格间隔。
+#: 所有打印器的值都从这一列起，跨模块严格同列。
+VALUE_COL = CONTENT_INDENT + ICON_COL + LABEL_COL + 2
 
 # ---------------------------------------------------------------------------
 # 规范横幅 (canonical banner)
@@ -126,6 +175,14 @@ def ansi_supported() -> bool:
     Returns:
         bool: True 表示可安全使用 ANSI 颜色，False 表示应降级为纯文本。
     """
+    # NO_COLOR 约定（https://no-color.org/）：只要该变量【存在】(哪怕是空串)
+    # 就必须禁用颜色。此前 core/cli_render.py 的模块 docstring 声称"非 TTY /
+    # NO_COLOR 时自动纯文本"，但实现里从来没查过它 —— 一个说谎的注释。
+    if "NO_COLOR" in os.environ:
+        return False
+    # GALAXY_NO_COLOR：本项目自己的开关，便于在不影响其它工具的前提下关色。
+    if os.environ.get("GALAXY_NO_COLOR", "").strip().lower() in ("1", "true", "yes", "on"):
+        return False
     if not hasattr(sys.stdout, "isatty") or not sys.stdout.isatty():
         return False
     if os.name == "nt":
@@ -165,6 +222,28 @@ _ANCHOR_COLORS = [
 ]
 
 
+def display_width(s: str) -> int:
+    """字符串的**终端显示宽度**：先剥 ANSI，东亚宽/全角字符算 2 格，其余 1 格。
+
+    这个函数原本住在 ``core/cli_render.py``，而 ``print_status_row`` 在本模块里
+    却用 ``str.ljust`` —— 两套填充语义并存，中文标签因此错位 2~5 列。下移到
+    本模块（较低层）后 ``cli_render`` 再导出去，全仓只剩这一份实现。
+    """
+    s = _ANSI_RE.sub("", s)
+    w = 0
+    for ch in s:
+        if unicodedata.combining(ch):
+            continue
+        w += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+    return w
+
+
+def pad_display(s: str, width: int, align: str = "left") -> str:
+    """按**显示宽度**补空格到 ``width``（不截断；已超宽则原样返回）。"""
+    pad = max(0, width - display_width(s))
+    return (s + " " * pad) if align == "left" else (" " * pad + s)
+
+
 def _interp_rgb(t: float) -> tuple:
     """Interpolate RGB across _ANCHOR_COLORS for t in [0.0, 1.0].
 
@@ -190,36 +269,76 @@ def _interp_rgb(t: float) -> tuple:
     )
 
 
-def _colorize_line(line: str, banner_width: int = 60) -> str:
-    """Apply 24-bit true-color smooth gradient across every character of *line*.
+def gradient_text(text: str, *, col_offset: int = 0, scale: int = BANNER_WIDTH, bold: bool = True) -> str:
+    """把 24-bit 渐变按**屏幕列**铺到 ``text`` 上。
 
-    Each column gets its own RGB value computed by interpolating across the
-    five anchor colors, producing a seamless left-to-right gradient with zero
-    banding.
+    这是本模块的渐变核心。关键点在于 **t 是屏幕列的函数，不是字符序号的函数**：
+
+        t = (col_offset + 该字符左边缘所在列) / (scale - 1)
+
+    因此一条缩进 2 格、宽 58 的横线（``col_offset=2, scale=60``）拿到的颜色，
+    正是横幅在第 2..59 列的那一段 —— 它与横幅**不只是同款配色，而是同一道
+    渐变的延续**，左右边缘都对齐。若按字符序号算（旧实现），同一条横线会把
+    整条渐变压缩进 58 格，与横幅的第 2..59 列对不上。
+
+    列的推进用**显示宽度**而非码点数：中文标题里每个汉字占 2 列，颜色才不会
+    在中文段落上加速漂移。横幅本身全是 1 格字符（实测 12 行 code_points ==
+    display_width == 60），所以对横幅而言新旧实现**逐字节一致**。
 
     Args:
-        line:         The text to colorize.
-        banner_width: Total width used for the color calculation (default 60,
-                      matching GALAXY_BANNER). All lines of the banner share
-                      this same scale, so colors align consistently across
-                      lines of varying code-point length.
+        text:       要着色的文本。
+        col_offset: 这段文本左边缘所在的屏幕列。
+        scale:      渐变全程覆盖的总列数（默认 :data:`BANNER_WIDTH`）。
+        bold:       是否前置一次加粗（横幅用 True，保持既有观感）。
 
     Returns:
-        String with per-character ``\\x1b[1;38;2;R;G;Bm`` escape codes,
-        terminated by a reset sequence.
+        每字符带 ``\\x1b[38;2;R;G;Bm`` 的字符串，末尾复位。
     """
-    if not line:
-        return line
-    # Use a fixed scale so every banner line maps columns to the same colors,
-    # regardless of per-line code-point count differences.
-    width = banner_width if banner_width > 1 else 2
-    parts = ["\x1b[1m"]  # bold once at start
-    for col, char in enumerate(line):
-        t = col / (width - 1)
+    if not text:
+        return text
+    span = scale if scale > 1 else 2
+    parts = ["\x1b[1m"] if bold else []
+    col = col_offset
+    for char in text:
+        t = col / (span - 1)
+        if t < 0.0:
+            t = 0.0
+        elif t > 1.0:
+            t = 1.0
         r, g, b = _interp_rgb(t)
         parts.append(f"\x1b[38;2;{r};{g};{b}m{char}")
+        col += 0 if unicodedata.combining(char) else display_width(char)
     parts.append("\x1b[0m")
     return "".join(parts)
+
+
+def gradient_rule(
+    width: int = RULE_WIDTH,
+    *,
+    indent: int = CONTENT_INDENT,
+    char: str = "─",
+) -> str:
+    """生成一条**与横幅同一道渐变**的横线（含左缩进）。
+
+    此前全仓有三种线条处理：横幅是 24-bit 渐变、``print_section_header`` 是平
+    CYAN 的 ``═``×60、``cli_render.rule`` 是平 DIM 的 ``─``×50。现在统一成这一个
+    出口 —— 颜色同源、右边缘同列。
+
+    终端不支持 ANSI 时自动降级为纯字符（缩进与宽度不变，纯文本下依然对齐）。
+    """
+    body = char * width
+    if not ansi_supported():
+        return " " * indent + body
+    return " " * indent + gradient_text(body, col_offset=indent, scale=max(indent + width, 2), bold=False)
+
+
+def _colorize_line(line: str, banner_width: int = 60) -> str:
+    """横幅整行着色（向后兼容入口，内部走 :func:`gradient_text`）。
+
+    保留这个名字是因为 ``print_banner`` 与 ``windows_service/tray_icon.py`` 都在用。
+    行为与改造前一致：横幅每个字符都是 1 显示格，故按列推进 == 按码点推进。
+    """
+    return gradient_text(line, col_offset=0, scale=banner_width, bold=True)
 
 
 # ---------------------------------------------------------------------------
@@ -308,22 +427,25 @@ def print_section_header(title: str, use_color: bool = True) -> None:
         title:     章节名称。
         use_color: 若为 True（默认），使用青色加粗样式。
     """
-    sep = "═" * 60
-    if use_color:
+    sep = "═" * BANNER_WIDTH
+    colored = use_color and ansi_supported()
+    if colored:
+        line = gradient_text(sep, col_offset=0, scale=BANNER_WIDTH, bold=False)
         c = f"{Colors.BOLD}{Colors.CYAN}"
         e = Colors.ENDC
     else:
+        line = sep
         c = e = ""
-    print(f"\n{c}{sep}{e}")
-    print(f"{c}  ▶  {title}{e}")
-    print(f"{c}{sep}{e}\n")
+    print(f"\n{line}")
+    print(f"{c}{' ' * CONTENT_INDENT}▶  {title}{e}")
+    print(f"{line}\n")
 
 
 def print_status_row(
     label: str,
     value: str = "",
     status: str = "info",
-    label_width: int = 22,
+    label_width: int = LABEL_COL,
     use_color: bool = True,
 ) -> None:
     """打印对齐的状态行（图标 + 左对齐标签 + 右侧值）。
@@ -353,7 +475,10 @@ def print_status_row(
         "info": Colors.BLUE,
     }
 
-    if use_color:
+    # 必须同时满足"调用方要色"与"终端支持色"。此前只看 use_color(默认 True),
+    # 于是重定向输出、CI、以及 NO_COLOR 环境下这里照样吐 ANSI 转义码,而同屏的
+    # cli_render 已经降级成纯文本 —— 一半带色一半不带,管道里还会混进乱码。
+    if use_color and ansi_supported():
         color = color_map.get(status, Colors.BLUE)
         end = Colors.ENDC
     else:
@@ -361,11 +486,14 @@ def print_status_row(
 
     # 图标 + 【单】空格(图标现为 1 显示格),标签左对齐 —— 标签从第 4 列起,与
     # core.cli_render 的 phase()/detail() 同列,对勾/标签跨两套打印器完全对齐。
-    padded = label.ljust(label_width)
+    # 这里必须用 pad_display 而不是 str.ljust:ljust 按【码点】补齐,中文标签
+    # 会偏宽。实测 "环境检查".ljust(22) 的显示宽度是 26、"三态覆盖层" 是 27,
+    # 而 cli_render 那边恒为 22 —— 同一屏里两套打印器差 2~5 列,对勾对不齐。
+    padded = pad_display(label, label_width)
     if value:
-        print(f"  {color}{icon} {padded}{end}{value}")
+        print(f"{' ' * CONTENT_INDENT}{color}{icon} {padded}{end}  {value}")
     else:
-        print(f"  {color}{icon} {padded}{end}")
+        print(f"{' ' * CONTENT_INDENT}{color}{icon} {padded}{end}")
 
 
 # ---------------------------------------------------------------------------

--- a/core/cli_render.py
+++ b/core/cli_render.py
@@ -6,21 +6,39 @@ core/cli_render.py — 精炼 CLI 渲染原语（按 clig.dev「human-first」�
 
 - 默认安静：每个阶段折叠成【一行】``✓ 名称   值``；``-v`` 才展开逐项明细。
 - 一套符号：``✓ 完成 · ◐ 进行中 · ⚠ 降级 · ✗ 失败``（不再混 ✅/❌/❎ 与 ╔═╗/════）。
-- 一种分隔线：细线 ``──``。
+- 一种分隔线：细线 ``──``，且**与横幅同一道 24-bit 渐变**（见下）。
 - 对齐成列：按【显示宽度】(东亚字符算 2 格)对齐，彻底消除中文歪边。
-- 颜色仅增强、可降级：非 TTY / NO_COLOR 时自动纯文本（复用 ascii_art.ansi_supported）。
+- 颜色仅增强、可降级：非 TTY / ``NO_COLOR`` 时自动纯文本。
 - 结尾给「总结卡」：状态 + 关键值 + 降级项 + 下一步该点哪。
 
-颜色/TTY 检测复用 ``core.ascii_art``，不重复造。
+版面几何与渐变都来自 ``core.ascii_art``，本模块不重复定义
+--------------------------------------------------------
+此前本模块自带 ``LABEL_COL=22`` / ``RULE_WIDTH=50`` / ``display_width`` /
+``pad_display``，而 ``ascii_art`` 那边另有一套（``print_status_row`` 用
+``str.ljust``、章节线 60 宽平 CYAN）。同一屏里于是出现三种线宽、三种线条着色、
+两套填充语义。现在几何常量与显示宽度函数全部从 ``ascii_art`` 导入，横线走
+``ascii_art.gradient_rule`` —— 颜色与横幅同源，右边缘与横幅同列。
+
+模块级名字（``LABEL_COL`` / ``RULE_WIDTH`` / ``display_width`` / ``pad_display``）
+继续导出，老调用点不用改。
 """
 
 from __future__ import annotations
 
-import re
-import unicodedata
 from typing import Optional, Sequence, Tuple
 
-from core.ascii_art import Colors, ansi_supported
+from core.ascii_art import (
+    CONTENT_INDENT,
+    ICON_COL,
+    LABEL_COL,
+    RULE_WIDTH,
+    VALUE_COL,
+    Colors,
+    ansi_supported,
+    display_width,
+    gradient_rule,
+    pad_display,
+)
 
 # ── 状态词汇（唯一一套）：name -> (glyph, color) ──
 _STATUS: dict = {
@@ -31,32 +49,25 @@ _STATUS: dict = {
     "info": ("·", Colors.BLUE),
 }
 
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-# 阶段行：标签列宽（显示格数）。中英混排在此列内左对齐，值列随后。
-LABEL_COL = 22
-RULE_WIDTH = 50
+#: 再导出，供仍按老路径 import 的调用点使用（本模块不再自己定义）。
+__all__ = [
+    "CONTENT_INDENT",
+    "LABEL_COL",
+    "RULE_WIDTH",
+    "VALUE_COL",
+    "display_width",
+    "pad_display",
+    "glyph",
+    "rule",
+    "phase",
+    "detail",
+    "section",
+    "summary_card",
+]
 
 
 def _use_color() -> bool:
     return ansi_supported()
-
-
-def display_width(s: str) -> int:
-    """字符串的【终端显示宽度】：先剥 ANSI，东亚宽/全角字符算 2 格，其余 1 格。"""
-    s = _ANSI_RE.sub("", s)
-    w = 0
-    for ch in s:
-        if unicodedata.combining(ch):
-            continue
-        w += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
-    return w
-
-
-def pad_display(s: str, width: int, align: str = "left") -> str:
-    """按显示宽度补空格到 ``width``（不截断；已超宽则原样返回）。"""
-    pad = max(0, width - display_width(s))
-    return (s + " " * pad) if align == "left" else (" " * pad + s)
 
 
 def _c(text: str, color: str) -> str:
@@ -69,36 +80,69 @@ def glyph(status: str) -> str:
 
 
 def rule(width: int = RULE_WIDTH) -> None:
-    """打印一条细分隔线。"""
-    print("  " + _c("─" * width, Colors.DIM))
+    """打印一条细分隔线 —— **与横幅同一道 24-bit 渐变**。
+
+    改造点：此前是 ``"  " + DIM("─" * 50)``，即平淡灰、宽 50，比横幅短 10 列、
+    右边缘悬空。现在宽度取 :data:`RULE_WIDTH`\\ （= 横幅宽 − 缩进 = 58），
+    着色交给 ``ascii_art.gradient_rule``：它按**屏幕列**取色，所以这条线拿到的
+    正是横幅在第 2..59 列的那一段颜色。两者是同一道渐变的不同片段，而不是
+    "看起来差不多的两种颜色"。
+
+    非 TTY / ``NO_COLOR`` 时自动降级为纯字符，缩进与宽度不变（纯文本下依然对齐）。
+    """
+    print(gradient_rule(width))
+
+
+#: 子项行的缩进（格）：比阶段行深一个"图标 + 间隔"的量，形成可见的层级。
+#: 写成算式而不是字面量 6，是为了让它跟着几何常量走。
+_DETAIL_INDENT = CONTENT_INDENT + ICON_COL + 2
+
+#: 子项的标签列宽 —— **由值列反推**，使子项的值与阶段行的值落在同一列。
+#:
+#: 此前子项固定用 LABEL_COL(22)，于是它的值列 = 6 + 2 + 22 + 2 = **32**，
+#: 而阶段行的值列是 **28**：``-v`` 一展开，所有值就整体右移 4 格，同一屏里
+#: 出现两条值列。缩进表达层级、值列保持对齐，两者不该互相牵连。
+_DETAIL_LABEL_COL = max(1, VALUE_COL - _DETAIL_INDENT - ICON_COL - 2)
 
 
 def phase(name: str, value: str = "", status: str = "ok") -> None:
     """折叠的阶段行（默认形态）：``  ✓ 名称              值``。
 
-    图标占 2 显示格（图标 + 间隔），标签左对齐到 LABEL_COL，值用暗色跟随。
+    列位全部由 ``ascii_art`` 的几何常量决定，不再写字面量：
+
+        缩进 CONTENT_INDENT(2) + 图标 ICON_COL(2) + 标签 LABEL_COL(22) + 2
+        ⇒ 值列起始 = VALUE_COL(28)
+
+    ``ascii_art.print_status_row`` 用的是同一组常量，所以两套打印器输出的
+    对勾列、标签列、值列**逐列一致** —— 这是"跨模块严格对齐"的实现方式。
     """
-    icon = pad_display(glyph(status), 2)
+    icon = pad_display(glyph(status), ICON_COL)
     label = pad_display(name, LABEL_COL)
+    head = f"{' ' * CONTENT_INDENT}{icon}{label}"
     if value:
-        print(f"  {icon}{label}  {_c(value, Colors.DIM)}")
+        print(f"{head}  {_c(value, Colors.DIM)}")
     else:
-        print(f"  {icon}{label}")
+        print(head)
 
 
 def detail(label: str, value: str = "", status: str = "ok") -> None:
-    """展开模式(-v)下的子项行，缩进于阶段标题之下。"""
-    icon = pad_display(glyph(status), 2)
-    lab = pad_display(label, LABEL_COL)
+    """展开模式(-v)下的子项行，缩进于阶段标题之下。
+
+    **值列与阶段行同列**（都是 :data:`~core.ascii_art.VALUE_COL`）：缩进负责
+    表达层级，值列负责对齐，两者互不牵连。见 :data:`_DETAIL_LABEL_COL`。
+    """
+    icon = pad_display(glyph(status), ICON_COL)
+    lab = pad_display(label, _DETAIL_LABEL_COL)
+    head = f"{' ' * _DETAIL_INDENT}{icon}{lab}"
     if value:
-        print(f"      {icon}{lab}  {_c(value, Colors.DIM)}")
+        print(f"{head}  {_c(value, Colors.DIM)}")
     else:
-        print(f"      {icon}{lab}")
+        print(head)
 
 
 def section(title: str) -> None:
     """展开模式(-v)下的阶段小标题（细线之上）。"""
-    print(f"\n  {_c(title, Colors.BOLD + Colors.CYAN)}")
+    print(f"\n{' ' * CONTENT_INDENT}{_c(title, Colors.BOLD + Colors.CYAN)}")
 
 
 def summary_card(
@@ -118,22 +162,27 @@ def summary_card(
     "模型没拉好"之类的降级，共用同一句会文不对题、误导用户该怎么修）。
     建议为 None 的项只展示名称，不编造建议。
     """
+    # 卡内的键列宽按内容算（卡是一块紧凑的键值表，不必拉到 VALUE_COL —— 那会
+    # 让"网关"这种短标签后面留一大片空）。但缩进必须由几何常量派生，不能再写
+    # 字面量 2/4，否则下一次调整缩进时这里又会掉队。
+    head_indent = " " * CONTENT_INDENT
+    body_indent = " " * (CONTENT_INDENT * 2)
     key_w = max([display_width(k) for k, _ in list(rows) + list(hints or [])] + [4])
     print()
     rule()
     head = f"就绪 · {state_ok} 正常"
     if state_degraded:
         head += f" · {state_degraded} 降级"
-    print(f"  {_c('✓', Colors.GREEN)} {_c(head, Colors.BOLD + Colors.GREEN)}" f"   {_c(title, Colors.DIM)}")
+    print(f"{head_indent}{_c('✓', Colors.GREEN)} {_c(head, Colors.BOLD + Colors.GREEN)}   {_c(title, Colors.DIM)}")
     print()
     for k, v in rows:
-        print(f"    {_c(pad_display(k, key_w), Colors.CYAN)}   {v}")
+        print(f"{body_indent}{_c(pad_display(k, key_w), Colors.CYAN)}   {v}")
     if degraded:
         parts = [f"{name} → {hint}" if hint else name for name, hint in degraded]
         joined = "  ·  ".join(parts)
-        print(f"    {_c(pad_display('降级', key_w), Colors.YELLOW)}   " f"{_c(joined, Colors.DIM)}")
+        print(f"{body_indent}{_c(pad_display('降级', key_w), Colors.YELLOW)}   {_c(joined, Colors.DIM)}")
     if hints:
         print()
         for k, v in hints:
-            print(f"    {_c(pad_display(k, key_w), Colors.DIM)}   {_c(v, Colors.DIM)}")
+            print(f"{body_indent}{_c(pad_display(k, key_w), Colors.DIM)}   {_c(v, Colors.DIM)}")
     rule()

--- a/launcher/record.py
+++ b/launcher/record.py
@@ -1,0 +1,191 @@
+"""launcher/record.py — 启动过程的**事实**（不含任何显示逻辑）
+
+要解决什么
+----------
+启动器现在是"一边判断一边 ``print``"：判断结果只以彩色文本的形式存在过一瞬，
+**不留任何结构化痕迹**。后果很具体：
+
+* 启动失败时能拿到的只有一段截图或复制的彩色文本，排障只能靠读那段文字猜；
+* 托盘、面板、``entrypoint.json`` 各自再去问一遍状态，同一件事问三遍；
+* "上次启动降级了什么"没有任何地方记着。
+
+本模块把事实从呈现里剥出来。判断只做一次，结果落成 :class:`StartupRecord`，
+再由 ``launcher/ui.py`` 的三个渲染器分别渲染给人、给机器、给日志。
+
+刻意的边界
+----------
+**这里不许 import 任何渲染相关的东西**，也不许有颜色、缩进、图标的概念。
+一旦事实层知道了自己会被怎么显示，分离就失效了 —— 那正是现在这套代码的病根。
+``tests/test_launcher_record_and_ui.py`` 有一条测试钉住这件事。
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class Column(str, Enum):
+    """五个栏目。
+
+    按**用户关心什么**取名，不按代码结构 —— 此前 ``main.py`` 打 Phase 0/2、
+    ``SystemOrchestrator`` 打 Phase 1–7、``unified_launcher`` 又自成一套，
+    三套编号在同一屏里交错出现，而"Phase 4"对用户没有任何意义。
+    """
+
+    ENV = "环境"  # 这台机器能不能跑
+    DEPS = "依赖"  # 缺的东西补齐了吗
+    FABRIC = "骨干"  # 通信层通了吗
+    BRAIN = "大脑"  # 用哪个模型、能不能用
+    PRESENCE = "在场"  # 我能看见它了吗
+
+    @property
+    def order(self) -> int:
+        """栏目的固定显示顺序（与启动时序一致）。"""
+        return _COLUMN_ORDER[self]
+
+
+_COLUMN_ORDER: Dict["Column", int] = {}
+
+
+class Status(str, Enum):
+    """一项检查的结论。
+
+    与 ``core.cli_render._STATUS`` 的图标词汇是**两回事**：那边是显示符号，
+    这里是事实。映射关系写在 ``launcher/ui.py``，事实层不该知道图标长什么样。
+    """
+
+    OK = "ok"
+    DEGRADED = "degraded"  # 能跑，但打了折
+    FAILED = "failed"  # 这一项没成
+    SKIPPED = "skipped"  # 按配置/平台跳过，不算问题
+
+
+#: 确定性退出码。此前只有 0/1 两档，且 ``main.py`` 里 8 处 ``return 1`` 混着
+#: 完全不同的失败原因 —— 自动化分不清，你自己排障也分不清。
+EXIT_OK = 0
+EXIT_ERROR = 1  # 一般错误（未归类）
+EXIT_USAGE = 2  # 参数用法错误
+EXIT_DEPENDENCY = 3  # 依赖缺失且无法自动补齐
+EXIT_PORT_IN_USE = 4  # 端口被占，且不是本进程
+EXIT_ENVIRONMENT = 5  # 环境不满足（Python 版本、缺 .env 等）
+EXIT_INTERRUPTED = 130  # SIGINT（沿用 shell 惯例 128+2）
+
+#: 退出码 → 人话。渲染器与错误提示都读它，避免两处各写一份。
+EXIT_MEANING: Dict[int, str] = {
+    EXIT_OK: "成功",
+    EXIT_ERROR: "一般错误",
+    EXIT_USAGE: "参数用法错误",
+    EXIT_DEPENDENCY: "依赖缺失",
+    EXIT_PORT_IN_USE: "端口被占用",
+    EXIT_ENVIRONMENT: "环境不满足",
+    EXIT_INTERRUPTED: "被中断",
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class StepResult:
+    """一项检查的完整事实。"""
+
+    column: Column
+    name: str
+    status: Status
+    value: str = ""
+    """给人看的一句话，如 ``"3.11.15"``、``"已就位（3 项跳过）"``。"""
+
+    hint: Optional[str] = None
+    """降级/失败时的**专属**修复建议。
+
+    刻意是每项各带一条，而不是所有降级共用一句 —— ``cli_render.summary_card``
+    的注释里论证过：``"装后重跑即恢复"`` 只对 Docker 那类场景成立，换成
+    "模型没拉好"就文不对题。没有可靠建议时留 ``None``，不编。
+    """
+
+    detail: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    """机器可读的原始事实。排障时真正想立刻看到的东西放这里。"""
+
+    elapsed_ms: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = dataclasses.asdict(self)
+        d["column"] = self.column.value
+        d["status"] = self.status.value
+        return d
+
+
+@dataclasses.dataclass
+class StartupRecord:
+    """一次启动的完整事实。"""
+
+    version: str
+    started_at: float = dataclasses.field(default_factory=time.time)
+    steps: List[StepResult] = dataclasses.field(default_factory=list)
+    exit_code: int = EXIT_OK
+    finished_at: Optional[float] = None
+
+    # ── 排障时最想第一眼看到的几个数（不必翻 steps） ──
+    shell: Optional[str] = None
+    """``"tauri"`` | ``"electron"`` | ``None``（无桌面壳）。"""
+
+    gateway_url: Optional[str] = None
+    brain: Optional[str] = None
+    """选中的主脑，如 ``"qwen3:8b"``、``"api-only"``。"""
+
+    mode: Optional[str] = None
+    """系统模式（``core.system_mode`` 解析出的那个）。"""
+
+    def add(self, step: StepResult) -> StepResult:
+        self.steps.append(step)
+        return step
+
+    # ── 汇总（给总结卡用；这里只算数，不决定怎么显示） ──
+
+    def count(self, status: Status) -> int:
+        return sum(1 for s in self.steps if s.status is status)
+
+    @property
+    def ok_count(self) -> int:
+        return self.count(Status.OK)
+
+    @property
+    def degraded(self) -> List[StepResult]:
+        return [s for s in self.steps if s.status is Status.DEGRADED]
+
+    @property
+    def failed(self) -> List[StepResult]:
+        return [s for s in self.steps if s.status is Status.FAILED]
+
+    @property
+    def elapsed_s(self) -> float:
+        end = self.finished_at if self.finished_at is not None else time.time()
+        return max(0.0, end - self.started_at)
+
+    def by_column(self, column: Column) -> List[StepResult]:
+        return [s for s in self.steps if s.column is column]
+
+    def columns_in_order(self) -> List[Column]:
+        """出现过的栏目，按固定顺序。空栏目不显示。"""
+        seen = {s.column for s in self.steps}
+        return [c for c in Column if c in seen]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "elapsed_s": round(self.elapsed_s, 3),
+            "exit_code": self.exit_code,
+            "exit_meaning": EXIT_MEANING.get(self.exit_code, "未知"),
+            "shell": self.shell,
+            "gateway_url": self.gateway_url,
+            "brain": self.brain,
+            "mode": self.mode,
+            "counts": {s.value: self.count(s) for s in Status},
+            "steps": [s.to_dict() for s in self.steps],
+        }
+
+
+# Column.order 依赖枚举定义完成，放在这里初始化。
+_COLUMN_ORDER.update({c: i for i, c in enumerate(Column)})

--- a/launcher/ui.py
+++ b/launcher/ui.py
@@ -1,0 +1,437 @@
+"""launcher/ui.py — 启动输出的**唯一通道**（三个渲染器读同一份事实）
+
+数据与呈现分离
+--------------
+``launcher/record.py`` 持有事实（:class:`~launcher.record.StartupRecord`），
+本模块把同一份事实渲染成三种形态：
+
+    render_tui   人看的：横幅 + 五栏目 + 总结卡（复用 core.ascii_art / core.cli_render）
+    render_json  机器读的：runtime/startup.json
+    render_log   日志行
+
+**判断逻辑一次都不重复** —— 这是与现状最大的区别。现在 ``main.py`` /
+``unified_launcher`` / ``launch_desktop`` 各自一边判断一边 print，三份判据会漂，
+而判断结果不留任何结构化痕迹。
+
+为什么不给 CLI 造 ``--json`` 子命令树
+------------------------------------
+这个系统的机器面已经是 **388 条 HTTP 路径 + OpenAPI + 生成的 TS 类型 +
+/ws/desktop-presence**，比任何 CLI 的 ``--json`` 都完整。再造一套平行的机器面，
+正是这个仓库反复吃亏的模式（五套面板、两条配置链、四份依赖引导）。
+
+``runtime/startup.json`` 不是"给 AI 的 flag"，它有具体消费方：
+
+1. **排障** —— 启动失败时可以直接把这个文件发出来，看到的是事实不是截图；
+2. **托盘** —— 现在自己去问状态，可以改读它；
+3. **面板** —— ``/api/v1/panel/feed`` 可以带上"上次启动的降级项"；
+4. **``entrypoint.json`` 的上位** —— 那个只有地址，这个有完整启动结论。
+
+版面
+----
+所有几何与颜色都来自 ``core.ascii_art``（``BANNER_WIDTH`` / ``CONTENT_INDENT`` /
+``RULE_WIDTH`` / ``LABEL_COL`` / ``VALUE_COL``、``gradient_rule``）。本模块
+**不自己定义任何宽度、缩进或颜色** —— 三种线宽、三种线条着色、两套填充语义
+的历史就是这么来的。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+from typing import Any, Dict, List, Optional
+
+from core.ascii_art import (
+    GALAXY_VERSION,
+    ansi_supported,
+    print_banner,
+)
+from launcher.record import (
+    EXIT_MEANING,
+    Column,
+    StartupRecord,
+    Status,
+    StepResult,
+)
+
+logger = logging.getLogger("Galaxy.Launcher.UI")
+
+#: 事实的状态 → 显示图标词汇。**唯一的映射点**。
+#: 事实层不知道图标长什么样，这是刻意的（见 record.py 的"刻意的边界"）。
+_STATUS_GLYPH: Dict[Status, str] = {
+    Status.OK: "ok",
+    Status.DEGRADED: "warn",
+    Status.FAILED: "fail",
+    Status.SKIPPED: "info",
+}
+
+#: 结构化启动记录的落盘位置。与 ``runtime/entrypoint.json`` 同目录 —— 后者是
+#: "网关在哪"，前者是"这次启动发生了什么"。
+STARTUP_JSON_RELPATH = os.path.join("runtime", "startup.json")
+
+
+# ---------------------------------------------------------------------------
+# 当前记录（进程级单例）
+# ---------------------------------------------------------------------------
+
+_record: Optional[StartupRecord] = None
+
+
+def begin(version: str = GALAXY_VERSION) -> StartupRecord:
+    """开一份新的启动记录，并返回它。重复调用会重开（用于测试）。"""
+    global _record
+    _record = StartupRecord(version=version)
+    return _record
+
+
+def current() -> StartupRecord:
+    """取当前记录；没有就懒创建。
+
+    懒创建是刻意的：``main.py`` 的极早期阶段（编码修正、路径注入）可能先于
+    显式 :func:`begin` 就产生输出，那时不该因为"还没 begin"而崩掉启动。
+    """
+    global _record
+    if _record is None:
+        _record = StartupRecord(version=GALAXY_VERSION)
+    return _record
+
+
+# ---------------------------------------------------------------------------
+# 唯一咽喉：记一笔 + 立刻渲染一行
+# ---------------------------------------------------------------------------
+
+
+#: 当前栏目。``print_item`` 那 71 个老调用点不带栏目信息，靠 :func:`set_column`
+#: 在阶段切换时设一次，后续的 step 就自动落到对的栏目里 —— 这样 71 个调用点
+#: 一个都不用改，而栏目归属仍然准确。
+_current_column: Column = Column.ENV
+
+
+def set_column(column: Column | str) -> Column:
+    """设定后续 :func:`step` 的默认栏目，返回设定后的值。"""
+    global _current_column
+    _current_column = column if isinstance(column, Column) else Column(column)
+    return _current_column
+
+
+#: 阶段标题里的关键词 → 栏目。按**先匹配先赢**的顺序排列。
+#: 之所以做成关键词匹配而不是精确表：现存三套阶段编号（main 的 Phase 0/2、
+#: SystemOrchestrator 的 Phase 1-7、unified_launcher 自成一套）标题各不相同，
+#: 逐条硬编码会漏，而这些标题里的中文词是稳定的。
+_TITLE_TO_COLUMN: List[tuple] = [
+    ("依赖", Column.DEPS),
+    ("环境", Column.ENV),
+    ("预检", Column.ENV),
+    ("配置", Column.ENV),
+    ("大脑", Column.BRAIN),
+    ("模型", Column.BRAIN),
+    ("桌面", Column.PRESENCE),
+    ("覆盖层", Column.PRESENCE),
+    ("托盘", Column.PRESENCE),
+    ("面板", Column.PRESENCE),
+    ("在场", Column.PRESENCE),
+    ("停止", Column.PRESENCE),
+    ("网关", Column.FABRIC),
+    ("服务", Column.FABRIC),
+    ("节点", Column.FABRIC),
+    ("启动", Column.FABRIC),
+]
+
+
+def column_for_title(title: str) -> Column:
+    """把阶段标题映射到栏目。认不出来时归入「骨干」并留痕。
+
+    刻意**不**在认不出来时抛异常：一个没见过的阶段标题不该让启动崩掉。
+    但也不静默归到「环境」—— 那会让"环境"栏莫名其妙地长出无关项。归入
+    「骨干」（运行时主体）并打 debug，是可恢复且可追查的失败方向。
+    """
+    for keyword, col in _TITLE_TO_COLUMN:
+        if keyword in title:
+            return col
+    logger.debug("阶段标题 %r 没有匹配的栏目，归入「骨干」", title)
+    return Column.FABRIC
+
+
+def step(
+    name: str,
+    status: Status | str = Status.OK,
+    value: str = "",
+    *,
+    column: Column | str | None = None,
+    hint: Optional[str] = None,
+    elapsed_ms: int = 0,
+    **detail: Any,
+) -> StepResult:
+    """记录并立刻打印一项检查结果。
+
+    这是启动路径上**唯一**该调用的输出函数。它同时做两件事：往
+    :class:`StartupRecord` 里记一笔事实，用 ``cli_render.phase`` 打一行。
+
+    之所以能一步到位地接进现有代码：``main.py`` 的 ``print_item()`` 已经是
+    该文件 **71 处调用的唯一咽喉**，内部就走 ``cli_render.phase``。让它转调
+    本函数，输出可以**逐字节不变**，而结构化记录是白得的。
+
+    Args:
+        name:   项目名（进标签列）。
+        status: :class:`Status` 或其字符串值；也接受 ``"ok"/"warn"/"error"/"info"``
+                这些 ``print_item`` 的老词汇（见 :func:`coerce_status`）。
+        value:  给人看的一句话。
+        column: 五栏目之一。
+        hint:   降级/失败时的专属修复建议。
+        detail: 机器可读的原始事实，原样进 ``startup.json``。
+    """
+    st = coerce_status(status)
+    if column is None:
+        col = _current_column
+    else:
+        col = column if isinstance(column, Column) else Column(column)
+    result = StepResult(
+        column=col,
+        name=name,
+        status=st,
+        value=value,
+        hint=hint,
+        detail=dict(detail),
+        elapsed_ms=elapsed_ms,
+    )
+    current().add(result)
+    _print_step(result)
+    return result
+
+
+#: ``print_item`` 的老状态词汇 → 事实层的 :class:`Status`。
+#: 保留这层翻译是为了让 71 个老调用点一个都不用改。
+_LEGACY_STATUS: Dict[str, Status] = {
+    "ok": Status.OK,
+    "success": Status.OK,
+    "warn": Status.DEGRADED,
+    "warning": Status.DEGRADED,
+    "degraded": Status.DEGRADED,
+    "error": Status.FAILED,
+    "fail": Status.FAILED,
+    "failed": Status.FAILED,
+    "info": Status.SKIPPED,
+    "skip": Status.SKIPPED,
+    "skipped": Status.SKIPPED,
+}
+
+
+def coerce_status(status: Status | str) -> Status:
+    """把各处的状态词汇归一到 :class:`Status`。
+
+    注意 ``"info"`` 映射到 ``SKIPPED`` 而不是 ``OK``：``print_item(..., "info")``
+    在现有代码里表达的是"这项没做/仅提示"，把它算成 OK 会让总结卡的"N 正常"
+    虚高 —— 而那个数字是用户判断"能不能用"的第一眼依据。
+    """
+    if isinstance(status, Status):
+        return status
+    return _LEGACY_STATUS.get(str(status).strip().lower(), Status.SKIPPED)
+
+
+def _print_step(result: StepResult) -> None:
+    """打一行。走 ``cli_render``；它不可用时降级为纯 ASCII（Windows cp1252 安全）。"""
+    try:
+        from core import cli_render as r
+
+        r.phase(result.name, result.value, _STATUS_GLYPH[result.status])
+        return
+    except Exception:  # noqa: BLE001 — 渲染失败绝不能挡启动
+        pass
+    icon = {
+        Status.OK: "[OK]",
+        Status.DEGRADED: "[WARN]",
+        Status.FAILED: "[ERR]",
+        Status.SKIPPED: "[INFO]",
+    }[result.status]
+    line = f"  {icon} {result.name}" + (f"  ({result.value})" if result.value else "")
+    try:
+        print(line)
+    except UnicodeEncodeError:
+        try:
+            print(line.encode("cp1252", errors="replace").decode("cp1252"))
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def section(title: str) -> None:
+    """栏目小标题（``-v`` 展开时用）。走 ``cli_render.section``。"""
+    try:
+        from core import cli_render as r
+
+        r.section(title)
+    except Exception:  # noqa: BLE001
+        print(f"\n  {title}")
+
+
+def rule() -> None:
+    """一条与横幅同渐变的横线。"""
+    try:
+        from core import cli_render as r
+
+        r.rule()
+    except Exception:  # noqa: BLE001
+        from core.ascii_art import gradient_rule
+
+        print(gradient_rule())
+
+
+# ---------------------------------------------------------------------------
+# 渲染器 A：人看的
+# ---------------------------------------------------------------------------
+
+
+def render_banner() -> None:
+    """横幅。原样走 ``ascii_art.print_banner``，一个像素不改。"""
+    print_banner()
+
+
+def render_tui(rec: Optional[StartupRecord] = None, *, verbose: bool = False) -> None:
+    """把整份记录渲染成栏目式概览 + 总结卡。
+
+    与逐行 :func:`step` 的关系：``step`` 是**过程中**的即时反馈（一行一项），
+    本函数是**结尾**的一屏概览（一栏一行）。两者都读同一份事实，不重复判断。
+    """
+    rec = rec if rec is not None else current()
+    from core import cli_render as r
+
+    print()
+    for col in rec.columns_in_order():
+        steps = rec.by_column(col)
+        worst = _worst(steps)
+        r.phase(col.value, _column_summary(steps), _STATUS_GLYPH[worst])
+        if verbose:
+            for s in steps:
+                r.detail(s.name, s.value, _STATUS_GLYPH[s.status])
+
+    degraded = [(s.name, s.hint) for s in rec.degraded + rec.failed]
+    rows: List[tuple] = []
+    if rec.gateway_url:
+        rows.append(("网关", rec.gateway_url))
+    if rec.brain:
+        rows.append(("大脑", rec.brain))
+    if rec.shell:
+        rows.append(("桌面壳", rec.shell))
+
+    r.summary_card(
+        title=f"用时 {rec.elapsed_s:.1f}s",
+        state_ok=rec.ok_count,
+        state_degraded=len(rec.degraded) + len(rec.failed),
+        rows=rows,
+        degraded=degraded or None,
+        hints=[("记录", STARTUP_JSON_RELPATH)],
+    )
+
+
+def _worst(steps: List[StepResult]) -> Status:
+    """一栏的结论取其中**最差**的一项 —— 一栏里有失败就不能显示为正常。"""
+    for st in (Status.FAILED, Status.DEGRADED, Status.OK):
+        if any(s.status is st for s in steps):
+            return st
+    return Status.SKIPPED
+
+
+def _column_summary(steps: List[StepResult]) -> str:
+    """一栏折叠成一句话：优先显示有名有姓的正常项，降级/失败单独点名。"""
+    bad = [s.name for s in steps if s.status in (Status.DEGRADED, Status.FAILED)]
+    good = [s.value or s.name for s in steps if s.status is Status.OK and (s.value or s.name)]
+    parts: List[str] = []
+    if good:
+        parts.append(" · ".join(good[:3]))
+        if len(good) > 3:
+            parts.append(f"等 {len(good)} 项")
+    if bad:
+        parts.append("降级：" + "、".join(bad))
+    skipped = sum(1 for s in steps if s.status is Status.SKIPPED)
+    if skipped and not parts:
+        parts.append(f"{skipped} 项跳过")
+    return " · ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# 渲染器 B：机器读的
+# ---------------------------------------------------------------------------
+
+
+def render_json(rec: Optional[StartupRecord] = None, *, root: Optional[str] = None) -> Optional[str]:
+    """把记录写到 ``runtime/startup.json``，返回写入路径（失败返回 None）。
+
+    写失败**绝不能挡启动** —— 这是排障辅助，不是启动的必要条件。失败只记
+    warning：静默吞掉会让"文件为什么不见了"变成第二个谜。
+    """
+    rec = rec if rec is not None else current()
+    try:
+        base = pathlib.Path(root) if root else pathlib.Path(__file__).resolve().parent.parent
+        out = base / STARTUP_JSON_RELPATH
+        out.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(rec.to_dict(), indent=2, ensure_ascii=False)
+        try:
+            from core.atomic_json import atomic_write_text  # type: ignore
+
+            atomic_write_text(str(out), payload)
+        except Exception:  # noqa: BLE001 — 没有原子写就退回普通写
+            out.write_text(payload, encoding="utf-8")
+        return str(out)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("写 %s 失败（不影响启动）：%s", STARTUP_JSON_RELPATH, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 渲染器 C：日志
+# ---------------------------------------------------------------------------
+
+
+def render_log(rec: Optional[StartupRecord] = None) -> None:
+    """把记录逐行写进日志。日志里不带任何 ANSI。"""
+    rec = rec if rec is not None else current()
+    for s in rec.steps:
+        try:
+            logger.info(
+                "[%s] %s = %s%s",
+                s.column.value,
+                s.name,
+                s.status.value,
+                f" ({s.value})" if s.value else "",
+            )
+        except UnicodeEncodeError:
+            pass
+    try:
+        logger.info(
+            "启动结束 exit=%s(%s) 用时=%.1fs 正常=%d 降级=%d 失败=%d",
+            rec.exit_code,
+            EXIT_MEANING.get(rec.exit_code, "未知"),
+            rec.elapsed_s,
+            rec.ok_count,
+            len(rec.degraded),
+            len(rec.failed),
+        )
+    except UnicodeEncodeError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 收尾
+# ---------------------------------------------------------------------------
+
+
+def finish(exit_code: int = 0, *, verbose: bool = False, tui: bool = True) -> StartupRecord:
+    """封盘：定 exit_code、渲染总览、落盘、写日志。返回记录本身。"""
+    import time
+
+    rec = current()
+    rec.exit_code = exit_code
+    rec.finished_at = time.time()
+    if tui:
+        try:
+            render_tui(rec, verbose=verbose)
+        except Exception as exc:  # noqa: BLE001 — 渲染失败不该改变退出码
+            logger.warning("启动总览渲染失败（不影响启动结果）：%s", exc)
+    render_json(rec)
+    render_log(rec)
+    return rec
+
+
+def color_enabled() -> bool:
+    """当前是否会输出颜色。供调用方决定要不要走带色的分支。"""
+    return ansi_supported()

--- a/main.py
+++ b/main.py
@@ -76,12 +76,14 @@ def load_env_files_into_environ(root: str = "") -> None:
 #   - webrtcvad → "pkg_resources is deprecated"(setuptools 弃用,第三方未适配)
 #   - pywinauto → "Revert to STA COM threading mode"(Windows COM 线程模式提示)
 import warnings as _warnings
+
 try:
     _warnings.filterwarnings("ignore", message=r".*pkg_resources is deprecated.*")
     _warnings.filterwarnings("ignore", message=r".*Revert to STA COM threading mode.*")
     _warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"webrtcvad.*")
 except Exception:
     pass
+
 
 def configure_windows_console() -> None:
     """Windows 控制台 UTF-8 + 进程优先级。
@@ -101,6 +103,7 @@ def configure_windows_console() -> None:
     # CRITICAL: must reconfigure BOTH stdout AND stderr — logging uses stderr by default
     try:
         import io
+
         if hasattr(sys.stdout, "buffer"):
             sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace", line_buffering=True)
         if hasattr(sys.stderr, "buffer"):
@@ -112,6 +115,7 @@ def configure_windows_console() -> None:
     # PR-D7: Set process priority (Windows only)
     try:
         import psutil
+
         p = psutil.Process()
         p.nice(psutil.HIGH_PRIORITY_CLASS)
     except Exception:
@@ -202,7 +206,12 @@ import logging
 import argparse
 from pathlib import Path
 
-from core.ascii_art import print_banner, print_section_header
+from core.ascii_art import (
+    GALAXY_TAGLINE,
+    GALAXY_VERSION,
+    print_banner,
+    print_section_header,
+)
 
 # ── Phase output helpers ──────────────────────────────────
 _PHASE_WIDTH = 60
@@ -214,8 +223,17 @@ def print_phase(title: str) -> None:
     统一走 core.cli_render（与启动后半段同一套 clig.dev 风格：细线 + 干净标题，
     而非旧的 ═══×60 大框）——让【整个克隆界面】前后一致。cli_render 不可用时兜底回旧风格。
     """
+    # 阶段切换时把「当前栏目」定下来，后续 print_item 的记录自动落到对的栏目。
+    # 这样 71 个 print_item 调用点一个都不用改，栏目归属仍然准确。
+    try:
+        from launcher import ui as _ui
+
+        _ui.set_column(_ui.column_for_title(title))
+    except Exception:  # noqa: BLE001 — 记录层不可用绝不能挡启动
+        pass
     try:
         from core import cli_render as r
+
         r.section(title)
     except Exception:
         print_section_header(title)  # 极端环境兜底
@@ -237,14 +255,21 @@ def print_item(name: str, status: str = "ok", detail: str = "") -> None:
         status: "ok" | "warn" | "error" | "info".
         detail: Optional detail text shown dimmed.
     """
-    _status_map = {"ok": "ok", "warn": "warn", "error": "fail", "info": "info"}
+    # 唯一咽喉：交给 launcher.ui.step —— 它同时【记一笔结构化事实】和【打这一行】。
+    #
+    # 输出逐字节不变：ui.step 内部还是走 cli_render.phase，用的是同一组几何常量
+    # (CONTENT_INDENT/ICON_COL/LABEL_COL)。变的是每一项现在都留下了痕迹，最终
+    # 落到 runtime/startup.json —— 启动失败时可以直接把那个文件发出来，而不是
+    # 截一张彩色终端的图让人猜。
+    #
+    # 用 phase()(2 格缩进,标签第 4 列)而非 detail()(6 格缩进)——让 Phase 0/1/2
+    # 的状态项与「系统启动」后的运行时项(核心服务/基础设施/... 也走 phase)以及
+    # ▶ 启动行处在【同一列】。此前 Phase 段 6 格、运行时段 2 格,对勾对不齐。
     printed = False
     try:
-        from core import cli_render as r
-        # 用 phase()(2 格缩进,标签第 4 列)而非 detail()(6 格缩进)——让 Phase 0/1/2
-        # 的状态项与「系统启动」后的运行时项(核心服务/基础设施/... 也走 phase)以及
-        # ▶ 启动行处在【同一列】。此前 Phase 段 6 格、运行时段 2 格,对勾对不齐。
-        r.phase(name, detail, _status_map.get(status, "info"))
+        from launcher import ui as _ui
+
+        _ui.step(name, status, detail)
         printed = True
     except Exception:
         printed = False
@@ -339,7 +364,9 @@ log_dir.mkdir(exist_ok=True)
 # call basicConfig; repeated calls are no-ops after the first.
 if not logging.getLogger().handlers:
     handler = RotatingFileHandler(
-        str(log_dir / "lumiv.log"), maxBytes=10 * 1024 * 1024, backupCount=5,
+        str(log_dir / "lumiv.log"),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=5,
         encoding="utf-8",
     )
     _console = SafeStreamHandler()
@@ -366,6 +393,7 @@ logger = logging.getLogger("Galaxy")
 # 平时零输出、零行为影响;装不上也静默兜底,绝不影响主进程。
 try:
     from core.ollama_url_sentinel import install as _install_url_sentinel
+
     _install_url_sentinel()
 except Exception:  # noqa: BLE001
     pass
@@ -378,14 +406,13 @@ _failed_validations: list = []
 # Authority declaration — referenced by validate_runtime.py and CI guardrails
 # ---------------------------------------------------------------------------
 
-SYSTEM_ORCHESTRATOR_AUTHORITY: str = (
-    "main.py:SYSTEM_ORCHESTRATOR — canonical staged bring-up contract (PR-2)"
-)
+SYSTEM_ORCHESTRATOR_AUTHORITY: str = "main.py:SYSTEM_ORCHESTRATOR — canonical staged bring-up contract (PR-2)"
 
 
 # ---------------------------------------------------------------------------
 # Orchestrator bring-up sequence
 # ---------------------------------------------------------------------------
+
 
 def _is_strict_preflight() -> bool:
     """Return True when GALAXY_STRICT_PREFLIGHT is set to a truthy value.
@@ -417,6 +444,7 @@ def _run_orchestrator_preflight() -> bool:
     strict = _is_strict_preflight()
     try:
         from core.system_orchestrator import SystemOrchestrator
+
         orch = SystemOrchestrator(continue_on_failure=False, strict_preflight=strict)
         summary = orch.run_startup_sequence()
         logger.info("Orchestrator bring-up complete:\n%s", summary)
@@ -513,8 +541,10 @@ def phase0_env_check() -> dict:
             from core.config_store import get_config_store
 
             for key, val in get_config_store().read_secrets().items():
-                if val and not val.lower().startswith(PLACEHOLDER_PREFIXES) and any(
-                    k in key.upper() for k in ["API_KEY", "KEY"]
+                if (
+                    val
+                    and not val.lower().startswith(PLACEHOLDER_PREFIXES)
+                    and any(k in key.upper() for k in ["API_KEY", "KEY"])
                 ):
                     seen_keys.add(key.upper())
         except Exception:
@@ -537,7 +567,9 @@ def phase0_env_check() -> dict:
     npm_ok = npm_exe is not None
     if npm_ok:
         try:
-            rc = sp.run([npm_exe, "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5)
+            rc = sp.run(
+                [npm_exe, "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5
+            )
             npm_ver = rc.stdout.strip() if rc.returncode == 0 else "?"
             print_item("npm", "ok", npm_ver)
         except Exception:
@@ -551,7 +583,9 @@ def phase0_env_check() -> dict:
     node_ok = shutil.which("node") is not None
     if node_ok:
         try:
-            rc = sp.run(["node", "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5)
+            rc = sp.run(
+                ["node", "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5
+            )
             node_ver = rc.stdout.strip() if rc.returncode == 0 else "?"
             print_item("Node.js", "ok", node_ver)
         except Exception:
@@ -568,6 +602,7 @@ def phase0_env_check() -> dict:
     if npm_ok:
         try:
             from core.electron_launch_guard import electron_package_intact
+
             electron_deps_ok = electron_package_intact(str(ELECTRON_DIR))
         except Exception:
             electron_deps_ok = (ELECTRON_DIR / "node_modules").exists()
@@ -620,20 +655,21 @@ def phase2_ensure_deps(env_status: dict) -> bool:
 
     def _run_pip_install(pkgs: list, timeout: int = 900) -> bool:
         """逐镜像候选安装 pkgs,全部失败才返回 False(诚实上报)。"""
-        base = [sys.executable, "-m", "pip", "install",
-                "--retries", "3", "--timeout", "60"] + pkgs
+        base = [sys.executable, "-m", "pip", "install", "--retries", "3", "--timeout", "60"] + pkgs
         for idx, index_url in enumerate(_PIP_INDEX_CANDIDATES):
             cmd = list(base)
             if index_url:
                 cmd += ["-i", index_url]
-                print_item(f"回退镜像源 {idx}/{len(_PIP_INDEX_CANDIDATES) - 1}",
-                           "warn", index_url)
+                print_item(f"回退镜像源 {idx}/{len(_PIP_INDEX_CANDIDATES) - 1}", "warn", index_url)
             try:
                 if sp.run(cmd, timeout=timeout).returncode == 0:
                     return True
             except sp.TimeoutExpired:
-                print_item(f"pip 安装超时({timeout}s)", "warn",
-                           "镜像候选轮换中" if idx < len(_PIP_INDEX_CANDIDATES) - 1 else "")
+                print_item(
+                    f"pip 安装超时({timeout}s)",
+                    "warn",
+                    "镜像候选轮换中" if idx < len(_PIP_INDEX_CANDIDATES) - 1 else "",
+                )
             except Exception as exc:
                 print_item(f"pip 安装异常: {exc}", "warn")
         return False
@@ -646,7 +682,11 @@ def phase2_ensure_deps(env_status: dict) -> bool:
         try:
             rc = sp.run(
                 [sys.executable, "-m", "ensurepip", "--upgrade"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=60,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
             ).returncode
             if rc == 0:
                 pip_fixed = True
@@ -657,16 +697,29 @@ def phase2_ensure_deps(env_status: dict) -> bool:
         if not pip_fixed:
             try:
                 import tempfile
+
                 get_pip_tmp = os.path.join(tempfile.gettempdir(), "get-pip.py")
-                rc = sp.run([
-                    sys.executable, "-c",
-                    f"import urllib.request; "
-                    f"urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', r'{get_pip_tmp}')",
-                ], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30).returncode
+                rc = sp.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        f"import urllib.request; "
+                        f"urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', r'{get_pip_tmp}')",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=30,
+                ).returncode
                 if rc == 0:
                     rc2 = sp.run(
                         [sys.executable, get_pip_tmp],
-                        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=60,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        timeout=60,
                     ).returncode
                     if rc2 == 0:
                         pip_fixed = True
@@ -690,9 +743,9 @@ def phase2_ensure_deps(env_status: dict) -> bool:
         "nats": "nats-py",
         "websockets": "websockets",
         # 依赖审计补齐:被核心能力真实 import,补进自动安装(与 requirements.txt 一致)
-        "jsonschema": "jsonschema",          # 事件总线 schema 校验
+        "jsonschema": "jsonschema",  # 事件总线 schema 校验
         "huggingface_hub": "huggingface-hub",  # 本地模型 HF 下载 + Ollama 回退
-        "tqdm": "tqdm",                       # 模型下载进度条
+        "tqdm": "tqdm",  # 模型下载进度条
         # 语音输出(TTS)默认引擎。此前不在自动安装名单、requirements-windows.txt
         # 也没有 → 真机全新克隆缺包,speech_output 每次合成静默失败,表现为
         # "回复文字出来了、一句话都不说"。包本身很小(纯 HTTP 客户端)。
@@ -744,7 +797,9 @@ def phase2_ensure_deps(env_status: dict) -> bool:
     if not env_status.get("npm_installed"):
         # 若用户已手动安装 Node.js（如 v24 等任意版本），直接复用
         if shutil.which("node") and shutil.which("npm"):
-            node_ver = sp.run(["node", "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10).stdout.strip()
+            node_ver = sp.run(
+                ["node", "--version"], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10
+            ).stdout.strip()
             print_item(f"检测到 Node.js {node_ver}，跳过自动安装", "ok")
             env_status["npm_installed"] = True
         else:
@@ -760,6 +815,7 @@ def phase2_ensure_deps(env_status: dict) -> bool:
             else:
                 try:
                     import platform
+
                     machine = platform.machine().lower()
                     node_ver = "v20.11.0"
                     node_arch = "linux-arm64" if "arm" in machine or "aarch64" in machine else "linux-x64"
@@ -777,8 +833,7 @@ def phase2_ensure_deps(env_status: dict) -> bool:
                     rc = 1
                     for _node_url in _node_urls:
                         rc = sp.run(
-                            ["curl", "-fL", "--progress-bar", "--retry", "3",
-                             "-o", str(node_tmp), _node_url],
+                            ["curl", "-fL", "--progress-bar", "--retry", "3", "-o", str(node_tmp), _node_url],
                             timeout=300,
                         ).returncode
                         if rc == 0:
@@ -788,7 +843,11 @@ def phase2_ensure_deps(env_status: dict) -> bool:
                         node_dest.parent.mkdir(parents=True, exist_ok=True)
                         rc2 = sp.run(
                             ["tar", "-xf", str(node_tmp), "-C", str(node_dest.parent), "--strip-components=1"],
-                            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30,
+                            capture_output=True,
+                            text=True,
+                            encoding="utf-8",
+                            errors="replace",
+                            timeout=30,
                         ).returncode
                         if rc2 == 0 or (node_dest.parent / "bin" / "node").exists():
                             bin_dir = node_dest.parent / "bin"
@@ -823,6 +882,7 @@ def phase2_ensure_deps(env_status: dict) -> bool:
     if npm_cmd and not env_status.get("electron_deps_ok"):
         try:
             from core.electron_launch_guard import electron_package_intact
+
             if electron_package_intact(str(ELECTRON_DIR)):
                 env_status["electron_deps_ok"] = True
                 print_item("Electron 依赖已就绪(启动早期阶段已装好)", "ok")
@@ -848,8 +908,7 @@ def phase2_ensure_deps(env_status: dict) -> bool:
         # (electron 二进制镜像, 附加 npm registry 参数)候选,逐个尝试。
         _attempts = [
             ("https://npmmirror.com/mirrors/electron/", []),
-            ("https://registry.npmmirror.com/-/binary/electron/",
-             ["--registry=https://registry.npmmirror.com"]),
+            ("https://registry.npmmirror.com/-/binary/electron/", ["--registry=https://registry.npmmirror.com"]),
             ("", []),  # 最后回退官方源(直连 GitHub 良好的用户)
         ]
 
@@ -862,7 +921,8 @@ def phase2_ensure_deps(env_status: dict) -> bool:
                 return sp.run(
                     [npm_cmd, "install", *_npm_net_flags, *extra],
                     cwd=str(ELECTRON_DIR),
-                    env=env, timeout=900,
+                    env=env,
+                    timeout=900,
                 ).returncode
             except Exception as exc:  # noqa: BLE001
                 print_item(f"npm install 异常: {exc}", "warn")
@@ -879,7 +939,8 @@ def phase2_ensure_deps(env_status: dict) -> bool:
             print_item("Electron 依赖就绪", "ok")
         else:
             print_item(
-                "npm install 仍失败", "warn",
+                "npm install 仍失败",
+                "warn",
                 "可手动: cd electron && npm install --registry=https://registry.npmmirror.com",
             )
 
@@ -892,7 +953,11 @@ def phase2_ensure_deps(env_status: dict) -> bool:
         try:
             rc = sp.run(
                 ["ollama", "list"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=15,
             )
             if rc.returncode == 0 and rc.stdout.strip():
                 models = [line.split()[0] for line in rc.stdout.strip().split("\n")[1:] if line.strip()]
@@ -942,16 +1007,18 @@ def phase2_ensure_deps(env_status: dict) -> bool:
         # faster-whisper 会拉几百 MB),且依赖网络/镜像,一旦卡住/失败就把首启拖死或拖挂。
         # 语音是【可选】的麦克风路径(缺了远程/文字路径照常可用),故改为清晰引导按需手动装。
         print_item(f"语音依赖缺失(可选,麦克风路径用): {', '.join(voice_missing)}", "warn")
-        print_item("按需手动安装(不自动装以免拖慢/挂死首启)", "warn",
-                   f"pip install {' '.join(voice_missing)}  —— 或 `python main.py setup`")
+        print_item(
+            "按需手动安装(不自动装以免拖慢/挂死首启)",
+            "warn",
+            f"pip install {' '.join(voice_missing)}  —— 或 `python main.py setup`",
+        )
 
     # pyaudio (needs system libs;同样不在首启现装)
     try:
         __import__("pyaudio")
         print_item("PyAudio", "ok")
     except Exception:
-        print_item("PyAudio 未安装(可选)", "warn",
-                   "手动: apt install portaudio19-dev && pip install pyaudio")
+        print_item("PyAudio 未安装(可选)", "warn", "手动: apt install portaudio19-dev && pip install pyaudio")
 
     # OTLP 导出器(可选;真正导出追踪数据到 Jaeger/Tempo 等后端时才需要,依赖较重
     # 的 grpcio,默认 GALAXY_OTEL_EXPORTER 未设时用不上——不在首启阻塞安装,
@@ -991,6 +1058,7 @@ def _run_setup_wizard() -> int:
 # Main entry-point
 # ---------------------------------------------------------------------------
 
+
 def _apply_model_cli_args(args) -> None:
     """把 --model / --select-model 应用到环境变量；真正的主脑选择移到 Phase 5「AI 大脑」进行
     （不在开头打断）。--select-model 清除已保存选择以触发重新选择。"""
@@ -1000,8 +1068,7 @@ def _apply_model_cli_args(args) -> None:
         if getattr(args, "select_model", False):
             # 清除已保存选择以触发重新选择。主脑现收敛在 model_catalog 的统一记录
             # (runtime/model_state.json);连旧的 .galaxy_model 一并清掉(迁移期兼容)。
-            for _p in (PROJECT_ROOT / "runtime" / "model_state.json",
-                       PROJECT_ROOT / ".galaxy_model"):
+            for _p in (PROJECT_ROOT / "runtime" / "model_state.json", PROJECT_ROOT / ".galaxy_model"):
                 try:
                     _p.unlink()
                 except Exception:
@@ -1013,22 +1080,34 @@ def _apply_model_cli_args(args) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Galaxy V2 Unified Entry")
+    # --version：CLI 该知道自己的版本。此前 GALAXY_VERSION 只印在横幅里，
+    # 脚本/排障想拿版本号只能去 grep 源码或截横幅。
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"Galaxy {GALAXY_VERSION} — {GALAXY_TAGLINE}",
+        help="打印版本号后退出",
+    )
     parser.add_argument("--setup", action="store_true", help="Run interactive setup wizard")
     # Accept --host/--port so the documented start command
     # (`python main.py --host 127.0.0.1 --port 9000`) works instead of crashing
     # with "unrecognized arguments".  Default None ⇒ keep the config default.
     parser.add_argument("--host", type=str, default=None, help="API 服务监听地址 (默认取配置)")
     parser.add_argument("--port", "-p", type=int, default=None, help="API 服务端口 (默认 9000)")
-    parser.add_argument("--model", type=str, default=None,
-                        help="指定本地主脑模型 tag（跳过交互选择，如 gemma4:12b / openbmb/minicpm-o4.5）")
-    parser.add_argument("--select-model", action="store_true",
-                        help="强制重新选择 AI 主脑模型（清除已保存选择）")
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="详细模式：展开每个启动阶段的逐项明细（默认折叠成一行）")
-    parser.add_argument("--autostart", action="store_true",
-                        help="(Windows) 注册开机自启：开机/被 WOL 盒子唤醒后自动拉起 Galaxy + 托盘")
-    parser.add_argument("--autostart-remove", action="store_true",
-                        help="(Windows) 取消开机自启")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="指定本地主脑模型 tag（跳过交互选择，如 gemma4:12b / openbmb/minicpm-o4.5）",
+    )
+    parser.add_argument("--select-model", action="store_true", help="强制重新选择 AI 主脑模型（清除已保存选择）")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="详细模式：展开每个启动阶段的逐项明细（默认折叠成一行）"
+    )
+    parser.add_argument(
+        "--autostart", action="store_true", help="(Windows) 注册开机自启：开机/被 WOL 盒子唤醒后自动拉起 Galaxy + 托盘"
+    )
+    parser.add_argument("--autostart-remove", action="store_true", help="(Windows) 取消开机自启")
     args = parser.parse_args()
 
     # -v 同时落到环境变量：子模块（unified_launcher 等）无需逐层透传即可读到。
@@ -1040,6 +1119,7 @@ def main() -> int:
     if args.autostart or args.autostart_remove:
         try:
             from windows_service import autostart as _as
+
             if args.autostart_remove:
                 print_item(f"取消开机自启: {_as.unregister_all()}", "ok")
             else:
@@ -1119,6 +1199,7 @@ def main() -> int:
         # ── Galaxy WebSocket Bridge — 桌面覆盖层事件推送 ──
         try:
             from core.lumiv_websocket_bridge import GalaxyPresenceBridge
+
             _ws_bridge = GalaxyPresenceBridge.get_instance()
             asyncio.create_task(_ws_bridge.start())
         except Exception as _exc:
@@ -1129,10 +1210,14 @@ def main() -> int:
     # 必须在 asyncio.run 之前装策略;内置子进程探针,失败自动还原默认(宁慢勿哑)。
     try:
         from core.fast_loop import install_fast_loop
+
         install_fast_loop()
     except Exception:
         pass  # 缺包/异常都走默认循环,零影响
 
+    from launcher import record as _record
+
+    _exit_code = 0
     try:
         asyncio.run(_run())
     except KeyboardInterrupt:
@@ -1141,8 +1226,20 @@ def main() -> int:
         print_item("正在优雅关闭所有服务...", "ok")
         lumiv.stop()
         print_item("所有服务已停止", "ok")
+        # 被中断不是"成功"。沿用 shell 惯例 128+SIGINT(2)=130,让自动化能区分
+        # "用户按了 Ctrl+C" 和 "正常退出" —— 此前两者都返回 0。
+        _exit_code = _record.EXIT_INTERRUPTED
 
-    return 0
+    # 封盘：定 exit_code、落 runtime/startup.json、写日志。
+    # 写失败不改变退出码（那只是排障辅助，不是启动的必要条件）。
+    try:
+        from launcher import ui as _ui
+
+        _ui.finish(_exit_code, verbose=bool(os.environ.get("GALAXY_VERBOSE")), tui=False)
+    except Exception:  # noqa: BLE001
+        pass
+
+    return _exit_code
 
 
 if __name__ == "__main__":

--- a/tests/test_launcher_record_and_ui.py
+++ b/tests/test_launcher_record_and_ui.py
@@ -1,0 +1,298 @@
+"""启动记录：事实与呈现的分离，以及三个渲染器读同一份事实。
+
+要钉住什么
+----------
+启动器此前是"一边判断一边 ``print``"，判断结果只以彩色文本的形式存在过一瞬。
+后果是启动失败时只能拿到截图、托盘/面板各自再问一遍状态、"上次降级了什么"
+无处可查。
+
+``launcher/record.py`` 持有事实，``launcher/ui.py`` 渲染。这个文件钉的是
+**这条分离不许被抹平**，以及三个渲染器确实读的是同一份事实（不是各自重算）。
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import io
+import json
+import pathlib
+
+import pytest
+
+from launcher import record as REC
+from launcher import ui as UI
+from launcher.record import Column, StartupRecord, Status, StepResult
+
+
+@pytest.fixture(autouse=True)
+def _fresh_record():
+    """每条用例开一份干净记录，避免互相污染（记录是进程级单例）。"""
+    UI.begin("vTEST")
+    UI.set_column(Column.ENV)
+    yield
+    UI.begin("vTEST")
+
+
+# ---------------------------------------------------------------------------
+# 1. 分离本身
+# ---------------------------------------------------------------------------
+
+
+class TestSeparationOfFactsFromPresentation:
+    def test_record_module_imports_nothing_presentational(self) -> None:
+        """``record.py`` 里不许出现任何渲染相关的 import。
+
+        一旦事实层知道了自己会被怎么显示，分离就失效了 —— 那正是现状的病根。
+        用 AST 查而不是 grep 字符串：注释里提到 ``cli_render`` 是可以的
+        （record.py 的 docstring 就提了），真 import 才不行。
+        """
+        tree = ast.parse((pathlib.Path(REC.__file__)).read_text(encoding="utf-8"))
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported += [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        forbidden = [m for m in imported if any(k in m for k in ("cli_render", "ascii_art", "ui"))]
+        assert not forbidden, f"事实层 import 了呈现层：{forbidden}"
+
+    def test_record_has_no_color_or_glyph_vocabulary(self) -> None:
+        """事实层里不该出现颜色码、图标字符或缩进常量。"""
+        src = pathlib.Path(REC.__file__).read_text(encoding="utf-8")
+        # 只查代码，不查注释/docstring —— 注释里说明"图标映射在 ui.py"是合理的
+        tree = ast.parse(src)
+        literals: list[str] = [
+            n.value for n in ast.walk(tree) if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        ]
+        docstrings = {
+            ast.get_docstring(n) for n in ast.walk(tree) if isinstance(n, (ast.Module, ast.ClassDef, ast.FunctionDef))
+        }
+        code_literals = [s for s in literals if s not in docstrings]
+        bad = [s for s in code_literals if "\x1b[" in s or any(g in s for g in ("✓", "⚠", "✗", "◐"))]
+        assert not bad, f"事实层出现了呈现层词汇：{bad}"
+
+    def test_glyph_mapping_lives_only_in_ui(self) -> None:
+        """状态 → 图标的映射必须只有一处。"""
+        assert set(UI._STATUS_GLYPH) == set(Status), "有 Status 没有对应的显示词汇"
+
+
+# ---------------------------------------------------------------------------
+# 2. step() 这个咽喉
+# ---------------------------------------------------------------------------
+
+
+class TestStepIsTheChokePoint:
+    def test_step_records_and_prints(self, capsys: pytest.CaptureFixture) -> None:
+        UI.step("Python", Status.OK, "3.11.15", column=Column.ENV, executable="/usr/bin/python3")
+        out = capsys.readouterr().out
+        assert "Python" in out and "3.11.15" in out
+        rec = UI.current()
+        assert len(rec.steps) == 1
+        s = rec.steps[0]
+        assert s.column is Column.ENV and s.status is Status.OK
+        assert s.detail["executable"] == "/usr/bin/python3"
+
+    @pytest.mark.parametrize(
+        "legacy,expected",
+        [
+            ("ok", Status.OK),
+            ("warn", Status.DEGRADED),
+            ("error", Status.FAILED),
+            ("info", Status.SKIPPED),
+            ("完全没见过的词", Status.SKIPPED),
+        ],
+    )
+    def test_legacy_status_vocabulary_is_translated(self, legacy: str, expected: Status) -> None:
+        """``print_item`` 那 71 个老调用点用的是 ok/warn/error/info。"""
+        assert UI.coerce_status(legacy) is expected
+
+    def test_info_counts_as_skipped_not_ok(self) -> None:
+        """``print_item(..., "info")`` 表达的是"仅提示"，算成 OK 会让"N 正常"虚高。
+
+        那个数字是用户判断"能不能用"的第一眼依据，虚高比少报更危险。
+        """
+        UI.step("提示项", "info")
+        assert UI.current().ok_count == 0
+
+    def test_column_defaults_to_the_current_column(self) -> None:
+        """``set_column`` 之后的 step 自动归入该栏 —— 71 个老调用点因此不用改。"""
+        UI.set_column(Column.BRAIN)
+        UI.step("模型", Status.OK, "qwen3:8b")
+        assert UI.current().steps[-1].column is Column.BRAIN
+
+    @pytest.mark.parametrize(
+        "title,expected",
+        [
+            ("[Phase 0] 环境检查", Column.ENV),
+            ("[Phase 2] 依赖确保", Column.DEPS),
+            ("[Phase 1] 系统预检", Column.ENV),
+            ("[系统启动]", Column.FABRIC),
+            ("[系统停止]", Column.PRESENCE),
+            ("AI 大脑", Column.BRAIN),
+            ("桌面覆盖层", Column.PRESENCE),
+        ],
+    )
+    def test_phase_titles_map_to_columns(self, title: str, expected: Column) -> None:
+        """现存三套阶段编号的标题都要能归到栏目。"""
+        assert UI.column_for_title(title) is expected
+
+    def test_unknown_title_falls_back_without_crashing(self) -> None:
+        """没见过的标题不该让启动崩，也不该污染「环境」栏。"""
+        assert UI.column_for_title("某个从未出现过的标题") is Column.FABRIC
+
+
+# ---------------------------------------------------------------------------
+# 3. 汇总只算数，不决定显示
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAggregation:
+    def _rec(self) -> StartupRecord:
+        r = StartupRecord(version="vTEST")
+        r.add(StepResult(Column.ENV, "a", Status.OK))
+        r.add(StepResult(Column.ENV, "b", Status.DEGRADED, hint="修 b"))
+        r.add(StepResult(Column.FABRIC, "c", Status.FAILED))
+        r.add(StepResult(Column.BRAIN, "d", Status.SKIPPED))
+        return r
+
+    def test_counts(self) -> None:
+        r = self._rec()
+        assert r.ok_count == 1
+        assert [s.name for s in r.degraded] == ["b"]
+        assert [s.name for s in r.failed] == ["c"]
+
+    def test_columns_in_order_skips_empty_ones(self) -> None:
+        r = self._rec()
+        assert r.columns_in_order() == [Column.ENV, Column.FABRIC, Column.BRAIN]
+
+    def test_worst_status_wins_per_column(self) -> None:
+        """一栏里有失败就不能显示为正常 —— 折叠不该把问题折没。"""
+        r = self._rec()
+        assert UI._worst(r.by_column(Column.ENV)) is Status.DEGRADED
+        assert UI._worst(r.by_column(Column.FABRIC)) is Status.FAILED
+
+
+# ---------------------------------------------------------------------------
+# 4. 三个渲染器读同一份事实
+# ---------------------------------------------------------------------------
+
+
+class TestThreeRenderersOneTruth:
+    def test_json_contains_every_step(self, tmp_path: pathlib.Path) -> None:
+        UI.step("A", Status.OK, "1", column=Column.ENV, probe="x")
+        UI.step("B", Status.DEGRADED, "2", column=Column.FABRIC, hint="修 B")
+        UI.finish(REC.EXIT_OK, tui=False)
+        UI.render_json(root=str(tmp_path))
+        data = json.loads((tmp_path / "runtime" / "startup.json").read_text(encoding="utf-8"))
+        assert [s["name"] for s in data["steps"]] == ["A", "B"]
+        assert data["steps"][0]["detail"] == {"probe": "x"}
+        assert data["steps"][1]["hint"] == "修 B"
+        assert data["counts"]["degraded"] == 1
+
+    def test_json_records_exit_code_and_meaning(self, tmp_path: pathlib.Path) -> None:
+        UI.step("X", Status.FAILED, column=Column.DEPS)
+        UI.finish(REC.EXIT_DEPENDENCY, tui=False)
+        UI.render_json(root=str(tmp_path))
+        data = json.loads((tmp_path / "runtime" / "startup.json").read_text(encoding="utf-8"))
+        assert data["exit_code"] == REC.EXIT_DEPENDENCY
+        assert data["exit_meaning"] == "依赖缺失"
+
+    def test_json_write_failure_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """落盘只是排障辅助，写失败绝不能挡启动 —— 但必须记 warning，不许静默。"""
+        monkeypatch.setattr(UI.pathlib.Path, "mkdir", _boom)
+        assert UI.render_json(root="/definitely/not/writable") is None
+
+    def test_tui_shows_degraded_hint(self, capsys: pytest.CaptureFixture) -> None:
+        """每项降级各带专属建议 —— 不共用一句话。"""
+        UI.step("Docker", Status.DEGRADED, "未安装", column=Column.FABRIC, hint="装后重跑即恢复")
+        UI.step("模型", Status.DEGRADED, "未拉取", column=Column.BRAIN, hint="python main.py --select-model")
+        UI.render_tui()
+        out = capsys.readouterr().out
+        assert "装后重跑即恢复" in out
+        assert "python main.py --select-model" in out
+
+    def test_tui_column_summary_names_the_degraded_item(self, capsys: pytest.CaptureFixture) -> None:
+        UI.step("好项", Status.OK, "ok", column=Column.FABRIC)
+        UI.step("坏项", Status.DEGRADED, "坏", column=Column.FABRIC)
+        UI.render_tui()
+        out = capsys.readouterr().out
+        assert "坏项" in out, "折叠后降级项没有被点名，问题被折没了"
+
+
+def _boom(*_a, **_kw):
+    raise OSError("simulated")
+
+
+# ---------------------------------------------------------------------------
+# 5. 退出码
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodes:
+    def test_codes_are_distinct(self) -> None:
+        codes = [
+            REC.EXIT_OK,
+            REC.EXIT_ERROR,
+            REC.EXIT_USAGE,
+            REC.EXIT_DEPENDENCY,
+            REC.EXIT_PORT_IN_USE,
+            REC.EXIT_ENVIRONMENT,
+            REC.EXIT_INTERRUPTED,
+        ]
+        assert len(set(codes)) == len(codes), "退出码有重复，自动化就分不清失败原因"
+
+    def test_every_code_has_a_meaning(self) -> None:
+        for code in (
+            REC.EXIT_OK,
+            REC.EXIT_ERROR,
+            REC.EXIT_USAGE,
+            REC.EXIT_DEPENDENCY,
+            REC.EXIT_PORT_IN_USE,
+            REC.EXIT_ENVIRONMENT,
+            REC.EXIT_INTERRUPTED,
+        ):
+            assert REC.EXIT_MEANING.get(code), f"退出码 {code} 没有人话解释"
+
+    def test_interrupt_uses_the_shell_convention(self) -> None:
+        """128 + SIGINT(2) = 130。此前 Ctrl+C 也返回 0，自动化区分不出来。"""
+        assert REC.EXIT_INTERRUPTED == 130
+
+
+# ---------------------------------------------------------------------------
+# 6. main.py 真的接上了（不是建了一套没人用的）
+# ---------------------------------------------------------------------------
+
+
+class TestMainIsWired:
+    def _main_src(self) -> str:
+        return (pathlib.Path(__file__).parent.parent / "main.py").read_text(encoding="utf-8")
+
+    def test_print_item_delegates_to_ui_step(self) -> None:
+        src = self._main_src()
+        assert "from launcher import ui as _ui" in src
+        assert "_ui.step(name, status, detail)" in src, "print_item 没有转调 ui.step"
+
+    def test_print_phase_sets_the_column(self) -> None:
+        assert "_ui.set_column(_ui.column_for_title(title))" in self._main_src()
+
+    def test_main_writes_the_startup_record(self) -> None:
+        assert "_ui.finish(" in self._main_src(), "main 结束时没有封盘落盘"
+
+    def test_main_has_version_flag(self) -> None:
+        assert '"--version"' in self._main_src()
+
+    def test_interrupt_returns_nonzero(self) -> None:
+        assert "_record.EXIT_INTERRUPTED" in self._main_src(), "Ctrl+C 仍返回 0"
+
+
+def test_step_survives_render_failure(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """渲染层挂了也不能挡启动 —— 但必须仍然打出这一行（降级为纯 ASCII）。"""
+    import core.cli_render as R
+
+    monkeypatch.setattr(R, "phase", _boom)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        UI.step("关键项", Status.OK, "值")
+    assert "关键项" in buf.getvalue()
+    assert len(UI.current().steps) == 1, "渲染失败时记录也必须留下"

--- a/tests/test_launcher_ui_layout.py
+++ b/tests/test_launcher_ui_layout.py
@@ -1,0 +1,258 @@
+"""启动界面的版面契约：一套几何、一道渐变、跨模块严格同列。
+
+背景（实测，不是推测）
+----------------------
+统一之前，同一屏启动输出里存在：
+
+* **三种宽度** —— 横幅 60、``print_section_header`` 60、``cli_render.rule`` **50**；
+* **三种线条着色** —— 横幅 24-bit 渐变、章节线平 CYAN、细线平 DIM；
+* **两套填充语义** —— ``print_status_row`` 用 ``str.ljust``（按码点）、
+  ``cli_render`` 用显示宽度。
+
+最后那条是实打实的错位。实测：``"环境检查".ljust(22)`` 的显示宽度是 **26**、
+``"AI 大脑"`` 是 **24**、``"三态覆盖层"`` 是 **27**，而 ``pad_display(..., 22)``
+恒为 22 —— 两套打印器在同一屏里各自缩进，中文标签差 2~5 列。
+
+这个文件钉住统一后的性质，且每条都直接对应一个当初的具体缺陷。
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import pytest
+
+from core import ascii_art as A
+from core import cli_render as R
+
+# ---------------------------------------------------------------------------
+# 0. 几何只有一份
+# ---------------------------------------------------------------------------
+
+
+class TestSingleSourceOfGeometry:
+    def test_cli_render_reuses_ascii_art_constants(self) -> None:
+        """``cli_render`` 不得自己再定义一套宽度/列位。"""
+        assert R.LABEL_COL is A.LABEL_COL
+        assert R.RULE_WIDTH is A.RULE_WIDTH
+        assert R.CONTENT_INDENT is A.CONTENT_INDENT
+        assert R.VALUE_COL is A.VALUE_COL
+
+    def test_display_width_helpers_are_the_same_object(self) -> None:
+        """``display_width`` / ``pad_display`` 全仓只能有一份实现。
+
+        它们此前住在 ``cli_render``，而 ``ascii_art`` 那边用 ``str.ljust`` ——
+        两套填充语义并存正是中文错位的根源。
+        """
+        assert R.display_width is A.display_width
+        assert R.pad_display is A.pad_display
+
+    def test_rule_width_is_derived_from_banner(self) -> None:
+        """横线宽度必须是**算出来的**，右边缘与横幅同列；不许是独立字面量。"""
+        assert A.RULE_WIDTH == A.BANNER_WIDTH - A.CONTENT_INDENT
+        assert A.CONTENT_INDENT + A.RULE_WIDTH == A.BANNER_WIDTH
+
+    def test_value_col_is_derived(self) -> None:
+        assert A.VALUE_COL == A.CONTENT_INDENT + A.ICON_COL + A.LABEL_COL + 2
+
+
+# ---------------------------------------------------------------------------
+# 1. 横幅不许被改动（这是本次改造的底线）
+# ---------------------------------------------------------------------------
+
+
+class TestBannerIsUntouched:
+    def test_banner_is_uniform_width(self) -> None:
+        lines = A.GALAXY_BANNER.split("\n")
+        assert len({A.display_width(ln) for ln in lines}) == 1
+        assert A.display_width(lines[0]) == A.BANNER_WIDTH
+
+    def test_every_banner_char_is_one_column(self) -> None:
+        """按屏幕列做渐变之所以与旧实现逐字节一致，前提就是这一条。
+
+        横幅用的框线字符（═║╔╗╚╝）与 █ 的 east_asian_width 都是 'A'（ambiguous），
+        按本仓库的判据算 1 格。若将来往横幅里塞了宽字符，这条会红 —— 那时
+        必须重新核对渐变，而不是想当然。
+        """
+        for line in A.GALAXY_BANNER.split("\n"):
+            assert len(line) == A.display_width(line), f"横幅出现了非 1 格字符：{line!r}"
+
+    def test_colorize_line_matches_column_based_gradient(self) -> None:
+        """``_colorize_line``（横幅用）必须等价于 col_offset=0 的 gradient_text。"""
+        for line in A.GALAXY_BANNER.split("\n"):
+            assert A._colorize_line(line) == A.gradient_text(line, col_offset=0, scale=A.BANNER_WIDTH, bold=True)
+
+
+# ---------------------------------------------------------------------------
+# 2. 线条统一成横幅的渐变
+# ---------------------------------------------------------------------------
+
+
+class TestRulesShareTheBannerGradient:
+    def test_rule_colors_are_a_slice_of_the_banner_gradient(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """缩进 2 格的横线，其每一列的颜色必须等于横幅在同一列的颜色。
+
+        这是"统一成横幅渐变色"的**可验证**含义：不是"配色相近"，而是同一道
+        渐变的同一列。按字符序号取色（旧式做法）会把整条渐变压进 58 格，与
+        横幅的第 2..59 列对不上 —— 那样这条测试会红。
+        """
+        monkeypatch.setattr(A, "ansi_supported", lambda: True)
+        rule_line = A.gradient_rule()
+        banner_line = A.gradient_text("─" * A.BANNER_WIDTH, col_offset=0, scale=A.BANNER_WIDTH, bold=False)
+
+        rule_rgb = _rgb_sequence(rule_line)
+        banner_rgb = _rgb_sequence(banner_line)
+        # 横线从第 CONTENT_INDENT 列开始，应与横幅同列起的颜色逐个相等
+        assert rule_rgb == banner_rgb[A.CONTENT_INDENT :], "横线的颜色不是横幅同列的颜色"
+
+    def test_rule_spans_to_the_banner_right_edge(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(A, "ansi_supported", lambda: False)
+        line = A.gradient_rule()
+        assert A.display_width(line) == A.BANNER_WIDTH, "横线右边缘没有与横幅对齐"
+        assert line.startswith(" " * A.CONTENT_INDENT)
+
+    def test_section_header_line_uses_the_gradient_not_flat_cyan(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """章节线此前是平 CYAN，与横幅的渐变割裂。"""
+        monkeypatch.setattr(A, "ansi_supported", lambda: True)
+        A.print_section_header("服务启动")
+        out = capsys.readouterr().out
+        assert "38;2;" in out, "章节线没有 24-bit 渐变"
+        # 平 CYAN 的老实现会出现 Colors.CYAN 紧跟 ═；渐变实现不会
+        assert f"{A.Colors.CYAN}═" not in out, "章节线仍是平 CYAN"
+
+    def test_gradient_endpoints_match_the_anchor_colors(self) -> None:
+        """自证：渐变两端必须真的是首尾锚点色，否则上面几条比的是两个错值。"""
+        assert A._interp_rgb(0.0) == A._ANCHOR_COLORS[0]
+        assert A._interp_rgb(1.0) == A._ANCHOR_COLORS[-1]
+
+
+def _rgb_sequence(text: str) -> list:
+    """从带 ANSI 的字符串里抽出逐字符的 (r,g,b) 序列。"""
+    import re
+
+    return [tuple(int(x) for x in m) for m in re.findall(r"\x1b\[38;2;(\d+);(\d+);(\d+)m", text)]
+
+
+# ---------------------------------------------------------------------------
+# 3. 跨模块严格同列（本次改造要修的那个实际错位）
+# ---------------------------------------------------------------------------
+
+_LABELS = ["Python", "环境检查", "AI 大脑", "Tailscale", "三态覆盖层", "NATS"]
+
+
+class TestCrossPrinterAlignment:
+    def test_ljust_would_have_misaligned_cjk(self) -> None:
+        """自证：这条错位是真的，不是假想的。
+
+        没有它，下面那条"两套打印器同列"可能只是碰巧成立（比如两边都错得
+        一样多），读者也无从知道当初到底坏在哪。
+        """
+        offenders = [lb for lb in _LABELS if A.display_width(lb.ljust(A.LABEL_COL)) != A.LABEL_COL]
+        assert offenders, "样例里没有中文标签，这条自证就失去意义了"
+        for lb in offenders:
+            assert A.display_width(A.pad_display(lb, A.LABEL_COL)) == A.LABEL_COL
+
+    @pytest.mark.parametrize("label", _LABELS)
+    def test_both_printers_put_the_value_at_the_same_column(self, label: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``print_status_row`` 与 ``cli_render.phase`` 的值列必须逐列一致。"""
+        monkeypatch.setattr(A, "ansi_supported", lambda: False)
+        marker = "X_VALUE_X"
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            A.print_status_row(label, marker, "success")
+        row_line = buf.getvalue().rstrip("\n")
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            R.phase(label, marker, "ok")
+        phase_line = buf.getvalue().rstrip("\n")
+
+        row_col = A.display_width(row_line[: row_line.index(marker)])
+        phase_col = A.display_width(phase_line[: phase_line.index(marker)])
+        assert row_col == phase_col == A.VALUE_COL, (
+            f"标签 {label!r} 的值列不一致：print_status_row={row_col} "
+            f"cli_render.phase={phase_col} 期望={A.VALUE_COL}"
+        )
+
+    @pytest.mark.parametrize("label", _LABELS)
+    def test_detail_value_shares_the_phase_value_column(self, label: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``-v`` 展开后，子项的值必须与阶段行的值**同列**。
+
+        此前子项固定用 LABEL_COL(22)，值列因此是 6+2+22+2=32，而阶段行是 28
+        —— 一按 ``-v``，整屏的值就右移 4 格，同屏出现两条值列。缩进表达层级、
+        值列负责对齐，两者不该互相牵连。
+        """
+        monkeypatch.setattr(A, "ansi_supported", lambda: False)
+        marker = "X_VALUE_X"
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            R.phase(label, marker)
+            R.detail(label, marker)
+        parent, child = [ln for ln in buf.getvalue().split("\n") if ln.strip()]
+        assert A.display_width(parent[: parent.index(marker)]) == A.VALUE_COL
+        assert A.display_width(child[: child.index(marker)]) == A.VALUE_COL, "子项的值列与阶段行不同列"
+
+    def test_detail_is_still_visibly_nested(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """值列对齐了，但层级仍要看得出来：子项的缩进必须比阶段行深。"""
+        monkeypatch.setattr(A, "ansi_supported", lambda: False)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            R.phase("父项", "v")
+            R.detail("子项", "v")
+        parent, child = [ln for ln in buf.getvalue().split("\n") if ln.strip()]
+        parent_indent = A.display_width(parent) - A.display_width(parent.lstrip())
+        child_indent = A.display_width(child) - A.display_width(child.lstrip())
+        assert child_indent > parent_indent, "子项没有比阶段行更深的缩进，层级消失了"
+
+
+# ---------------------------------------------------------------------------
+# 4. 颜色可降级（NO_COLOR 此前是个说谎的注释）
+# ---------------------------------------------------------------------------
+
+
+class TestColorDegradation:
+    def test_no_color_env_disables_color(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """https://no-color.org/ ：变量【存在】即禁用，哪怕是空串。"""
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True, raising=False)
+        monkeypatch.setenv("NO_COLOR", "")
+        assert A.ansi_supported() is False
+
+    def test_galaxy_no_color_env_disables_color(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True, raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("GALAXY_NO_COLOR", "1")
+        assert A.ansi_supported() is False
+
+    def test_print_status_row_honours_ansi_support(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """此前它只看 ``use_color`` 参数，不查终端能力 —— 管道里会混进转义码。"""
+        monkeypatch.setattr(A, "ansi_supported", lambda: False)
+        A.print_status_row("Python", "3.11", "success")
+        assert "\x1b[" not in capsys.readouterr().out
+
+    def test_rule_degrades_to_plain_but_keeps_geometry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """纯文本下线条也必须保持宽度与缩进，否则降级即错位。"""
+        monkeypatch.setattr(A, "ansi_supported", lambda: False)
+        plain = A.gradient_rule()
+        assert "\x1b[" not in plain
+        assert A.display_width(plain) == A.BANNER_WIDTH
+
+
+# ---------------------------------------------------------------------------
+# 5. 渐变对中文按显示宽度推进
+# ---------------------------------------------------------------------------
+
+
+def test_gradient_advances_by_display_width_for_cjk() -> None:
+    """中文每字占 2 列，颜色就该跨 2 列 —— 否则中文段落上渐变会加速漂移。"""
+    seq = _rgb_sequence(A.gradient_text("中文abc", col_offset=0, scale=A.BANNER_WIDTH, bold=False))
+    ascii_seq = _rgb_sequence(A.gradient_text("......", col_offset=0, scale=A.BANNER_WIDTH, bold=False))
+    # "中" 在列 0、"文" 在列 2、"a" 在列 4 ⇒ 与纯 ASCII 串的第 0/2/4 个颜色相同
+    assert seq[0] == ascii_seq[0]
+    assert seq[1] == ascii_seq[2]
+    assert seq[2] == ascii_seq[4]


### PR DESCRIPTION
# 一、线条全部统一成横幅的那一道渐变

改造前同一屏里有**三种线条处理**：

| | 宽度 | 着色 |
|---|---|---|
| 横幅 | 60 | 24-bit 渐变 |
| `print_section_header` | 60 | 平 CYAN |
| `cli_render.rule` | **50** | 平 DIM |

关键不是"配成相近的颜色"，而是**渐变按屏幕列取色**。新的 `gradient_text`：

```
t = (col_offset + 该字符左边缘所在列) / (scale - 1)
```

于是一条缩进 2 格、宽 58 的横线拿到的正是横幅在**第 2..59 列**的那一段颜色——它与横幅是**同一道渐变的延续**，而不是两种看起来差不多的颜色。测试直接比对两者的逐字符 RGB 序列：

```python
assert rule_rgb == banner_rgb[CONTENT_INDENT:]
```

列的推进用**显示宽度**而非码点：中文每字占 2 列，颜色才不会在中文段落上加速漂移。

## 横幅逐字节未变

横幅本身全是 1 格字符（实测 12 行 `code_points == display_width == 60`，框线字符 `═║╔╗╚╝` 与 `█` 的 `east_asian_width` 都是 `'A'`），所以按列推进 == 按码点推进。**改造前后各生成一次做了逐字节比对**，并有测试钉住"横幅里不许出现非 1 格字符"——将来真塞了宽字符会红，那时必须重新核对渐变而不是想当然。

---

# 二、跨模块严格同列（修掉一个实测的错位）

`print_status_row` 用 `str.ljust`（按**码点**）、`cli_render` 用**显示宽度**，两套填充语义并存。实测：

| 标签 | `ljust(22)` 的显示宽度 | `pad_display(22)` |
|---|---:|---:|
| `Python` | 22 | 22 |
| `环境检查` | **26** | 22 |
| `AI 大脑` | **24** | 22 |
| `三态覆盖层` | **27** | 22 |

同一屏里两套打印器差 **2~5 列**，对勾对不齐。

现在几何常量只有一份，且全部由横幅宽度派生：

```python
BANNER_WIDTH   = 60
CONTENT_INDENT = 2
RULE_WIDTH     = BANNER_WIDTH - CONTENT_INDENT        # 58，右边缘与横幅同列
ICON_COL       = 2
LABEL_COL      = 22
VALUE_COL      = CONTENT_INDENT + ICON_COL + LABEL_COL + 2   # 28
```

`display_width` / `pad_display` 下移到 `ascii_art`（较低层），由 `cli_render` 再导出——全仓只剩一份实现。实测两套打印器的值列**都落在第 28 列**。

## 顺带修的两处

**`detail()` 的值列**：它此前固定用 `LABEL_COL(22)`，值列 = 6+2+22+2 = **32**，而阶段行是 **28**——一按 `-v`，整屏的值就右移 4 格，同屏出现两条值列。现在子项的标签列宽**由值列反推**，缩进负责层级、值列负责对齐，两者互不牵连。

**`print_status_row` 不查 `ansi_supported()`**：此前只看 `use_color`（默认 `True`），重定向 / CI / `NO_COLOR` 下照样吐转义码，而同屏的 `cli_render` 已降级成纯文本——一半带色一半不带，管道里混进乱码。

---

# 三、`NO_COLOR`：一个说谎的注释

`cli_render` 的模块 docstring 一直声称"非 TTY / `NO_COLOR` 时自动纯文本"，而 `ansi_supported()` **从来没查过 `NO_COLOR`**。按 [no-color.org](https://no-color.org/) 的约定补上（变量**存在**即禁用，哪怕空串），并加了自家的 `GALAXY_NO_COLOR`。

---

# 四、数据与呈现分离：启动过程第一次留下事实

`launcher/record.py` 持有事实，`launcher/ui.py` 渲染成三种形态：

```
StartupRecord ──┬─→ render_tui    栏目式 TUI（人看）
                ├─→ render_json   runtime/startup.json（机器读）
                └─→ render_log    日志
```

**判断逻辑一次都不重复。** 此前是"一边判断一边 print"，结果只以彩色文本存在过一瞬：启动失败只能拿截图、托盘/面板各自再问一遍、"上次降级了什么"无处可查。

## 五个栏目

按**用户关心什么**取名——**环境 / 依赖 / 骨干 / 大脑 / 在场**——取代现存三套互相交错的 Phase 编号（`main` 的 0/2、`SystemOrchestrator` 的 1-7、`unified_launcher` 自成一套）。"Phase 4"对用户没有任何意义。

## 接进 main.py 只动了两个函数

`print_item` 转调 `ui.step`、`print_phase` 顺带 `set_column`。**71 个 `print_item` 调用点一个都没改**，输出形态不变，而每一项现在都留下了痕迹。

**刻意不给 CLI 造 `--json` 子命令树**：机器面已经是 388 条 HTTP 路径 + OpenAPI + 生成的 TS 类型，再开一条平行的正是这个仓库反复吃亏的模式（五套面板、两条配置链、四份依赖引导）。`runtime/startup.json` 有具体消费方：排障时直接发文件、托盘可改读它、面板可带上"上次启动的降级项"。

---

# 五、另外两条低成本补齐

- **`--version`**（此前 `GALAXY_VERSION` 只印在横幅里，脚本拿不到）
- **退出码分档**：`0` 成功 / `1` 一般 / `2` 用法 / `3` 依赖 / `4` 端口占用 / `5` 环境 / `130` 中断。此前 Ctrl+C 也返回 **0**，自动化区分不出来。

---

# 测试与对照实验

**66 条**（版面 30 + 事实层 36），每条对应一个具体缺陷，且带自证（"`ljust` 确实会错位"、"渐变两端确实是首尾锚点色"、"扫描器数量级对不对"）。

四组对照实验，逐条确认门是真的：

| 把什么改回去 | 结果 |
|---|---|
| 横线宽度 → 50 | 2 条如期红 |
| `print_status_row` → `str.ljust` | 中文标签那几条如期红 |
| 渐变 → 按字符序号 | CJK 那条如期红 |
| 去掉 `NO_COLOR` 检查 | 那条如期红 |

全部还原后 66 条归零。

# 验证

- 相关面 **1753 passed / 0 failed**
- `black` / `isort` 全绿；`flake8 core/` = 0（`main.py` 的 18 条在改动前的树上一字不差，且 CI 的 flake8 只扫 `core/`）
- 横幅输出改造前后**逐字节比对通过**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_