### PR TITLE
联网核实四家旗舰型号:Grok 4.6 真升级,GLM-5.3 查到但确认不该现在加

### DIFF
--- a/config/file_complexity_baseline.json
+++ b/config/file_complexity_baseline.json
@@ -65,7 +65,7 @@
     "core/mesh/mesh_session_lifecycle.py": 1082,
     "core/multi_device_canonical_governance.py": 1386,
     "core/multi_device_control_integrity.py": 1860,
-    "core/multi_llm_router.py": 3974,
+    "core/multi_llm_router.py": 4001,
     "core/nats_bus.py": 1572,
     "core/network_topology_runtime.py": 1542,
     "core/node_cognition_activation.py": 1194,

--- a/core/multi_llm_router.py
+++ b/core/multi_llm_router.py
@@ -384,8 +384,11 @@ def _provider_quality_tier(name: str) -> int:
 # 提供商 → 推荐模型 (2026-05-29 全面更新)
 PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
     "openai": {
-        # GPT-5.6 家族(2026-07-09 GA):gpt-5.6 = 旗舰 Sol 的别名(1.05M ctx/128K out);
-        # terra=日常均衡($2.5/$15);luna=快而省($1/$6)。
+        # GPT-5.6 家族(2026-07-09 GA,2026-08-15 联网复核型号 id 仍正确):
+        # gpt-5.6 = 旗舰 Sol 的别名(1.05M ctx/128K out);terra=日常均衡;
+        # luna=快而省。价位在 2026-07-30 降过一轮(terra -20%、luna -80%,
+        # sol 未变)——型号 id 不受影响,这里不复述具体数字,理由同 deepseek
+        # 那条注释:没有一手定价页确认前不改会影响路由的 cost_in/cost_out。
         TaskType.REASONING: "gpt-5.6",
         TaskType.FAST_RESPONSE: "gpt-5.6-luna",
         TaskType.CODING: "gpt-5.6",
@@ -433,14 +436,19 @@ PROVIDER_MODEL_MAP: Dict[str, Dict[TaskType, str]] = {
         TaskType.GENERAL: "Llama-4-Scout-17B-16E-Instruct-FP8",
     },
     "xai": {
-        TaskType.REASONING: "grok-4.5",
-        TaskType.FAST_RESPONSE: "grok-4.5",
-        TaskType.CODING: "grok-4.5",
-        TaskType.CREATIVE: "grok-4.5",
-        TaskType.ANALYSIS: "grok-4.5",
-        TaskType.PLANNING: "grok-4.5",
-        TaskType.AGENT_CONTROL: "grok-4.5",
-        TaskType.GENERAL: "grok-4.5",
+        # Grok 4.6(联网核实 2026-08-12 发布,多源交叉确认):同 4.5 的 V9 基座/1.5T
+        # 参数,靠后训练(SFT+RL)提升而非放大规模;500K 上下文,$2/M 输入 $6/M 输出。
+        # Artificial Analysis Intelligence Index 与 GPT-5.6 Sol 打平,是当前智能
+        # 前沿里最便宜的一档 —— 升为默认档,4.5 仍是有效型号,保留在 registry 里
+        # 作为该家自己的旧档回退(不是"已下线,不该出现"那种要清掉的幽灵)。
+        TaskType.REASONING: "grok-4.6",
+        TaskType.FAST_RESPONSE: "grok-4.6",
+        TaskType.CODING: "grok-4.6",
+        TaskType.CREATIVE: "grok-4.6",
+        TaskType.ANALYSIS: "grok-4.6",
+        TaskType.PLANNING: "grok-4.6",
+        TaskType.AGENT_CONTROL: "grok-4.6",
+        TaskType.GENERAL: "grok-4.6",
     },
     "mistral": {
         TaskType.REASONING: "mistral-large-3",
@@ -1521,13 +1529,16 @@ PROVIDER_REGISTRY: List[Dict[str, Any]] = [
         "extra": {"multimodal": True},
     },
     {
+        # Grok 4.6 —— 联网核实,2026-08-12 发布,xAI 官方 API / OpenRouter / Cursor /
+        # Vercel / Cloudflare 同步上线,base_url/协议与 4.5 一致(同一 provider,
+        # 只是新模型 id),不是猜的命名惯例延伸。
         "name": "xai",
         "env_key": "XAI_API_KEY",
         "base_url": "https://api.x.ai/v1",
-        "models": ["grok-4.5", "grok-4.3"],
-        "default_model": "grok-4.5",
-        "cost_in": 0.005,
-        "cost_out": 0.015,
+        "models": ["grok-4.6", "grok-4.5", "grok-4.3"],
+        "default_model": "grok-4.6",
+        "cost_in": 0.002,
+        "cost_out": 0.006,
         "extra": {"multimodal": True},
     },
     {
@@ -1573,6 +1584,15 @@ PROVIDER_REGISTRY: List[Dict[str, Any]] = [
         "extra": {"multimodal": True},
     },
     {
+        # deepseek-v4-pro 型号 id 本身核对过仍然正确(2026-08-15 联网核实,当前上游
+        # 快照 deepseek-v4-pro-0813)。但多个第三方计费站点显示价格明显上调过
+        # (缓存未命中输入/输出都涨到原来的十几倍),而这里 cost_in/cost_out 是
+        # cost_budget SLO 用来做路由判断的字段——没有拿到官方一手定价页确认具体
+        # 数字前,宁可不动这两个值,也不要把聚合站估算塞进一个会影响路由行为的
+        # 字段。要拿准确数字,配好 DEEPSEEK_API_KEY 跑一次
+        # verify_provider_apis.py --only deepseek(它走的是路由器自己的请求链路,
+        # 不是这里去猜)。即便按查到的高估计,换算下来仍远低于本仓各任务类型的
+        # cost_budget 阈值,不会现在就影响路由结果。
         "name": "deepseek",
         "env_key": "DEEPSEEK_API_KEY",
         "base_url": "https://api.deepseek.com/v1",
@@ -1593,6 +1613,13 @@ PROVIDER_REGISTRY: List[Dict[str, Any]] = [
         "extra": {"multimodal": True},
     },
     {
+        # 查过 GLM-5.3(2026-08-15 联网核实,发布于 2026-08-14):**刻意不加进 models**。
+        # 它目前只通过 GLM Coding Plan / 编码 CLI 发布,权重还差两周才放出,标准
+        # open.bigmodel.cn 端点(本 provider 实际调用的那个)上的公开 model id 与
+        # 独立计费"仍在安全评审后才放出"——不是本仓命名惯例推出来的猜测,是查到
+        # 它现在**还没有**。这种时候加进去,后果和本轮修的那 8 处"清单声称有、
+        # 实际没有"是同一类:选路成功,直到真发请求才 404。等它经标准 API 开放,
+        # 用 verify_provider_apis.py --only zhipu 核验后再升,不要提前抄。
         "name": "zhipu",
         "env_key": "ZHIPU_API_KEY",
         "base_url": "https://open.bigmodel.cn/api/paas/v4",

--- a/tests/test_provider_model_registry_consistency.py
+++ b/tests/test_provider_model_registry_consistency.py
@@ -182,6 +182,58 @@ class TestNewFlagshipModels:
         assert per_task["fast_response"] == "glm-5.1-flash"
 
 
+class TestGrok46Upgrade:
+    """2026-08-15 联网核实四家旗舰(DeepSeek V4 Pro / GLM-5.3 / Grok 4.6 / GPT-5.6
+    三档)后的结论:只有 Grok 4.6 是真的要升的。
+
+    其余三个核对结果:
+
+    * ``deepseek-v4-pro``:型号 id 本身仍正确(上游快照 deepseek-v4-pro-0813),
+      不用改;第三方计费站显示价格明显上调,但 cost_in/cost_out 是驱动
+      cost_budget 路由判断的字段,没有一手定价页确认具体数字之前不动它 ——
+      详见 registry 里那条注释。
+    * GPT-5.6 Sol/Terra/Luna(``gpt-5.6`` / ``-terra`` / ``-luna``):三档 id 已经
+      是对的,2026-07-30 降过一轮价,id 不受影响。
+    * GLM-5.3:**没有加**。查到它 2026-08-14 发布,但只经 GLM Coding Plan /
+      编码 CLI 放出,标准 open.bigmodel.cn 端点(本 provider 实际调用的那个)上
+      的公开 model id 与独立计费仍在安全评审后才放 —— 见下面
+      ``test_glm53_deliberately_not_added``。
+    """
+
+    def test_grok_4_6_is_declared_and_default(self):
+        assert "grok-4.6" in _REGISTRY["xai"]["models"]
+        assert _REGISTRY["xai"]["default_model"] == "grok-4.6"
+
+    def test_grok_4_5_stays_as_a_fallback_not_a_ghost(self):
+        """4.5 没有被 4.6 取代下线(不是 opus-4.8 那种"已作废,不该残留"的情况)——
+        xAI 自己的文档里两个 id 目前都还在服务,所以保留在 models 里作为该家自己
+        的旧档回退,而不是从 registry 里清掉。"""
+        assert "grok-4.5" in _REGISTRY["xai"]["models"]
+
+    @pytest.mark.parametrize(
+        "task",
+        ["reasoning", "fast_response", "coding", "creative", "analysis", "planning", "agent_control", "general"],
+    )
+    def test_xai_task_map_upgraded_to_grok_4_6(self, task):
+        """同上面 anthropic/moonshot/zhipu/qwen 那条判据:新型号不只是"加进清单",
+        原先指向旧旗舰的任务槽位要真的升上去。"""
+        per_task = {getattr(tt, "value", tt): m for tt, m in PROVIDER_MODEL_MAP["xai"].items()}
+        assert per_task[task] == "grok-4.6"
+
+    def test_glm53_deliberately_not_added(self):
+        """钉住"现在不加"这个决定本身,不只是钉当前状态。
+
+        没有这条,下一个人(或下一轮"顺手更新模型列表")看到 zhipu 只有到 5.2,
+        很容易复刻本仓一贯的"按命名惯例推新档"手法(kimi-k2.6→k3、
+        qwen3.7→3.8 那种)直接加一个 "glm-5.3" —— 但这次的情况不一样:上一轮
+        那些是**推断,标注了未核验**;这一轮是**查到了并确认它现在还没有**。
+        两者都不该写死进 models,但原因不同,值得分开钉,免得将来有人把
+        "还没查"和"查过没有"混成一回事。
+        """
+        assert "glm-5.3" not in _REGISTRY["zhipu"]["models"]
+        assert "glm-5.3" != _REGISTRY["zhipu"]["default_model"]
+
+
 class TestConfigExampleStaysInSync:
     """``runtime/config.example.json`` 里的型号也要跟着升,否则新装机的人拿到的是旧型号。"""
 


### PR DESCRIPTION
按所有者要求联网核实四家旗舰型号(DeepSeek V4 Pro / GLM-5.3 / Grok 4.6 / GPT-5.6 三档),而非按仓库既有命名惯例推断。

## xai:Grok 4.6 —— 真的存在,已升级

2026-08-12 发布,xAI 官方 API / OpenRouter / Cursor / Vercel / Cloudflare 同步上线,多个独立信源交叉确认。同 4.5 的 V9 基座(1.5T 参数),靠后训练提升而非放大规模;500K 上下文,$2/M 输入 $6/M 输出。Artificial Analysis Intelligence Index 与 GPT-5.6 Sol 打平,是当前智能前沿最便宜的一档。

- `PROVIDER_REGISTRY['xai']`:`models` 加 `grok-4.6`,设为 `default_model`,`cost_in`/`cost_out` 按查到的定价更新;`grok-4.5` 保留作该家自己的旧档回退(不是下线幽灵,不清掉)。
- `PROVIDER_MODEL_MAP['xai']`:8 个任务类型全部从 `grok-4.5` 升到 `grok-4.6`——只加进 models 清单不够,原先指向旧旗舰的任务槽位不跟着升就是"加了没人用"。

## zhipu:GLM-5.3 —— 查到了,**刻意不加**

2026-08-14 发布,但只经 GLM Coding Plan / 编码 CLI 放出,权重还差两周才放,标准 `open.bigmodel.cn` 端点(本 provider 实际调用的那个)上的公开 model id 与独立计费"仍在安全评审后才放"。

现在写进 `models` 会造成的后果,和这几轮一直在清理的那类问题是同一种:选路成功,直到真发请求才 404。所以不加,只在 registry 里写清楚查到了什么、为什么不加,并补了一条测试钉住**这个决定本身**(不只是钉当前状态)——这次不是"没核验过的推断",是"核验过、确认现在没有",两者都不该写进 `models`,但原因不同,值得分开钉。

## deepseek / openai:型号 id 复核仍正确,价格信号不动路由字段

`deepseek-v4-pro` 与 `gpt-5.6`/`-terra`/`-luna` 三档 id 本来就对,不用改。两家都有第三方信源显示价格变动过(deepseek 疑似涨价,openai terra/luna 7/30 降价),但 `cost_in`/`cost_out` 是驱动 `cost_budget` SLO 路由判断的字段,一手定价页被本沙箱的网络策略拦住确认不了具体数字,所以只加注释说明信号来源与核验方法(跑 `verify_provider_apis.py --only <provider>`,需要真 key + 出网),**不把聚合站估算塞进会影响路由行为的字段**。

## config/file_complexity_baseline.json

`core/multi_llm_router.py` 因为上面这些有据可查的注释涨到 4001 行(基线 3974,+27)。这些不是可有可无的说明——用 `--update-baseline` 收敛,diff 只有这一个数字,可审。

## 测试:`TestGrok46Upgrade`

四条变异各自验证过(每次先确认变异真的落地再看颜色):

| 变异 | 结果 |
|---|---|
| 从 `xai.models` 删掉 `grok-4.6` | `test_grok_4_6_is_declared_and_default` 红 |
| 从 `xai.models` 删掉 `grok-4.5`(回退档) | `test_grok_4_5_stays_as_a_fallback_not_a_ghost` 红 |
| 漏升一个任务槽位(`AGENT_CONTROL` 留旧档) | `test_xai_task_map_upgraded_to_grok_4_6[agent_control]` 红 |
| 把 `glm-5.3` 加回 `zhipu.models` | `test_glm53_deliberately_not_added` 红 |

## 验证

- black / isort / flake8 全过
- `tests/test_provider_model_registry_consistency.py`:64 条全过
- `scripts/verify_provider_apis.py --offline`:静态对齐 0 问题
- `validate_ports` / hygiene / wiring / reachability / file-complexity `--strict` 全过
- 本地全量四分片:**40991 passed, 0 failed**(git 未被测试改脏)

过程中踩了两个环境坑,记录在案避免误判:
- 本容器是全新的,只装 `requirements-core.txt` 会漏 `authlib`/`jsonschema` 等包,连累 `test_oauth_surface_and_id_token.py` / `test_v3_schemas.py` / `test_hiclaw_api_routes.py` 一串跟本次改动无关的假红——补装完整 `requirements.txt`(减掉两个在无头容器编译不过的 GUI 自动化包)后确认这些文件单独跑全过,和本次改动无交集。
- `test_pip_require_hashes_dry_run` 真联网跑 pip 依赖解析,四分片里抖动过一次,单独连跑三次、shard 2 完整复跑一次均绿,判定是该测试固有的网络偶发抖动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy

---
_Generated by [Claude Code](https://claude.ai/code/session_018m2MJSbdofxq5R32pFQ9Wy)_