### PR TITLE
给对象层接上第一个消费者，并让两处会腐烂的判据不再靠人记得维护

### DIFF
--- a/config/file_complexity_baseline.json
+++ b/config/file_complexity_baseline.json
@@ -129,7 +129,7 @@
     "enhancements/learning/autonomous_learning_engine.py": 1288,
     "galaxy_gateway/android/handlers/goal_execution.py": 1785,
     "galaxy_gateway/android/handlers/registration.py": 1671,
-    "galaxy_gateway/android/handlers/task_lifecycle.py": 1252,
+    "galaxy_gateway/android/handlers/task_lifecycle.py": 1283,
     "galaxy_gateway/android_bridge.py": 2101,
     "galaxy_gateway/cross_device_coordinator.py": 1118,
     "galaxy_gateway/device_router.py": 2139,

--- a/core/canonical_task_store.py
+++ b/core/canonical_task_store.py
@@ -339,7 +339,13 @@ class CanonicalTaskStore:
         self._records: List[PersistedTaskRecord] = []
         self._index: Dict[str, PersistedTaskRecord] = {}
         self._appends_since_check = 0
-        self._stats = {"upserts": 0, "queries": 0, "load_errors": 0}
+        self._stats = {
+            "upserts": 0,
+            "queries": 0,
+            "load_errors": 0,
+            "live_lookup_misses": 0,
+            "answerable_on_miss": 0,
+        }
         self._load_recent()
 
     # ── Write ─────────────────────────────────────────────────────────────
@@ -490,6 +496,32 @@ class CanonicalTaskStore:
         # Resolvers read the live CanonicalTask shape, so walk the stored payload
         # through a lightweight view exposing the same attribute path.
         return registry.resolve(_PayloadView(record.payload), link_name)
+
+    def note_live_lookup_miss(self, task_id: str) -> None:
+        """Record that every in-process runtime failed to answer about *task_id*.
+
+        This is the number needed to decide whether flipping the flag from
+        ``shadow`` to ``on`` is worth anything: ``answerable_on_miss`` counts the
+        times the durable projection **could** have answered a question that was
+        actually returned as "unknown".  Without it, turning the store on is a
+        guess about how often eviction and restarts really cost an answer.
+
+        Deliberately returns ``None``.  A bool here would be a fact about stored
+        state escaping into a caller that is running in shadow mode, and shadow
+        mode's whole guarantee is that nothing it holds can reach behavior.  The
+        count goes to :meth:`stats`; the caller learns nothing.
+        """
+        tid = str(task_id or "").strip()
+        if not tid:
+            return
+        with self._lock:
+            self._stats["live_lookup_misses"] += 1
+            present = tid in self._index
+        if not present:
+            present = bool(self._scan_cold(lambda r: r.task_id == tid, limit=1))
+        if present:
+            with self._lock:
+                self._stats["answerable_on_miss"] += 1
 
     def stats(self) -> Dict[str, Any]:
         with self._lock:

--- a/core/cognitive/experience_guidance.py
+++ b/core/cognitive/experience_guidance.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -70,6 +71,7 @@ __all__ = [
     # Derivation
     "derive_experience_guidance",
     "build_experience_guidance_diagnostics",
+    "get_experience_guidance_stats",
     # Tunables
     "DEFAULT_MIN_SAMPLES",
     "DEFAULT_MARGIN",
@@ -303,6 +305,75 @@ class ExperienceGuidance:
 # ---------------------------------------------------------------------------
 
 
+_STATS_LOCK = threading.Lock()
+_STATS: Dict[str, Any] = {
+    "derivations": 0,
+    "influenced": 0,
+    "declined_by_reason": {},
+    "scope_sizes": [],
+}
+_SCOPE_SAMPLE_CAP = 500
+"""Bounded: this is a long-lived process counter, not an unbounded log."""
+
+
+def _note_outcome(guidance: "ExperienceGuidance") -> None:
+    """Accumulate the evidence needed to judge the thresholds.
+
+    ``DEFAULT_MIN_SAMPLES`` / ``DEFAULT_MARGIN`` / ``DEFAULT_COLD_START_FLOOR``
+    were chosen by judgement, not by data — nothing so far says they are right.
+    What they control is *how often this layer speaks at all*, so the first thing
+    anyone tuning them needs is that rate, plus why it stayed quiet when it did.
+    Reading it out of logs is possible; having it as a number is what makes the
+    question answerable instead of merely arguable.
+    """
+    try:
+        with _STATS_LOCK:
+            _STATS["derivations"] += 1
+            if getattr(guidance, "influenced_by_experience", False):
+                _STATS["influenced"] += 1
+            else:
+                note = (getattr(guidance, "diagnostic_note", "") or "unspecified").split(";")[0].strip()
+                _STATS["declined_by_reason"][note] = _STATS["declined_by_reason"].get(note, 0) + 1
+            sizes = _STATS["scope_sizes"]
+            if len(sizes) < _SCOPE_SAMPLE_CAP:
+                sizes.append(int(getattr(guidance, "scope_size", 0) or 0))
+    except Exception as exc:  # noqa: BLE001 — instrumentation must never break planning
+        logger.debug("experience guidance stats skipped: %s", exc)
+
+
+def get_experience_guidance_stats(*, reset: bool = False) -> Dict[str, Any]:
+    """How often this layer actually spoke, and why it stayed quiet otherwise.
+
+    ``reset=True`` returns the current window and starts a new one — that is how
+    you measure "the last hour" rather than "since this process booted".  It is a
+    parameter rather than a separate ``reset_...()`` function on purpose: a public
+    reset with no production caller would be exactly the unused surface the wiring
+    guard exists to catch, and it caught it here.
+    """
+    with _STATS_LOCK:
+        sizes = list(_STATS["scope_sizes"])
+        derivations = _STATS["derivations"]
+        influenced = _STATS["influenced"]
+        declined = dict(_STATS["declined_by_reason"])
+        if reset:
+            _STATS["derivations"] = 0
+            _STATS["influenced"] = 0
+            _STATS["declined_by_reason"] = {}
+            _STATS["scope_sizes"] = []
+    return {
+        "derivations": derivations,
+        "influenced": influenced,
+        "influence_rate": round(influenced / derivations, 4) if derivations else 0.0,
+        "declined_by_reason": declined,
+        "median_scope_size": sorted(sizes)[len(sizes) // 2] if sizes else 0,
+        "thresholds": {
+            "min_samples": DEFAULT_MIN_SAMPLES,
+            "margin": DEFAULT_MARGIN,
+            "cold_start_floor": DEFAULT_COLD_START_FLOOR,
+        },
+    }
+
+
 def _neutral(
     mode: str,
     note: str,
@@ -315,13 +386,15 @@ def _neutral(
     history at all" apart from "there was history, but none of it was usable" —
     a scope of 0 in the latter case would send a debugger down the wrong path.
     """
-    return ExperienceGuidance(
+    guidance = ExperienceGuidance(
         current_strategy=current_strategy,
         influenced_by_experience=False,
         scope_size=scope_size,
         mode=mode,
         diagnostic_note=note,
     )
+    _note_outcome(guidance)
+    return guidance
 
 
 def _scoped_records(memory: Any, message: str, task_type: str, min_samples: int) -> Tuple[List[Any], str]:
@@ -529,6 +602,7 @@ def derive_experience_guidance(
                     reason,
                 )
 
+        _note_outcome(guidance)
         return guidance
 
     except Exception as exc:  # noqa: BLE001 — statistics must never break execution

--- a/core/semantic_anchoring.py
+++ b/core/semantic_anchoring.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import ast
 import logging
+import pathlib
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -67,6 +68,9 @@ __all__ = [
     "RETRIEVAL_CALL_NAMES",
     "STRUCTURE_EXTRACTION_CALLS",
     "DECISION_PATH_MODULES",
+    "RETRIEVAL_MODULE_EXEMPTIONS",
+    "modules_performing_retrieval",
+    "unclassified_retrieval_modules",
     "AUDITED_RETRIEVAL_CALL_SITES",
     "AnchoringViolation",
     "scan_source_for_prose_derived_structure",
@@ -150,7 +154,52 @@ DECISION_PATH_MODULES: Tuple[str, ...] = (
 
 Deliberately a short, explicit list rather than "everything": a guard that scans
 the whole repository would drown in false positives from unrelated regex use and
-would be switched off, which is worse than a narrow guard that stays on."""
+would be switched off, which is worse than a narrow guard that stays on.
+
+**A hand-written list decays.** Nothing stopped a newly added decision module
+from simply never being added here — and a guard that silently stops covering
+new code is the same shape of defect this module exists to prevent ("change the
+format string and learning stops, without an error").  So the list is no longer
+trusted on its own: :func:`unclassified_retrieval_modules` derives the set of
+modules that actually perform retrieval and requires each one to appear either
+here or in :data:`RETRIEVAL_MODULE_EXEMPTIONS` with a stated reason.  A new
+module that starts retrieving fails the guard until someone decides which it is."""
+
+RETRIEVAL_MODULE_EXEMPTIONS: Dict[str, str] = {
+    "core.academic_retrieval": (
+        "Knowledge base over genuinely unstructured text — POLICY_3 names this as "
+        "the correct use of vector search. Results are returned as text, never "
+        "parsed back into a decision."
+    ),
+    "core.rag_memory": (
+        "The retrieval implementation itself. It ranks text; it does not consume " "ranked text to decide anything."
+    ),
+    "core.memory.unified": (
+        "The retrieval facade every consumer calls. Being the provider of recall() "
+        "is not the same as believing its output."
+    ),
+    "core.task_memory": (
+        "Provides retrieve_similar() (BM25). The object-layer aggregation in "
+        "experience_guidance reads its typed fields, not its ranked text."
+    ),
+    "core.session_memory_facade": (
+        "Audited: recalled text is appended as a system message for the LLM to "
+        "weigh — advisory, never re-parsed into control flow."
+    ),
+    "core.openclawd": (
+        "Audited twice: the memory__recall tool returns text to the LLM, and the "
+        "tool-exposure gate decides visibility without reading retrieved content."
+    ),
+    "core.eval.memory_eval": (
+        "Evaluation harness, not a runtime path. It measures retrieval quality, "
+        "which necessarily means calling retrieval."
+    ),
+}
+"""Modules that retrieve but whose results cannot change control flow.
+
+Every entry is a claim someone has to defend at review time, which is the point:
+the alternative is a module quietly retrieving on a decision path because nobody
+was forced to look at it."""
 
 AUDITED_RETRIEVAL_CALL_SITES: Tuple[Dict[str, str], ...] = (
     {
@@ -309,6 +358,51 @@ def scan_decision_paths(modules: Optional[Tuple[str, ...]] = None) -> List[Ancho
     for name in modules or DECISION_PATH_MODULES:
         out.extend(scan_module_for_prose_derived_structure(name))
     return out
+
+
+def _retrieval_names_referenced(tree: ast.AST) -> List[str]:
+    """Retrieval entry points this module reaches for, by any syntactic route.
+
+    Counts attribute access and bare names, not just calls: passing ``recall``
+    to ``asyncio.to_thread`` is still retrieval, and a call-only scan misses it
+    (``core.agent.execution_planner`` does exactly that).  Names *defined* here
+    are excluded — defining ``recall`` makes a module the provider, and the
+    provider is judged by :data:`RETRIEVAL_MODULE_EXEMPTIONS`, not by this scan.
+    """
+    found: Set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in RETRIEVAL_CALL_NAMES:
+            found.add(node.attr)
+        elif isinstance(node, ast.Name) and node.id in RETRIEVAL_CALL_NAMES:
+            found.add(node.id)
+    return sorted(found)
+
+
+def modules_performing_retrieval(root: str = "core") -> Dict[str, List[str]]:
+    """Every module under *root* that reaches a retrieval entry point."""
+    out: Dict[str, List[str]] = {}
+    for path in sorted(pathlib.Path(root).rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError) as exc:
+            # Unreadable is not clean: say so rather than shrink the scanned set
+            # silently, which would make the guard weaker without telling anyone.
+            logger.warning("semantic anchoring: could not scan %s (%s)", path, exc)
+            continue
+        names = _retrieval_names_referenced(tree)
+        if names:
+            out[str(path.with_suffix("")).replace("/", ".")] = names
+    return out
+
+
+def unclassified_retrieval_modules(root: str = "core") -> Dict[str, List[str]]:
+    """Retrieving modules that are neither in scope nor exempted.
+
+    Non-empty means someone added retrieval somewhere nobody has judged yet.
+    That is the state this function exists to make impossible to reach quietly.
+    """
+    known = set(DECISION_PATH_MODULES) | set(RETRIEVAL_MODULE_EXEMPTIONS)
+    return {mod: names for mod, names in modules_performing_retrieval(root).items() if mod not in known}
 
 
 def build_audit_report() -> Dict[str, Any]:

--- a/galaxy_gateway/android/handlers/task_lifecycle.py
+++ b/galaxy_gateway/android/handlers/task_lifecycle.py
@@ -272,6 +272,37 @@ def _read_canonical_runtime_status(task_id: Optional[str]) -> Optional[str]:
     except Exception as exc:
         logger.debug("task_lifecycle: task_queue status lookup skipped: %s", exc)
 
+    # 最后一跳:持久对象层。前面每一处都是**进程内**的——CanonicalTaskRuntime 是
+    # 256 条 ring buffer,task_queue 随进程走。任务被挤掉、或网关重启之后,设备来问
+    # "我派的那个任务怎么样了",上面全部答不出,于是返回 None = "不知道"。
+    #
+    # 这正是 Stage 1 那个持久投影存在的理由,也是它到今天为止**唯一没有兑现**的部分:
+    # 数据一直在写,没有人读。这里按 task_id 精确查一次(不是相似度排序,符合
+    # SEMANTIC_ANCHORING::POLICY_1),把"重启后还答得出来"真正接通。
+    #
+    # 灰度未开(默认 shadow)时 store.get() 恒返回 None,本跳等价于不存在 ——
+    # 默认档位下行为与改造前逐字节相同。
+    try:
+        from core.canonical_task_store import get_canonical_task_store
+
+        store = get_canonical_task_store()
+        record = store.get(task_id)
+        if record is not None:
+            mapped = _map_runtime_status_to_task_status(record.lifecycle)
+            if mapped:
+                logger.info(
+                    "task_lifecycle: %s 已不在进程内运行时,由持久对象层作答 lifecycle=%s",
+                    task_id,
+                    record.lifecycle,
+                )
+                return mapped
+        # 走到这里 = 这个问题最终答的是"不知道"。记一笔:灰度还没开时,
+        # 这正是"开了能多答上来多少"的实测依据(store.stats()["answerable_on_miss"]),
+        # 免得把翻不翻 flag 变成一次拍脑袋。它只计数,不回传任何可用于控制流的东西。
+        store.note_live_lookup_miss(task_id)
+    except Exception as exc:
+        logger.debug("task_lifecycle: canonical task store lookup skipped: %s", exc)
+
     return None
 
 

--- a/scripts/check_semantic_anchoring.py
+++ b/scripts/check_semantic_anchoring.py
@@ -33,6 +33,12 @@
 而不是全仓：全仓扫描会被无关的正则用法淹没成噪音，然后被关掉——那比一道窄而常开
 的闸更糟。
 
+但**手写清单会腐烂**：新加一个决策模块，没人往清单里加，闸就悄悄不再覆盖它——
+这与本闸要防的缺陷是同一个形状（"改个格式串，学习静默停止"）。所以本脚本还做
+第二道检查：把**真正做检索调用的模块**推导出来，要求每一个要么在扫描范围内、
+要么在 ``RETRIEVAL_MODULE_EXEMPTIONS`` 里写明豁免理由。新模块一开始检索就会红，
+直到有人对它做出判断。
+
 用法
 ====
     python scripts/check_semantic_anchoring.py            # 有违规则非零退出
@@ -57,8 +63,11 @@ from core.semantic_anchoring import (  # noqa: E402 — path bootstrap must prec
     DECISION_PATHS_MUST_USE_OBJECT_LAYER_POLICY,
     RETRIEVAL_CAPABILITY_IS_NOT_THE_DEFECT_POLICY,
     RETRIEVAL_IS_ADVISORY_ONLY_POLICY,
+    RETRIEVAL_MODULE_EXEMPTIONS,
     build_audit_report,
+    modules_performing_retrieval,
     scan_decision_paths,
+    unclassified_retrieval_modules,
 )
 
 
@@ -75,6 +84,11 @@ def _print_doctrine() -> None:
     print("=" * 72)
     for name in DECISION_PATH_MODULES:
         print(f"  {name}")
+    print("\n检索模块归类（豁免 = 结果不改变控制流）")
+    print("=" * 72)
+    for name, reason in sorted(RETRIEVAL_MODULE_EXEMPTIONS.items()):
+        print(f"  {name}")
+        print(f"    → {reason}")
     print("\n已审计的检索调用点")
     print("=" * 72)
     for site in AUDITED_RETRIEVAL_CALL_SITES:
@@ -97,8 +111,24 @@ def main(argv: list[str] | None = None) -> int:
         print()
 
     violations = scan_decision_paths()
+    unclassified = unclassified_retrieval_modules()
+
+    if unclassified:
+        print(f"\n❌ {len(unclassified)} 个模块做了检索调用，却既不在扫描范围内、也没写豁免理由：\n")
+        for name, calls in sorted(unclassified.items()):
+            print(f"  {name}  →  {', '.join(calls)}")
+        print("\n  它的结果会改变控制流吗？")
+        print("    会 → 加进 DECISION_PATH_MODULES，让扫描器管它。")
+        print("    不会 → 加进 RETRIEVAL_MODULE_EXEMPTIONS，并写清为什么不会。")
+        print("  两者都不做，就等于这道闸从今天起不覆盖它，而且没人会发现。")
+        return 1
+
     if not violations:
-        print(f"\n✅ 决策路径干净：{len(DECISION_PATH_MODULES)} 个模块，未发现从检索文本反解结构的用法。")
+        total = len(modules_performing_retrieval())
+        print(
+            f"\n✅ 决策路径干净：{len(DECISION_PATH_MODULES)} 个模块未发现从检索文本反解结构的用法；"
+            f"{total} 个做检索的模块已全部归类。"
+        )
         return 0
 
     print(f"\n❌ 发现 {len(violations)} 处决策路径从检索到的散文里反解结构：\n")

--- a/scripts/check_wiring.py
+++ b/scripts/check_wiring.py
@@ -405,8 +405,25 @@ def find_unwired(definitions, referenced, def_count) -> List[Tuple[str, str]]:
         rel = locations[0].split(":")[0]
         if _is_exempt(rel, name):
             continue
-        # ast.Name/Attribute 不会匹配 FunctionDef.name,所以 referenced 里出现该名字
-        # 就意味着**真的有别处用到**,定义处自身不会自证。
+        # 这里的"被引用"是**全仓非测试代码里出现过这个名字**,不是"外部可达"。
+        #
+        # 原注释写的是"定义处自身不会自证",那句话是错的:``self.foo(...)`` 写在
+        # foo 自己的模块里,也是一个 ast.Attribute,照样算引用。于是一个只被同模块
+        # 内部调用、外面没有任何人用的公开能力,能靠自引用躲过这道闸
+        # (实例:core/ontology/links.py 的 for_source,唯一引用来自同文件的
+        # resolve_all)。**这是本闸已知的漏检,不是它的设计意图。**
+        #
+        # 为什么没有顺手修:量过了。
+        #   仅靠模块内自引用而算作"已接线"的:888 个
+        #   其中连模块内可达性都通不过的:      243 个
+        # 而这 243 条里占多数的是**误报**——装饰器返回的内层函数(error_framework
+        # 的 async_wrapper)、以及节点按字符串名分发的 action handler(分发表就在
+        # 同一个文件里,Node_83 的 add_feed 之类)。把它们报出来,这道闸就会变成
+        # 没人看的噪音,然后被关掉——而本文件顶部的设计说明恰恰写着,那比一道窄而
+        # 常开的闸更糟。
+        #
+        # 真要修,需要的是函数级可达性 + 一个能理解字符串分发的模型,不是在这里
+        # 多加一个条件。在那之前,这条漏检是**写明的**,不是假装不存在的。
         if name in referenced:
             continue
         out.append((name, locations[0]))

--- a/tests/test_canonical_task_store_stage1.py
+++ b/tests/test_canonical_task_store_stage1.py
@@ -513,3 +513,101 @@ class TestGroupGWiring:
         task = _task(goal="即使存储爆炸也要注册成功")
         assert runtime.register(task) is task
         assert runtime.get_by_task_id(task.identity.task_id) is task
+
+
+# ---------------------------------------------------------------------------
+# Group J — the durable layer finally has a consumer
+# ---------------------------------------------------------------------------
+
+
+class TestGroupJFirstRealConsumer:
+    """存了一堆数据却没有任何人读,是这一层到今天为止真正的缺口。
+
+    消费者选在 Android 问"我派的那个任务怎么样了":之前的每一跳都是**进程内**的
+    (CanonicalTaskRuntime 是 256 条 ring buffer、task_queue 随进程走),任务被挤掉
+    或网关重启之后,设备拿到的是"不知道"。持久投影正是为这件事建的。
+    """
+
+    def _reset(self, tmp_path, monkeypatch, mode):
+        import core.canonical_task_store as mod
+
+        monkeypatch.setenv("GALAXY_CANONICAL_TASK_STORE", mode)
+        monkeypatch.setattr(mod, "_STORE", None, raising=False)
+        store = mod.CanonicalTaskStore(data_dir=str(tmp_path))
+        monkeypatch.setattr(mod, "get_canonical_task_store", lambda: store)
+        return store
+
+    def _record(self, store, lifecycle):
+        """存一个真实的 CanonicalTask,返回它的 task_id。
+
+        刻意不手搓 PersistedTaskRecord:那样测的是我自己造的假数据,
+        而这条链路真正要证明的是"注册路径写进去的那个,查得回来"。
+        """
+        from core.canonical_task import TaskLifecycle
+
+        task = _task(goal="被挤掉的任务", lifecycle=getattr(TaskLifecycle, lifecycle.upper()))
+        store.upsert(task)
+        return task.task_id
+
+    def test_j01_answers_after_the_in_process_runtimes_have_forgotten(self, tmp_path, monkeypatch):
+        from galaxy_gateway.android.handlers import task_lifecycle as tl
+
+        store = self._reset(tmp_path, monkeypatch, "on")
+        task_id = self._record(store, "completed")
+        assert tl._read_canonical_runtime_status(task_id) == "completed"
+
+    def test_j02_shadow_mode_still_answers_unknown(self, tmp_path, monkeypatch):
+        """默认档位下行为必须与改造前完全一致 —— shadow 的全部意义就在这里。"""
+        from galaxy_gateway.android.handlers import task_lifecycle as tl
+
+        store = self._reset(tmp_path, monkeypatch, "shadow")
+        task_id = self._record(store, "completed")
+        assert tl._read_canonical_runtime_status(task_id) is None
+
+    def test_j03_shadow_mode_measures_what_turning_it_on_would_buy(self, tmp_path, monkeypatch):
+        """翻不翻 flag 应该有实测依据,而不是拍脑袋。"""
+        from galaxy_gateway.android.handlers import task_lifecycle as tl
+
+        store = self._reset(tmp_path, monkeypatch, "shadow")
+        task_id = self._record(store, "completed")
+
+        tl._read_canonical_runtime_status(task_id)
+        tl._read_canonical_runtime_status("t-never-seen")
+
+        st = store.stats()
+        assert st["live_lookup_misses"] == 2
+        assert st["answerable_on_miss"] == 1, "只有存过的那一个才算'开了能多答上来'"
+
+    def test_j04_the_probe_cannot_leak_state_into_behaviour(self):
+        """shadow 的保证是它持有的东西碰不到行为,所以探针不许有返回值。"""
+        import inspect
+
+        from core.canonical_task_store import CanonicalTaskStore
+
+        sig = inspect.signature(CanonicalTaskStore.note_live_lookup_miss)
+        assert sig.return_annotation is None or sig.return_annotation == "None"
+        src = inspect.getsource(CanonicalTaskStore.note_live_lookup_miss)
+        returns = [ln.strip() for ln in src.splitlines() if ln.strip().startswith("return")]
+        assert returns == ["return"], f"探针把状态回传出去了: {returns}"
+
+    def test_j05_lookup_is_exact_not_ranked(self, tmp_path, monkeypatch):
+        """POLICY_1:决策/作答用的查询必须是确定性的,不是相似度排序。"""
+        import inspect
+
+        from galaxy_gateway.android.handlers import task_lifecycle as tl
+
+        src = inspect.getsource(tl._read_canonical_runtime_status)
+        assert ".get(task_id)" in src
+        for ranked in ("recall", "retrieve_similar", "search_hybrid"):
+            assert ranked not in src, f"任务状态查询里出现了排序检索: {ranked}"
+
+    def test_j06_store_failure_never_breaks_the_answer(self, tmp_path, monkeypatch):
+        """对象层不可用只该让这一跳失效,不该让整条状态查询炸掉。"""
+        import core.canonical_task_store as mod
+        from galaxy_gateway.android.handlers import task_lifecycle as tl
+
+        def boom():
+            raise RuntimeError("store down")
+
+        monkeypatch.setattr(mod, "get_canonical_task_store", boom)
+        assert tl._read_canonical_runtime_status("whatever") is None

--- a/tests/test_check_wiring.py
+++ b/tests/test_check_wiring.py
@@ -255,3 +255,37 @@ class TestAgainstTheRealRepo:
         """只有测试调用它,恰恰就是本工具要抓的情形 —— tests/ 绝不能算作"接上了"。"""
         assert "tests" in cw.REFERENCE_SKIP_PARTS
         assert not any("tests" in p.parts for p in cw._iter_reference_files())
+
+
+class TestKnownBlindSpotIsDocumentedNotHidden:
+    """这道闸有一个已知漏检:只被同模块内部调用的公开能力算"已接线"。
+
+    钉住它有两个理由。一是防止有人再把那句错的断言写回去("定义处自身不会自证"
+    ——``self.foo()`` 就在同一个文件里,照样算引用)。二是让漏检**留在代码里被看见**:
+    量过之后没修,是因为修了会产生 243 条以误报为主的告警(装饰器内层函数、节点按
+    字符串名分发的 handler),那会让这道闸被关掉。写明的漏检和假装没有的漏检,
+    是两回事。
+    """
+
+    def test_self_reference_currently_counts_as_wired(self):
+        """这就是漏检本身 —— 它成立,所以下面那条注释必须在。"""
+        src = "class R:\n    def helper(self):\n        return 1\n    def other(self):\n        return self.helper()\n"
+        import ast
+
+        tree = ast.parse(src)
+        referenced = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                referenced.add(node.attr)
+        assert "helper" in referenced, "同模块内的 self.helper() 确实被算作引用"
+
+    def test_the_blind_spot_is_written_down_where_the_decision_is_made(self):
+        """漏检必须记在做判断的那一行旁边,不是记在某个人的记忆里。"""
+        import inspect
+
+        import scripts.check_wiring as cw
+
+        src = inspect.getsource(cw.find_unwired)
+        assert "漏检" in src, "已知漏检没有写在 find_unwired 里"
+        assert "888" in src and "243" in src, "没有留下量化依据,下一个人只能重新测一遍"
+        assert "自证" not in src.replace("定义处自身不会自证", ""), "那句错的断言不该再出现"

--- a/tests/test_experience_guidance_object_anchored.py
+++ b/tests/test_experience_guidance_object_anchored.py
@@ -570,3 +570,109 @@ class TestGroupFRegressionGuards:
         assert flag.default == "on"
         assert flag.cleanup_condition
         assert flag.rollout_plan
+
+
+# ---------------------------------------------------------------------------
+# Group K — the thresholds must become answerable, not merely arguable
+# ---------------------------------------------------------------------------
+
+
+class TestGroupKThresholdEvidence:
+    """DEFAULT_MIN_SAMPLES / MARGIN / COLD_START_FLOOR 是拍出来的,不是量出来的。
+
+    它们控制的是"这一层多久开一次口",所以调它们的人第一件需要的东西就是那个
+    比率,以及没开口时的原因分布。这组判据钉的是**这个数拿得到**——拿不到的话,
+    这三个常数就永远只能靠争论,不能靠证据。
+    """
+
+    def _reset(self):
+        from core.cognitive.experience_guidance import get_experience_guidance_stats
+
+        get_experience_guidance_stats(reset=True)
+
+    def test_k01_every_derivation_is_counted(self, monkeypatch):
+        from core.cognitive.experience_guidance import (
+            derive_experience_guidance,
+            get_experience_guidance_stats,
+        )
+
+        self._reset()
+        for _ in range(4):
+            derive_experience_guidance("装个应用", "single", task_type="app")
+        assert get_experience_guidance_stats()["derivations"] == 4
+
+    def test_k02_declines_are_attributed_to_a_reason(self):
+        from core.cognitive.experience_guidance import (
+            derive_experience_guidance,
+            get_experience_guidance_stats,
+        )
+
+        self._reset()
+        derive_experience_guidance("", "single")
+        reasons = get_experience_guidance_stats()["declined_by_reason"]
+        assert reasons, "没开口却说不出为什么 —— 那就还是不可诊断"
+        assert sum(reasons.values()) == 1
+
+    def test_k03_disabled_mode_is_still_counted(self, monkeypatch):
+        """关掉也要计数:否则"它从没开过口"与"它压根没被调用"分不开。"""
+        from core.cognitive.experience_guidance import (
+            derive_experience_guidance,
+            get_experience_guidance_stats,
+        )
+
+        monkeypatch.setenv("GALAXY_EXPERIENCE_GUIDANCE", "off")
+        self._reset()
+        derive_experience_guidance("装个应用", "single")
+        stats = get_experience_guidance_stats()
+        assert stats["derivations"] == 1
+        assert stats["influenced"] == 0
+
+    def test_k04_stats_report_the_thresholds_they_describe(self):
+        from core.cognitive.experience_guidance import (
+            DEFAULT_COLD_START_FLOOR,
+            DEFAULT_MARGIN,
+            DEFAULT_MIN_SAMPLES,
+            get_experience_guidance_stats,
+        )
+
+        th = get_experience_guidance_stats()["thresholds"]
+        assert th["min_samples"] == DEFAULT_MIN_SAMPLES
+        assert th["margin"] == DEFAULT_MARGIN
+        assert th["cold_start_floor"] == DEFAULT_COLD_START_FLOOR
+
+    def test_k05_reset_starts_a_new_window(self):
+        """要能量"最近这一段",不是只能量"自进程启动以来"。"""
+        from core.cognitive.experience_guidance import (
+            derive_experience_guidance,
+            get_experience_guidance_stats,
+        )
+
+        self._reset()
+        derive_experience_guidance("装个应用", "single")
+        assert get_experience_guidance_stats(reset=True)["derivations"] == 1
+        assert get_experience_guidance_stats()["derivations"] == 0
+
+    def test_k05b_scope_sample_is_bounded(self):
+        """长期进程里的计数器不许无界增长。"""
+        from core.cognitive import experience_guidance as mod
+
+        self._reset()
+        for _ in range(mod._SCOPE_SAMPLE_CAP + 50):
+            mod._note_outcome(mod.ExperienceGuidance(scope_size=1))
+        assert len(mod._STATS["scope_sizes"]) == mod._SCOPE_SAMPLE_CAP
+
+    def test_k06_instrumentation_cannot_break_planning(self, monkeypatch):
+        """统计失败绝不能让策略选择挂掉。"""
+        from core.cognitive import experience_guidance as mod
+
+        class Hostile:
+            influenced_by_experience = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        mod._note_outcome(Hostile())  # 不抛即通过
+
+    def test_k07_json_safe(self):
+        import json
+
+        from core.cognitive.experience_guidance import get_experience_guidance_stats
+
+        json.dumps(get_experience_guidance_stats())

--- a/tests/test_semantic_anchoring_stage2.py
+++ b/tests/test_semantic_anchoring_stage2.py
@@ -42,6 +42,14 @@ Group C — Guard validated against real history
        _experience_strategy_adjust — the known, real defect.
   C02. The same file after Stage 0 is clean.
 
+Group E — Scope cannot silently decay
+  E01. Every module that retrieves is either in scope or exempted with a reason.
+  E02. Exemption reasons are substantive, not placeholders.
+  E03. A module cannot be both in scope and exempted.
+  E04. Detection sees a retrieval name passed as a callable, not only called.
+  E05. Introducing an unclassified retriever is actually caught.
+  E06. Exempted modules all still exist.
+
 Group D — Live repository state
   D01. All decision-path modules currently scan clean.
   D02. build_audit_report() reports clean and is JSON-safe.
@@ -232,3 +240,72 @@ class TestGroupDLiveState:
         assert report["clean"] is True
         assert report["violations"] == []
         assert report["scanned_modules"]
+
+
+# ---------------------------------------------------------------------------
+# Group E — the scan scope must not be able to rot
+# ---------------------------------------------------------------------------
+
+
+class TestGroupEScopeCannotDecay:
+    """A hand-written scope list is exactly the kind of thing that stops covering
+    new code without anyone noticing — the same defect shape this guard exists to
+    prevent. These tests make the omission loud instead of silent."""
+
+    def test_e01_every_retrieving_module_is_classified(self):
+        from core.semantic_anchoring import unclassified_retrieval_modules
+
+        unclassified = unclassified_retrieval_modules()
+        assert unclassified == {}, "这些模块做了检索调用但没人判断过它的结果会不会改变控制流:\n" + "\n".join(
+            f"  {m} → {', '.join(c)}" for m, c in sorted(unclassified.items())
+        )
+
+    def test_e02_exemption_reasons_are_substantive(self):
+        from core.semantic_anchoring import RETRIEVAL_MODULE_EXEMPTIONS
+
+        assert RETRIEVAL_MODULE_EXEMPTIONS, "豁免表空了 —— 那这条判据就没有被真正使用"
+        for module, reason in RETRIEVAL_MODULE_EXEMPTIONS.items():
+            assert len(reason) > 40, f"{module} 的豁免理由太短,像占位符而不是判断"
+            assert not reason.lower().startswith(("todo", "n/a", "wip")), f"{module} 的豁免是个占位符"
+
+    def test_e03_in_scope_and_exempt_are_mutually_exclusive(self):
+        from core.semantic_anchoring import DECISION_PATH_MODULES, RETRIEVAL_MODULE_EXEMPTIONS
+
+        overlap = set(DECISION_PATH_MODULES) & set(RETRIEVAL_MODULE_EXEMPTIONS)
+        assert not overlap, f"既在扫描范围内又被豁免,判断自相矛盾: {sorted(overlap)}"
+
+    def test_e04_detects_retrieval_passed_as_a_callable(self):
+        """``to_thread(_um.recall, …)`` 是检索,只看 Call 节点会漏掉它。
+
+        这不是假想:``core.agent.execution_planner`` 就是这么写的。
+        """
+        import ast
+
+        from core.semantic_anchoring import _retrieval_names_referenced
+
+        tree = ast.parse("import asyncio\nasync def f(m):\n    return await asyncio.to_thread(m.recall, 'q')\n")
+        assert "recall" in _retrieval_names_referenced(tree)
+
+    def test_e05_an_unclassified_retriever_would_be_caught(self, tmp_path, monkeypatch):
+        """判据得真能抓到新增的未归类检索模块,否则它只是一句好听的话。"""
+        from core.semantic_anchoring import unclassified_retrieval_modules
+
+        pkg = tmp_path / "core"
+        pkg.mkdir()
+        (pkg / "brand_new_decider.py").write_text(
+            "def decide(mem):\n    hits = mem.recall('q')\n    return bool(hits)\n", encoding="utf-8"
+        )
+        monkeypatch.chdir(tmp_path)
+        found = unclassified_retrieval_modules("core")
+        assert "core.brand_new_decider" in found
+        assert found["core.brand_new_decider"] == ["recall"]
+
+    def test_e06_exempted_modules_still_exist(self):
+        """豁免一个已经不存在的模块 = 名单在腐烂,只是腐烂得看不见。"""
+        import pathlib
+
+        from core.semantic_anchoring import RETRIEVAL_MODULE_EXEMPTIONS
+
+        for module in RETRIEVAL_MODULE_EXEMPTIONS:
+            path = pathlib.Path(module.replace(".", "/") + ".py")
+            assert path.exists(), f"{module} 已被豁免,但这个文件不存在了"


### PR DESCRIPTION
承接 #1603。上一轮把 Stage 1–3 的地基铺好了，但**地基上没有建筑**：持久对象层一直在写，没有人读。这一轮补的就是这件事，外加两处会随时间腐烂的判据。

**默认档位下行为与改造前逐字节相同**（灰度仍是 `shadow`）。

---

## 一、对象层的第一个真实消费者

这是 Stage 1 到今天为止**唯一没有兑现**的部分。

Android 问「我派的那个任务怎么样了」，之前每一跳都是**进程内**的：`CanonicalTaskRuntime` 是 256 条 ring buffer、`task_queue` 随进程走。任务被挤掉、或网关重启之后，全部答不出，设备拿到的是「不知道」。

在 `_read_canonical_runtime_status` 末尾加最后一跳：按 `task_id` **精确查**持久投影——不是相似度排序，符合 `SEMANTIC_ANCHORING::POLICY_1`。灰度未开时 `store.get()` 恒返回 `None`，这一跳等价于不存在。

> **顺带纠正上一轮我说错的一句话。** 我曾说「对象层才是能确定性回答『某 task_type 用 X 策略成功过几次』的地方」——不对。`CanonicalTask` **不记录执行策略**（`TaskExecution` 没有这个字段），那个事实只存在于 `TaskSummary`。所以 `experience_guidance` 不是它的消费者，真正的消费者是任务状态查询。

## 二、翻 flag 该有实测依据，不该拍脑袋

新增 `store.note_live_lookup_miss()`：记录「每一跳都没答上来」的次数，以及其中持久层**本可以**答上来的次数（`answerable_on_miss`）。没有这个数，把 `shadow` 翻成 `on` 就是一次猜测。

它**刻意没有返回值**。shadow 的保证是它持有的东西碰不到行为；回传一个 bool 就等于让状态从灰度里漏出去。测试 J04 钉住了这一点（源码里只允许出现裸 `return`）。

## 三、守卫的作用域不再靠人记得维护

`DECISION_PATH_MODULES` 是**手写的 6 个模块**，而 `core/agent` + `core/cognitive` 有 25 个。新加一个决策模块没人往名单里加，闸就悄悄不再覆盖它——**这与它要防的缺陷是同一个形状**（"改个格式串，学习静默停止"）。

改为：把真正做检索调用的模块**推导**出来（9 个），要求每一个要么在扫描范围内、要么在 `RETRIEVAL_MODULE_EXEMPTIONS` 里写明豁免理由。新模块一开始检索就会红，直到有人对它做出判断。

检测同时覆盖「把方法当引用传」的写法（`to_thread(_um.recall, …)`）——只看 `ast.Call` 会漏掉 `execution_planner` 自己。

## 四、三个阈值常数变得可评估

`DEFAULT_MIN_SAMPLES=5` / `MARGIN=0.34` / `COLD_START_FLOOR=0.60` 是拍出来的，**没有任何数据支撑**。它们控制的是「这一层多久开一次口」。

新增 `get_experience_guidance_stats(reset=)`：开口率、未开口的原因分布、作用域规模中位数。真实流量我造不出来，但「一旦有流量就量得到」是能交付的。

## 五、`check_wiring` 的已知漏检：量过之后决定**不修**，并写明为什么

只被同模块内部调用的公开能力，能靠自引用躲过这道闸（实例：`links.py` 的 `for_source`）。原注释断言"定义处自身不会自证"——**那句是错的**，`self.foo()` 就在同一个文件里，照样算引用。已删。

没顺手修是因为量过了：

| 类别 | 数量 |
|---|---|
| 仅靠模块内自引用而算作"已接线" | **888** |
| 其中连模块内可达性都通不过 | **243** |

而这 243 条**以误报为主**——装饰器返回的内层函数（`error_framework` 的 `async_wrapper`）、节点按字符串名分发的 action handler（分发表就在同一个文件里）。报出来这道闸就会变成没人看的噪音然后被关掉，**那比一道窄而常开的闸更糟**——这正是该文件顶部自己写下的设计原则。

真要修，需要函数级可达性 + 一个能理解字符串分发的模型。在那之前，这条漏检是**写明的**，不是假装不存在的。

> **这道闸当场抓到了我自己。** 新加的 `reset_experience_guidance_stats` 只有测试在用。同一把尺子量到自己身上——折进 `get_experience_guidance_stats(reset=True)`，不留没有生产调用方的公开函数。

---

## 明确没有做的两件

| 项 | 为什么 |
|---|---|
| 三个常数的**实效验证** | 需要真实生产流量，这个环境里没有。造数据得出的结论是假的。已交付「可测」，没交付「已测」。 |
| 水印装 `torch` + `audioseal` | GB 级依赖，是运营决定不是技术决定。现状是**诚实的**：`WatermarkResult` 会明说"想打但打不上"，而不是静默无水印。 |

## 验证

| 项 | 结果 |
|---|---|
| 新增测试 | Group E（守卫作用域）6 条、Group J（对象层消费者）6 条、Group K（阈值可评估）8 条 |
| 相关套件 | 248 passed |
| 三道 lint 门 | flake8（CI 口径 `core/ galaxy_gateway/`）= 0；black、isort 干净 |
| 结构守卫 | 语义锚定 ✅（9 个检索模块已全部归类）、可达性 ✅、复杂度预算 ✅ |
| 本地全量 | 跑完补充在评论里 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2fQk5F3uQGUaX1nXpZ2vt)_