### PR TITLE
把三份各自独立的界面理解收成一份（Stage A–C）

### DIFF
--- a/config/file_complexity_baseline.json
+++ b/config/file_complexity_baseline.json
@@ -135,7 +135,7 @@
     "galaxy_gateway/device_router.py": 2139,
     "galaxy_gateway/orchestrator/galaxy_orchestrator.py": 1371,
     "galaxy_gateway/orchestrator/task_orchestrator.py": 1051,
-    "galaxy_gateway/websocket_handler.py": 1250,
+    "galaxy_gateway/websocket_handler.py": 1262,
     "launcher/node_startup.py": 1003,
     "launcher/services.py": 2242,
     "main.py": 1718,

--- a/core/android_ui_snapshot.py
+++ b/core/android_ui_snapshot.py
@@ -53,6 +53,8 @@ __all__ = [
     "SNAPSHOT_RIDES_AN_EXISTING_UPLINK_POLICY",
     "ANDROID_CLASS_ROLE_MAP",
     "SNAPSHOT_PAYLOAD_KEY",
+    "SNAPSHOT_WIRE_FIELDS",
+    "SNAPSHOT_ELEMENT_WIRE_FIELDS",
     "project_android_snapshot",
     "absorb_snapshot_payload",
     "latest_graph_for",
@@ -89,6 +91,33 @@ SNAPSHOT_RIDES_AN_EXISTING_UPLINK_POLICY: str = (
 
 SNAPSHOT_PAYLOAD_KEY: str = "ui_snapshot_payload"
 """Android 端在 emission payload 上挂快照用的字段名(两端唯一约定处)。"""
+
+SNAPSHOT_WIRE_FIELDS: Tuple[str, ...] = ("packageName", "screenWidth", "screenHeight", "elements")
+"""快照顶层的线材字段名。"""
+
+SNAPSHOT_ELEMENT_WIRE_FIELDS: Tuple[str, ...] = (
+    "index",
+    "text",
+    "contentDescription",
+    "className",
+    "clickable",
+    "left",
+    "top",
+    "right",
+    "bottom",
+)
+"""单个元素的线材字段名。
+
+**为什么要把它写成常量而不是只靠一条跨仓测试。**
+最初这条对齐是用一个直接读 Kotlin 源文件的测试守的。它在本机能跑，在 CI 上
+**永远 skip**——两个仓的 CI 都只检出自己，谁也看不见对方。也就是说那条测试
+提供的保护是零，而它看起来像有保护，这比没有更糟。
+
+改成：字段名写在这里，两边各自验证自己那一半——
+  * V2 侧断言投影器确实按这些名字取值（本仓 CI 强制执行，不会 skip）；
+  * Android 侧 ``UiSnapshotUplinkTest`` 断言 DTO 确实发这些名字（android 仓 CI 强制执行）。
+两条独立的测试指向同一份写下来的约定，任何一边改名都会在**自己那边**红。
+跨仓源码比对仍然保留，但只作为本机可用时的额外一层，不再是唯一依靠。"""
 
 ANDROID_CLASS_ROLE_MAP: Dict[str, str] = {
     "button": "button",

--- a/core/android_ui_snapshot.py
+++ b/core/android_ui_snapshot.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+core/android_ui_snapshot.py — Android 无障碍快照 → 统一控件契约
+================================================================
+
+**Stage C：填上 ``UISource.ANDROID_A11Y`` 的生产者，让服务端"看得见"手机屏幕。**
+
+之前是什么状态
+--------------
+两端各自都做完了，中间那根线不存在：
+
+* **Android 端**：``AccessibilityUiSnapshotProvider`` 读 ``rootInActiveWindow``、
+  剪枝（只收可见且有语义价值的节点、上限 120、深度 40）、拍平成
+  ``UiStructuredSnapshot``，还修过一个节点未回收的真 bug。
+* **V2 端**：``UIGraph`` 契约里 ``UISource.ANDROID_A11Y`` 这个来源
+  **声明了却零生产者**；``ui_grounding`` 在 Android 上因此永远走 ``DEFER_TO_MODEL``。
+* 设备一直在上报 ``accessibility_ready: true``，而网关**只拿它做设备选择评分**，
+  从没有任何链路把那棵树取回来。
+
+本模块就是那根线的 V2 端。
+
+看得见 ≠ 可以决定
+-----------------
+这是本模块最要紧的一条纪律，写在 :data:`SNAPSHOT_IS_FOR_SEEING_POLICY`：
+拿到的图**只用于服务端"看得见"**——跨设备编排、面板呈现、多步规划的可行性判断
+——**绝不用于覆盖设备端 ``GroundingArbiter`` 已经做出的裁决**
+（见 :mod:`core.perception_grounding` 的 POLICY_1 / POLICY_3）。
+
+两端在延迟不同的两个瞬间看到的是不同的屏幕。让后到的一方推翻先到的一方，
+得到的不是更准，是不可复现——而且现场分不出这一下是谁点的。
+
+搭车而不是新开一条管道
+----------------------
+快照搭 ``DEVICE_PERCEPTION_EMISSION`` 这条既有上行（Android 端已在持续发送
+screenshot / vision / grounding），只多一个**默认为空的可选字段**。
+没有新消息类型、没有协议变更；设备不带这个字段时，整条链路与改造前逐字节相同。
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.schemas.ui_element import UIActionKind, UIBounds, UIElementNode, UIGraph, UISource
+
+logger = logging.getLogger("Galaxy.AndroidUISnapshot")
+
+__all__ = [
+    "SNAPSHOT_IS_FOR_SEEING_POLICY",
+    "SNAPSHOT_RIDES_AN_EXISTING_UPLINK_POLICY",
+    "ANDROID_CLASS_ROLE_MAP",
+    "SNAPSHOT_PAYLOAD_KEY",
+    "project_android_snapshot",
+    "absorb_snapshot_payload",
+    "latest_graph_for",
+    "snapshot_store_stats",
+]
+
+
+# ---------------------------------------------------------------------------
+# Policy sentinels
+# ---------------------------------------------------------------------------
+
+SNAPSHOT_IS_FOR_SEEING_POLICY: str = (
+    "ANDROID_UI_SNAPSHOT::POLICY_1: "
+    "A received snapshot is for the server to SEE with, never to decide with. "
+    "Android grounding is owned by the device (perception_grounding POLICY_1); "
+    "the two sides observed the screen at different instants, so a server-side "
+    "override produces irreproducibility rather than accuracy — and afterwards "
+    "nobody can tell which side issued the tap."
+)
+
+SNAPSHOT_RIDES_AN_EXISTING_UPLINK_POLICY: str = (
+    "ANDROID_UI_SNAPSHOT::POLICY_2: "
+    "The snapshot travels as one optional, default-absent field on the existing "
+    "DEVICE_PERCEPTION_EMISSION uplink.  No new message type and no protocol "
+    "change: a device that does not send the field leaves every byte of the "
+    "existing path unchanged, which is what makes this safe to land before "
+    "anyone has decided whether to switch it on."
+)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+SNAPSHOT_PAYLOAD_KEY: str = "ui_snapshot_payload"
+"""Android 端在 emission payload 上挂快照用的字段名(两端唯一约定处)。"""
+
+ANDROID_CLASS_ROLE_MAP: Dict[str, str] = {
+    "button": "button",
+    "imagebutton": "button",
+    "imageview": "image",
+    "edittext": "edit",
+    "autocompletetextview": "edit",
+    "textview": "text",
+    "checkbox": "checkbox",
+    "radiobutton": "radio",
+    "switch": "switch",
+    "switchcompat": "switch",
+    "seekbar": "slider",
+    "spinner": "combobox",
+    "recyclerview": "list",
+    "listview": "list",
+    "scrollview": "list",
+    "nestedscrollview": "list",
+    "viewpager": "tab",
+    "tablayout": "tab",
+    "webview": "group",
+    "framelayout": "group",
+    "linearlayout": "group",
+    "relativelayout": "group",
+    "constraintlayout": "group",
+    "view": "view",
+}
+"""Android 控件类名(去包名、小写)→ 契约里的规范化 role。
+
+查不到的类名落到 ``view``——**不是** ``text``:说不上来是什么，就别声称它是一段
+文字。谎报成不可交互的文字，模型就不会去点它。"""
+
+_MAX_DEVICES = 64
+"""最多为多少台设备各留一份最新快照。
+
+有界是必须的:这是长驻进程里的缓存,不是日志。超出后按最久未更新淘汰。"""
+
+_STALE_SECONDS = 120.0
+"""超过这个时长的快照不再作为"当前界面"回答。
+
+界面是会变的。把两分钟前的树当成现在的屏幕交出去,比说"我不知道"更危险——
+调用方会照着它规划一串再也点不中的动作。"""
+
+_lock = threading.Lock()
+_latest: Dict[str, Tuple[float, UIGraph]] = {}
+_stats: Dict[str, int] = {"absorbed": 0, "rejected": 0, "served": 0, "stale_declined": 0}
+
+
+def _role_of(class_name: str) -> str:
+    leaf = (class_name or "").strip().rsplit(".", 1)[-1].lower()
+    return ANDROID_CLASS_ROLE_MAP.get(leaf, "view")
+
+
+def _bounds_of(element: Dict[str, Any]) -> Optional[UIBounds]:
+    """LTRB → 左上角+宽高。给不出**可用**锚点时返回 None 并说明原因。
+
+    零面积框会被丢弃:它看起来像个有效坐标,却点不中任何东西,而下游拿到它就不会
+    再退回让模型看画面。猜错的坐标比没有坐标危险。
+    """
+    try:
+        left = int(element.get("left", 0) or 0)
+        top = int(element.get("top", 0) or 0)
+        right = int(element.get("right", 0) or 0)
+        bottom = int(element.get("bottom", 0) or 0)
+    except (TypeError, ValueError) as exc:
+        logger.warning("a11y 元素坐标无法解析(%s),该节点没有坐标锚点", exc)
+        return None
+    bounds = UIBounds(x=left, y=top, width=max(0, right - left), height=max(0, bottom - top))
+    if bounds.area() <= 0:
+        return None
+    return bounds
+
+
+def _project_element(raw: Dict[str, Any]) -> Optional[UIElementNode]:
+    text = str(raw.get("text", "") or "").strip()
+    desc = str(raw.get("contentDescription", "") or raw.get("content_description", "") or "").strip()
+    label = text or desc
+    clickable = bool(raw.get("clickable", False))
+    role = _role_of(str(raw.get("className", "") or raw.get("class_name", "")))
+    editable = role == "edit"
+
+    actions: List[UIActionKind] = []
+    if clickable:
+        actions.append(UIActionKind.TAP)
+    if editable:
+        actions.append(UIActionKind.SET_TEXT)
+
+    bounds = _bounds_of(raw)
+    if not label and bounds is None:
+        # 既叫不出名字、又点不中的节点，对模型和执行器都不构成一个可用候选：
+        # 它引用不了（to_prompt 里是一行空壳）、也落不了点。留着只会把图撑大，
+        # 还会让"拿到了一张图"这件事变得不再意味着"看得见这一屏"。
+        # 采集端本来就只收有语义价值的节点，走到这里说明这一条是坏的。
+        return None
+
+    index = raw.get("index")
+    return UIElementNode(
+        node_id=f"a11y-{index}" if index is not None else "",
+        role=role,
+        label=label,
+        bounds=bounds,
+        clickable=clickable,
+        editable=editable,
+        actions=actions,
+        source=UISource.ANDROID_A11Y,
+        # 结构节点是系统对自身的陈述,不是对像素的推断 —— 置信度就是 1.0。
+        confidence=1.0,
+        class_name=str(raw.get("className", "") or raw.get("class_name", "") or ""),
+        package=str(raw.get("package", "") or ""),
+    )
+
+
+def project_android_snapshot(payload: Any, *, device_id: str = "") -> Tuple[UIGraph, str]:
+    """``UiStructuredSnapshot`` 的 JSON → ``UIGraph``。返回 ``(图, 说明)``。
+
+    说明恒非空:"这一屏没有可用控件"与"载荷坏了"都产生空图,但前者该退回纯视觉,
+    后者是缺陷。空图配空说明会把这个区别抹掉。
+    """
+    empty = UIGraph(source=UISource.ANDROID_A11Y, device_id=device_id)
+    if not isinstance(payload, dict):
+        return empty, f"载荷不是对象({type(payload).__name__})"
+
+    raw_elements = payload.get("elements")
+    if not isinstance(raw_elements, list):
+        return empty, "载荷缺少 elements 列表"
+
+    children: List[UIElementNode] = []
+    skipped = 0
+    for raw in raw_elements:
+        if not isinstance(raw, dict):
+            skipped += 1
+            continue
+        node = _project_element(raw)
+        if node is None:
+            skipped += 1
+            continue
+        children.append(node)
+
+    if not children:
+        return empty, f"快照里没有可用控件(收到 {len(raw_elements)} 条,全部跳过)"
+
+    package = str(payload.get("packageName", "") or payload.get("package_name", "") or "")
+    root = UIElementNode(role="root", label=package, source=UISource.ANDROID_A11Y, confidence=1.0)
+    root.children = children
+
+    def _dim(*keys: str) -> int:
+        for key in keys:
+            try:
+                value = int(payload.get(key, 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if value:
+                return value
+        return 0
+
+    graph = UIGraph(
+        root=root,
+        source=UISource.ANDROID_A11Y,
+        device_id=device_id,
+        app=package,
+        screen_width=_dim("screenWidth", "screen_width"),
+        screen_height=_dim("screenHeight", "screen_height"),
+        captured_at_ms=int(time.time() * 1000),
+    )
+    note = f"a11y 快照:{len(children)} 个控件"
+    if skipped:
+        note += f"(跳过 {skipped} 条无效)"
+    return graph, note
+
+
+def _evict_locked() -> None:
+    while len(_latest) > _MAX_DEVICES:
+        oldest = min(_latest, key=lambda key: _latest[key][0])
+        _latest.pop(oldest, None)
+
+
+def absorb_snapshot_payload(payload: Any, *, device_id: str) -> Tuple[bool, str]:
+    """把设备上报的快照收进来。返回 ``(是否收下, 说明)``。
+
+    永不抛:它跑在 WebSocket 上行处理里,一个坏载荷不该影响连接。
+    """
+    if not device_id:
+        with _lock:
+            _stats["rejected"] += 1
+        return False, "缺少 device_id,无法归属"
+    try:
+        graph, note = project_android_snapshot(payload, device_id=device_id)
+    except Exception as exc:  # noqa: BLE001 — 上行处理绝不能因为一个坏载荷而中断
+        logger.warning("a11y 快照投影异常(device=%s): %s", device_id, exc)
+        with _lock:
+            _stats["rejected"] += 1
+        return False, f"投影异常({type(exc).__name__})"
+
+    if graph.root is None:
+        with _lock:
+            _stats["rejected"] += 1
+        return False, note
+
+    with _lock:
+        _latest[device_id] = (time.time(), graph)
+        _stats["absorbed"] += 1
+        _evict_locked()
+    logger.info("已收下设备 %s 的 %s", device_id, note)
+    return True, note
+
+
+def latest_graph_for(device_id: str) -> Tuple[Optional[UIGraph], str]:
+    """取某台设备最近一次的界面结构——**供服务端"看得见",不供覆盖设备裁决**。
+
+    过期的快照一律不给（见 :data:`_STALE_SECONDS`）：界面会变，把两分钟前的树
+    当成现在的屏幕交出去，调用方会照着它规划一串再也点不中的动作。
+    """
+    if not device_id:
+        return None, "缺少 device_id"
+    with _lock:
+        hit = _latest.get(device_id)
+        if hit is None:
+            return None, "该设备尚未上报过界面结构"
+        captured_at, graph = hit
+        age = time.time() - captured_at
+        if age > _STALE_SECONDS:
+            _stats["stale_declined"] += 1
+            return None, f"最近一次快照已过期({age:.0f}s > {_STALE_SECONDS:.0f}s)"
+        _stats["served"] += 1
+    return graph, f"{age:.1f}s 前的界面结构"
+
+
+def snapshot_store_stats() -> Dict[str, Any]:
+    """收了多少、拒了多少、给出去多少、因过期挡下多少。"""
+    with _lock:
+        return {**_stats, "devices": len(_latest), "stale_seconds": _STALE_SECONDS}

--- a/core/perception_grounding.py
+++ b/core/perception_grounding.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+core/perception_grounding.py — 界面定位的权威归属
+==================================================
+
+**Stage A：先写下「哪一端决定点哪个控件」，再谈把树接过来。**
+
+为什么这个模块必须先于接线存在
+------------------------------
+「这一步点哪个控件」这件事，仓库里目前有**三份各自独立的实现**：
+
+===========================================  ====================  ==================
+实现                                          位置                  现状
+===========================================  ====================  ==================
+``ui_grounding`` + ``grounded_planner``       V2 服务端             只有 Windows UIA 一个生产者
+``vision_pipeline``                           V2 服务端             自成一套形状，只通向 HTTP 端点
+``GroundingArbiter``(Kotlin)                  Android 设备本地      完整、有裁决矩阵与 JVM 单测
+===========================================  ====================  ==================
+
+三者互不相识，而契约里给另外两条预留的位置（``UISource.ANDROID_A11Y`` /
+``VISION`` / ``OCR``）至今零生产者。
+
+在这种状态下**先把 a11y 树传上来是错的**：没有归属约定，结果只会是第四份实现，
+而且是延迟最高的那一份。所以本模块只做一件事——**写下判断规则**，不读、不算、
+不决定，形状对齐 :mod:`core.semantic_anchoring`。
+
+归属结论
+--------
+* **Android 设备 → 设备本地是权威。** 三条理由，都不是偏好问题：
+  往返延迟直接体现在点击响应上；a11y 树剪枝后仍有上百个节点，每一拍上传是把
+  带宽换成没人读的数据流；而设备端 ``GroundingArbiter`` 已经有明确的裁决矩阵
+  （agreement / tree_override / tree_rescue / vlm_only）、两档阈值与单测。
+* **桌面（Windows UIA / AT-SPI / AX） → V2 服务端是权威。** 设备端没有对应实现。
+
+服务端拿到界面结构做什么
+------------------------
+**看得见，不等于替它决定。** V2 拿到 Android 的结构化快照是为了让服务端「看得见」
+——跨设备编排、面板呈现、多步规划的可行性判断——**绝不用于覆盖设备端已经做出的
+裁决**。两端在延迟不同的两个瞬间看到的是不同的屏幕，让后到的一方推翻先到的一方，
+得到的不是更准，是不可复现。
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Any, Dict, Tuple
+
+logger = logging.getLogger("Galaxy.PerceptionGrounding")
+
+__all__ = [
+    "PERCEPTION_GROUNDING_IS_AUTHORITY",
+    "GROUNDING_HAS_ONE_OWNER_PER_PLATFORM_POLICY",
+    "MODEL_SELECTS_NEVER_SUPPLIES_POLICY",
+    "SERVER_VIEW_NEVER_OVERRIDES_DEVICE_POLICY",
+    "GroundingOwner",
+    "PLATFORM_GROUNDING_OWNER",
+    "DEFAULT_OWNER",
+    "normalize_platform",
+    "grounding_owner_for",
+    "server_may_decide",
+    "describe_grounding_authority",
+]
+
+
+# ---------------------------------------------------------------------------
+# Authority / policy sentinels
+# ---------------------------------------------------------------------------
+
+PERCEPTION_GROUNDING_IS_AUTHORITY: str = (
+    "PERCEPTION_GROUNDING::AUTHORITY: "
+    "This module states which side decides which control gets acted on.  It "
+    "reads no screen, resolves no element and dispatches no action — it only "
+    "answers 'whose call is this', so that the answer exists in exactly one place."
+)
+
+GROUNDING_HAS_ONE_OWNER_PER_PLATFORM_POLICY: str = (
+    "PERCEPTION_GROUNDING::POLICY_1: "
+    "Deciding which control to act on has exactly ONE owner per platform. "
+    "Android is owned by the device (round-trip latency is felt in every tap, the "
+    "pruned a11y tree is still ~120 nodes, and GroundingArbiter already arbitrates "
+    "with a documented matrix and unit tests).  Desktop is owned by the server "
+    "(no device-side equivalent exists).  Neither side may build a second "
+    "arbitration for a platform the other already owns."
+)
+
+MODEL_SELECTS_NEVER_SUPPLIES_POLICY: str = (
+    "PERCEPTION_GROUNDING::POLICY_2: "
+    "A model reply may only be parsed for WHICH element was chosen — never for "
+    "what that element IS.  core.ui_grounding.parse_model_action extracts the "
+    "index [n] and takes label/bounds/coordinates from the typed graph.  Parsing "
+    "coordinates out of model prose would reintroduce the defect the object layer "
+    "exists to remove: a fact carrying the model's sampling error rather than the "
+    "authority of the underlying tree."
+)
+
+SERVER_VIEW_NEVER_OVERRIDES_DEVICE_POLICY: str = (
+    "PERCEPTION_GROUNDING::POLICY_3: "
+    "A structured snapshot the server receives from a device-owned platform is "
+    "for SEEING, never for deciding.  The server must not use it to override a "
+    "grounding decision the device already made: the two sides observed the "
+    "screen at different instants, so letting the later one win produces "
+    "irreproducibility, not accuracy."
+)
+
+
+# ---------------------------------------------------------------------------
+# Ownership
+# ---------------------------------------------------------------------------
+
+
+class GroundingOwner(str, Enum):
+    """Who resolves 'which control' for a given platform."""
+
+    DEVICE = "device"
+    """The device decides locally; the server observes but does not arbitrate."""
+
+    SERVER = "server"
+    """V2 resolves against the structured graph and dispatches an action."""
+
+
+PLATFORM_GROUNDING_OWNER: Dict[str, GroundingOwner] = {
+    "android": GroundingOwner.DEVICE,
+    "wearos": GroundingOwner.DEVICE,
+    "windows": GroundingOwner.SERVER,
+    "linux": GroundingOwner.SERVER,
+    "macos": GroundingOwner.SERVER,
+    "web": GroundingOwner.SERVER,
+}
+"""Platform → owner.  Every entry is a claim someone defends at review time."""
+
+DEFAULT_OWNER: GroundingOwner = GroundingOwner.SERVER
+"""Unknown platforms fall to the server.
+
+Deliberately not ``DEVICE``: an unrecognised platform has, by definition, no
+device-side arbitration we know of, and answering 'the device owns it' would
+silently leave nobody deciding.  Falling to the server preserves the behaviour
+that existed before this module — ``ui_act`` already defaults to the desktop
+node when the caller says nothing."""
+
+_PLATFORM_ALIASES: Dict[str, str] = {
+    "android_phone": "android",
+    "androidtv": "android",
+    "wear_os": "wearos",
+    "wear": "wearos",
+    "win": "windows",
+    "win32": "windows",
+    "darwin": "macos",
+    "mac": "macos",
+    "osx": "macos",
+    "browser": "web",
+}
+
+
+def normalize_platform(platform: str) -> str:
+    """Fold the spellings that actually appear in device reports onto one key."""
+    key = (platform or "").strip().lower().replace("-", "_")
+    return _PLATFORM_ALIASES.get(key, key)
+
+
+def grounding_owner_for(platform: str) -> GroundingOwner:
+    """Who decides 'which control' on *platform*.
+
+    Never raises and never returns ``None``: a missing answer here would leave
+    the caller to invent one, which is how the third implementation appeared.
+    """
+    key = normalize_platform(platform)
+    owner = PLATFORM_GROUNDING_OWNER.get(key)
+    if owner is None:
+        if key:
+            logger.info(
+                "未登记平台 %r 的 grounding 归属,按默认 %s 处理(见 PLATFORM_GROUNDING_OWNER)",
+                platform,
+                DEFAULT_OWNER.value,
+            )
+        return DEFAULT_OWNER
+    return owner
+
+
+def server_may_decide(platform: str) -> Tuple[bool, str]:
+    """May V2 resolve and dispatch an action for *platform* itself?
+
+    Returns ``(allowed, reason)``.  The reason is always populated — a bare
+    ``False`` would tell the caller nothing about whether this is a policy
+    decision or a missing capability, and those need different fixes.
+    """
+    owner = grounding_owner_for(platform)
+    if owner is GroundingOwner.SERVER:
+        return True, f"{normalize_platform(platform) or '未知平台'} 由服务端归属"
+    return False, (
+        f"{normalize_platform(platform)} 由设备本地归属(POLICY_1):"
+        "设备端 GroundingArbiter 已在做这件事,服务端再判一次就是第二份实现"
+    )
+
+
+def describe_grounding_authority(platform: str = "") -> Dict[str, Any]:
+    """A JSON-safe statement of who owns what — for responses and diagnostics.
+
+    Exposed on the wire so a caller can tell "the server declined to plan" apart
+    from "the server failed to plan".  Silently returning nothing for a
+    device-owned platform would make those two look identical.
+    """
+    payload: Dict[str, Any] = {
+        "policies": [
+            GROUNDING_HAS_ONE_OWNER_PER_PLATFORM_POLICY,
+            MODEL_SELECTS_NEVER_SUPPLIES_POLICY,
+            SERVER_VIEW_NEVER_OVERRIDES_DEVICE_POLICY,
+        ],
+        "owners": {name: owner.value for name, owner in sorted(PLATFORM_GROUNDING_OWNER.items())},
+        "default_owner": DEFAULT_OWNER.value,
+    }
+    if platform:
+        allowed, reason = server_may_decide(platform)
+        payload["platform"] = normalize_platform(platform)
+        payload["owner"] = grounding_owner_for(platform).value
+        payload["server_may_decide"] = allowed
+        payload["reason"] = reason
+    return payload

--- a/core/routes/ui_act.py
+++ b/core/routes/ui_act.py
@@ -11,9 +11,30 @@
       "ui_graph": {...UIGraph...},          # 必填:结构化界面图(桌面 UIA / 手机 a11y)
       "node_id": "Node_36_UIAWindows",      # 可选:目标操作节点(缺省按平台推断)
       "model_reply": "[2]",                 # 可选:模型看了 to_prompt() 后的回复
-      "execute": true                        # 可选:false=只规划不执行(dry-run)
+      "execute": true,                       # 可选:false=只规划不执行(dry-run)
+      "screenshot_b64": "...",               # 可选:没有结构树时走视觉投影;与 ui_graph 同给则融合
+      "device_id": "d1",                     # 可选:设备最近上报过界面结构就直接用
+      "platform": "android"                  # 可选:决定服务端能不能派发(见下)
     }
-    resp: { planned: {...}, dispatched: bool, result?: {...}, grounding_prompt?: str }
+    resp: { planned: {...}, dispatched: bool, result?: {...}, grounding_prompt?: str,
+            grounding_authority: {...}, vision_note?: str, dispatch_declined?: str }
+
+  GET /api/v1/ui/perception
+    界面感知自述:谁说了算、设备有没有在上报屏幕结构、有多少次因过期被挡下。
+
+界面图有三个来源，同一份契约
+----------------------------
+桌面 UIA(``Node_36_UIAWindows``)、视觉投影(``core.vision_ui_projection``,
+截图 → OCR/GUI 元素 → ``UISource.VISION``/``OCR``)、Android 无障碍快照
+(``core.android_ui_snapshot``, ``UISource.ANDROID_A11Y``)。结构与视觉同给时
+两条腿一起走(``UIGraph.merge``),不是谁 fallback 谁。
+
+谁能派发
+--------
+``platform`` 归属设备本地时(Android/WearOS)本接口**只规划不派发**,并在
+``dispatch_declined`` 里说明——设备端 ``GroundingArbiter`` 已在同一屏上裁决过,
+服务端再派一次,两个不同瞬间的判断会打架而现场看不出是谁点的。
+判据见 :mod:`core.perception_grounding`。
 
 结构优先命中 → 直接动作;点不准 → needs_model=True + 返回【与截图一同发给模型】的
 结构化辅助提示(由前端把它 + 截图交给多模态模型,再带 model_reply 回调本接口)。
@@ -64,6 +85,72 @@ class UIActRequest(BaseModel):
     node_id: str = ""
     model_reply: Optional[str] = None
     execute: bool = True
+    # 没有结构树的平台(Canvas/自绘/第三方封锁无障碍)可以只给截图:走视觉管线
+    # 解出控件再投影成同一份契约。见 core/vision_ui_projection.py。
+    screenshot_b64: Optional[str] = None
+    platform: str = ""
+    device_id: str = ""
+
+
+async def _graph_from_screenshot(req: UIActRequest) -> "tuple[Optional[Dict[str, Any]], str]":
+    """截图 → 视觉管线 → UIGraph(dict)。返回 ``(图, 说明)``,失败时图为 None。
+
+    说明恒非空:调用方要能区分"这一屏没识别出控件"与"视觉链路坏了",
+    两者都给不出图,但需要的处置完全不同。
+    """
+    try:
+        from core.vision_pipeline import VisionPipeline
+        from core.vision_ui_projection import project_vision_result
+    except Exception as exc:  # noqa: BLE001 — 视觉链路是可选能力,缺了不该炸掉本路由
+        logger.info("ui_act: 视觉链路不可用: %s", exc)
+        return None, f"视觉链路不可用({type(exc).__name__})"
+
+    try:
+        result = await VisionPipeline().understand(image_base64=req.screenshot_b64, mode="full")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ui_act: 视觉识别失败: %s", exc)
+        return None, f"视觉识别失败({type(exc).__name__})"
+
+    graph, note = project_vision_result(result, device_id=req.device_id)
+    if graph.root is None:
+        return None, note
+    return graph.model_dump(mode="json"), note
+
+
+async def _merge_screenshot_into(req: UIActRequest, structural: Dict[str, Any]) -> "tuple[Dict[str, Any], str]":
+    """结构图 + 截图 → 混合图。融合失败一律退回结构图，绝不因此丢掉本来就好的那份。"""
+    try:
+        from core.schemas.ui_element import UIGraph
+        from core.vision_pipeline import VisionPipeline
+        from core.vision_ui_projection import project_and_merge
+
+        base = UIGraph.model_validate(structural)
+        result = await VisionPipeline().understand(image_base64=req.screenshot_b64, mode="full")
+        merged, note = project_and_merge(result, base, device_id=req.device_id)
+        return merged.model_dump(mode="json"), note
+    except Exception as exc:  # noqa: BLE001 — 融合是增益,不是前提
+        logger.info("ui_act: 结构图与截图融合跳过: %s", exc)
+        return structural, f"融合跳过({type(exc).__name__}),按纯结构图规划"
+
+
+@router.get("/perception")
+async def ui_perception_state() -> Dict[str, Any]:
+    """界面感知的当前状态：谁说了算、设备有没有在上报屏幕结构。
+
+    没有这一处，Stage C 整条链路是不可见的：设备到底传没传、传上来的被不被当成
+    "当前界面"、有多少次因为过期被挡下——全都只能靠翻日志猜。
+    """
+    from core.perception_grounding import describe_grounding_authority
+
+    out: Dict[str, Any] = {"authority": describe_grounding_authority()}
+    try:
+        from core.android_ui_snapshot import snapshot_store_stats
+
+        out["android_ui_snapshot"] = snapshot_store_stats()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("界面快照统计不可读", exc_info=True)
+        out["android_ui_snapshot_error"] = type(exc).__name__
+    return out
 
 
 def _node_action(node_id: str, action_value: str) -> str:
@@ -74,12 +161,36 @@ def _node_action(node_id: str, action_value: str) -> str:
 async def ui_act(req: UIActRequest) -> Dict[str, Any]:
     """结构化操作:意图 + 界面图 → 规划 →(可选)派发执行。"""
     from core.grounded_planner import plan as plan_step
+    from core.perception_grounding import describe_grounding_authority, server_may_decide
     from core.schemas.ui_element import UIGraph
 
-    if not req.ui_graph:
-        return {"success": False, "error": "ui_graph 必填(结构化界面图)"}
+    ui_graph = req.ui_graph
+    graph_note = ""
+    if not ui_graph and req.device_id:
+        # 设备最近上报过界面结构就直接用(Stage C)。这一步只让服务端**看得见**——
+        # Android 仍不派发,下面 POLICY_1 那一段照样拦。
+        from core.android_ui_snapshot import latest_graph_for
+
+        stored, stored_note = latest_graph_for(req.device_id)
+        if stored is not None:
+            ui_graph, graph_note = stored.model_dump(mode="json"), stored_note
+        elif stored_note:
+            graph_note = stored_note
+    if not ui_graph and req.screenshot_b64:
+        ui_graph, graph_note = await _graph_from_screenshot(req)
+    elif ui_graph and req.screenshot_b64:
+        # 两样都给了就两条腿一起走:结构给视觉配精确边界与状态,视觉补结构漏掉的控件
+        # (Canvas / 自绘 / 第三方封锁无障碍的界面)。这是 ui_element 契约本身的立场
+        # ——不是谁 fallback 谁。
+        ui_graph, graph_note = await _merge_screenshot_into(req, ui_graph)
+    if not ui_graph:
+        return {
+            "success": False,
+            "error": "ui_graph 必填(结构化界面图);或给 screenshot_b64 走视觉投影",
+            **({"vision_note": graph_note} if graph_note else {}),
+        }
     try:
-        graph = UIGraph.model_validate(req.ui_graph)
+        graph = UIGraph.model_validate(ui_graph)
     except Exception as exc:  # noqa: BLE001
         logger.warning("ui_act: UIGraph 解析失败: %s", exc)
         return {"success": False, "error": "ui_graph 解析失败"}
@@ -89,7 +200,20 @@ async def ui_act(req: UIActRequest) -> Dict[str, Any]:
         "success": True,
         "planned": planned.model_dump(exclude={"grounding_prompt"}),
         "dispatched": False,
+        "grounding_authority": describe_grounding_authority(req.platform),
     }
+    if graph_note:
+        out["vision_note"] = graph_note
+
+    # POLICY_1:归属设备本地的平台,服务端**只规划不派发**。
+    # 说出来而不是静默照做:设备端 GroundingArbiter 已经在同一屏上做过裁决,
+    # 服务端再派一次动作,两个不同瞬间的判断会打架,而现场看不出是谁点的。
+    may_decide, why = server_may_decide(req.platform) if req.platform else (True, "")
+    if not may_decide:
+        out["dispatch_declined"] = why
+        out["needs_model"] = bool(planned.needs_model)
+        logger.info("ui_act: %s — 只规划不派发", why)
+        return out
 
     # 结构点不准 → 交多模态模型(视觉一直在看);把结构化辅助提示回给前端。
     if planned.needs_model or not planned.executable:

--- a/core/vision_ui_projection.py
+++ b/core/vision_ui_projection.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+core/vision_ui_projection.py — 视觉理解结果 → 统一控件契约
+============================================================
+
+**Stage B：让 ``vision_pipeline`` 成为 ``UIGraph`` 的第二个生产者，而不是第二套形状。**
+
+要解决的问题
+------------
+``core/vision_pipeline.py`` 已经能从一张截图里解出 OCR 文本框与 GUI 元素树（四级
+降级：DeepSeek OCR 2 → Gemini → Qwen3-VL → Tesseract+规则）。但它产出的是自己的
+``VisionResult``，而 grounding 那条链（``ui_grounding`` / ``grounded_planner`` /
+``/api/v1/ui/act``）吃的是 :class:`~core.schemas.ui_element.UIGraph`。
+
+于是同一件事有了两套表示：契约里 ``UISource.VISION`` 与 ``UISource.OCR`` 两个来源
+**声明了却零生产者**，而真正能产出它们的模块只挂在两个 HTTP 端点上，主链路走不到。
+本模块补的就是中间这一步投影。
+
+三条设计约束
+------------
+1. **纯投影，不改 vision_pipeline 任何行为。** 只加出口，不动它的降级链、不动它的
+   调用方。回滚等于删掉本文件。
+2. **失败必须可观测。** 投影不出东西时返回**空图并说明原因**，而不是静默返回
+   ``None``——"识别不出控件"与"投影坏了"是两件事，混成一个空值就无从排查。
+3. **不与结构树竞争。** 产出的图 ``source=VISION``，交由
+   :meth:`UIGraph.merge` 融进结构图：视觉给结构补它漏掉的控件（Canvas、自绘、
+   第三方封锁无障碍的界面），结构给视觉补精确边界与状态。**两条腿一起走，
+   不是谁 fallback 谁**——这是 ``ui_element`` 契约本身写下的立场。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.schemas.ui_element import UIActionKind, UIBounds, UIElementNode, UIGraph, UISource
+
+logger = logging.getLogger("Galaxy.VisionUIProjection")
+
+__all__ = [
+    "VISION_PROJECTION_IS_ADDITIVE_POLICY",
+    "VISION_NODES_ARE_NEVER_CERTAIN_POLICY",
+    "ELEMENT_ROLE_MAP",
+    "INTERACTION_ACTION_MAP",
+    "project_vision_result",
+    "project_and_merge",
+]
+
+
+# ---------------------------------------------------------------------------
+# Policy sentinels
+# ---------------------------------------------------------------------------
+
+VISION_PROJECTION_IS_ADDITIVE_POLICY: str = (
+    "VISION_UI_PROJECTION::POLICY_1: "
+    "This module only projects; it never changes how vision_pipeline recognises "
+    "anything and never becomes a second recogniser.  Rolling it back is deleting "
+    "the file — that property is what makes it safe to wire into the live path."
+)
+
+VISION_NODES_ARE_NEVER_CERTAIN_POLICY: str = (
+    "VISION_UI_PROJECTION::POLICY_2: "
+    "Projected nodes carry source=VISION/OCR and the recogniser's own confidence, "
+    "never 1.0.  A structural node from UIA/a11y is what the system reports about "
+    "itself; a vision node is an inference about pixels.  Flattening that "
+    "distinction would let a guess outrank a fact during merge."
+)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary mapping
+# ---------------------------------------------------------------------------
+
+ELEMENT_ROLE_MAP: Dict[str, str] = {
+    "button": "button",
+    "text": "text",
+    "input": "edit",
+    "image": "image",
+    "icon": "button",
+    "checkbox": "checkbox",
+    "radio": "radio",
+    "toggle": "switch",
+    "slider": "slider",
+    "dropdown": "combobox",
+    "tab": "tab",
+    "link": "link",
+    "menu": "menu",
+    "toolbar": "toolbar",
+    "status_bar": "statusbar",
+    "navigation": "navigation",
+    "dialog": "dialog",
+    "list_item": "listitem",
+    "card": "group",
+    "container": "group",
+    # 识别器自己都说不上来是什么 —— 就照实叫 unknown。映射成 text 会让下游以为
+    # 这是一段文字(不可交互),而它可能恰恰是个能点的东西。
+    "unknown": "unknown",
+}
+"""``ElementType`` → 契约里的规范化 role。
+
+``icon`` 落到 ``button``:图标在界面上就是可点的按钮,给它一个独有 role 只会让
+下游多一处分支。``card``/``container`` 落到 ``group``——它们是容器,不是可交互控件。"""
+
+INTERACTION_ACTION_MAP: Dict[str, UIActionKind] = {
+    "click": UIActionKind.TAP,
+    "long_press": UIActionKind.LONG_PRESS,
+    "type": UIActionKind.SET_TEXT,
+    "scroll": UIActionKind.SCROLL,
+    "swipe": UIActionKind.SWIPE,
+    "drag": UIActionKind.SWIPE,
+    "toggle": UIActionKind.TAP,
+    "select": UIActionKind.TAP,
+}
+"""``InteractionType`` → ``UIActionKind``。``none`` 不在表里:它表示"不可交互",
+映射成任何动作都是谎报。"""
+
+_EDITABLE_ROLES = frozenset({"edit"})
+_OCR_DEDUP_IOU = 0.55
+"""OCR 文本框与已识别 GUI 元素的重叠阈值。
+
+超过即认为这段文字就是那个控件的文案,不再单独建节点——否则同一个按钮会以
+"按钮"和"文字"两个节点出现两次,模型引用 [n] 时看到两个都对的候选。"""
+
+
+def _enum_value(raw: Any) -> str:
+    """Enum 或裸串都收——调用方可能已经把 VisionResult 序列化过一轮。"""
+    return str(getattr(raw, "value", raw) or "").strip().lower()
+
+
+def _bounds_of(bbox: Any) -> Optional[UIBounds]:
+    """坐标框 → ``UIBounds``；给不出**可用**锚点时返回 None 并说明。
+
+    两处不能用 ``getattr(..., 0)` 兜底糊过去：
+
+    * 对象根本没有 x/y/width/height —— 那样兜底会造出 ``(0,0,0x0)``，
+      也就是告诉模型"这个控件在屏幕左上角"。**猜错的坐标比没有坐标危险**：
+      没有坐标时 grounding 会 defer 给模型看画面，有个错坐标则会直接点过去。
+    * 面积为零 —— 同理，零面积框点不中任何东西，却看起来像个有效锚点。
+    """
+    if bbox is None:
+        return None
+    missing = [attr for attr in ("x", "y", "width", "height") if not hasattr(bbox, attr)]
+    if missing:
+        logger.warning("视觉元素的边界框缺少 %s,该节点将没有坐标锚点(不构造零值框)", "/".join(missing))
+        return None
+    try:
+        bounds = UIBounds(
+            x=int(getattr(bbox, "x", 0) or 0),
+            y=int(getattr(bbox, "y", 0) or 0),
+            width=int(getattr(bbox, "width", 0) or 0),
+            height=int(getattr(bbox, "height", 0) or 0),
+        )
+    except (TypeError, ValueError) as exc:
+        logger.warning("视觉元素的边界框无法解析(%s),该节点将没有坐标锚点", exc)
+        return None
+    if bounds.area() <= 0:
+        logger.warning("视觉元素给出零面积边界框 @(%d,%d),不作为坐标锚点", bounds.x, bounds.y)
+        return None
+    return bounds
+
+
+def _actions_of(element: Any) -> List[UIActionKind]:
+    out: List[UIActionKind] = []
+    for it in getattr(element, "interaction_types", None) or []:
+        mapped = INTERACTION_ACTION_MAP.get(_enum_value(it))
+        if mapped is not None and mapped not in out:
+            out.append(mapped)
+    return out
+
+
+def _project_element(element: Any) -> Optional[UIElementNode]:
+    """一个 ``GUIElement`` → 一个 ``UIElementNode``(含子树)。"""
+    role = ELEMENT_ROLE_MAP.get(_enum_value(getattr(element, "element_type", "")), "text")
+    actions = _actions_of(element)
+    interactable = bool(getattr(element, "interactable", False))
+    try:
+        confidence = float(getattr(element, "confidence", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+
+    node = UIElementNode(
+        node_id=str(getattr(element, "element_id", "") or ""),
+        role=role,
+        label=str(getattr(element, "text", "") or ""),
+        bounds=_bounds_of(getattr(element, "bbox", None)),
+        clickable=interactable and UIActionKind.SET_TEXT not in actions,
+        editable=role in _EDITABLE_ROLES or UIActionKind.SET_TEXT in actions,
+        scrollable=UIActionKind.SCROLL in actions or UIActionKind.SWIPE in actions,
+        actions=actions,
+        source=UISource.VISION,
+        # POLICY_2:视觉节点永远带识别器自己的置信度,不冒充结构节点的 1.0。
+        confidence=min(max(confidence, 0.0), 0.999),
+    )
+    for child in getattr(element, "children", None) or []:
+        projected = _project_element(child)
+        if projected is not None:
+            node.children.append(projected)
+    return node
+
+
+def _project_ocr_word(word: Any) -> Optional[UIElementNode]:
+    text = str(getattr(word, "text", "") or "").strip()
+    if not text:
+        return None
+    bounds = _bounds_of(getattr(word, "bbox", None))
+    try:
+        confidence = float(getattr(word, "confidence", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    return UIElementNode(
+        role="text",
+        label=text,
+        bounds=bounds,
+        clickable=False,
+        source=UISource.OCR,
+        confidence=min(max(confidence, 0.0), 0.999),
+    )
+
+
+def _covered_by(bounds: Optional[UIBounds], others: List[UIElementNode]) -> bool:
+    if bounds is None:
+        return False
+    for node in others:
+        if node.bounds is not None and node.bounds.iou(bounds) >= _OCR_DEDUP_IOU:
+            return True
+    return False
+
+
+def project_vision_result(
+    result: Any,
+    *,
+    device_id: str = "",
+    screen_width: int = 0,
+    screen_height: int = 0,
+    include_ocr: bool = True,
+) -> Tuple[UIGraph, str]:
+    """``VisionResult`` → ``UIGraph``。返回 ``(图, 说明)``。
+
+    说明这一栏不是装饰:调用方必须能区分"这一屏确实没识别出控件"与"投影失败了"。
+    两者都产生一张空图,但需要的处置完全不同——前者该退回纯视觉让模型自己看,
+    后者是本模块的缺陷。空图配一句空说明会把这个区别抹掉,那正是本轮改造一直在
+    消除的那类缺陷。
+    """
+    empty = UIGraph(source=UISource.VISION, device_id=device_id)
+    if result is None:
+        logger.warning("视觉投影收到空结果")
+        return empty, "视觉结果为空"
+
+    if not bool(getattr(result, "success", False)):
+        reason = str(getattr(result, "error", "") or "").strip() or "视觉识别未成功且未给出原因"
+        logger.info("视觉识别未成功,不产出结构图: %s", reason)
+        return empty, f"视觉识别未成功:{reason}"
+
+    children: List[UIElementNode] = []
+    for element in getattr(result, "gui_elements", None) or []:
+        projected = _project_element(element)
+        if projected is not None:
+            children.append(projected)
+
+    element_count = len(children)
+    ocr_added = 0
+    if include_ocr:
+        # OCR 文本单独成节点,但**不与已识别控件重复**:同一个按钮不该既是按钮
+        # 又是文字,那会让模型引用 [n] 时看到两个都对的候选。
+        flat_so_far = [n for parent in children for n in parent.flatten()]
+        for word in getattr(result, "ocr_words", None) or []:
+            node = _project_ocr_word(word)
+            if node is None or _covered_by(node.bounds, flat_so_far):
+                continue
+            children.append(node)
+            ocr_added += 1
+
+    if not children:
+        engine = str(getattr(result, "engine_used", "") or "未知引擎")
+        logger.info("视觉识别成功但未解出任何控件(engine=%s)", engine)
+        return empty, f"识别成功但无可用控件(engine={engine})"
+
+    scene = getattr(result, "scene", None)
+    app = str(getattr(scene, "app_name", "") or "") if scene is not None else ""
+
+    root = UIElementNode(role="root", label=app, source=UISource.VISION, confidence=0.999)
+    root.children = children
+
+    graph = UIGraph(
+        root=root,
+        source=UISource.VISION,
+        device_id=device_id,
+        app=app,
+        screen_width=int(screen_width or 0),
+        screen_height=int(screen_height or 0),
+    )
+    note = f"视觉投影:{element_count} 个控件"
+    if ocr_added:
+        note += f" + {ocr_added} 段独立文本"
+    engine = str(getattr(result, "engine_used", "") or "")
+    if engine:
+        note += f"(engine={engine})"
+    logger.info("%s", note)
+    return graph, note
+
+
+def project_and_merge(
+    result: Any,
+    structural: Optional[UIGraph] = None,
+    *,
+    device_id: str = "",
+    screen_width: int = 0,
+    screen_height: int = 0,
+) -> Tuple[UIGraph, str]:
+    """投影视觉结果，若给了结构图则融合成混合图。
+
+    融合方向固定为「结构为底、视觉补充」,不是反过来:结构节点是系统对自身的
+    陈述,视觉节点是对像素的推断。让推断当底、陈述当补丁,就是让猜测覆盖事实。
+    """
+    vision_graph, note = project_vision_result(
+        result,
+        device_id=device_id,
+        screen_width=screen_width,
+        screen_height=screen_height,
+    )
+    if structural is None or structural.root is None:
+        return vision_graph, note
+    if vision_graph.root is None:
+        return structural, f"{note};保持结构图不变"
+    try:
+        merged = structural.merge(vision_graph)
+    except Exception as exc:  # noqa: BLE001 — 融合失败必须退回结构图,而不是丢掉两边
+        logger.warning("结构图与视觉图融合失败(%s),退回纯结构图", exc)
+        return structural, f"{note};融合失败({type(exc).__name__}),已退回结构图"
+    return merged, f"{note};已与结构图融合(新增 {merged.vision_added} 个视觉控件)"

--- a/electron/renderer/panel/src/types/api.gen.ts
+++ b/electron/renderer/panel/src/types/api.gen.ts
@@ -2,7 +2,7 @@
 // 源:core/api_routes.py 组装出的权威 API 层的 OpenAPI 文档。
 // 后端加/删/改端点后重跑该脚本;CI 会比对生成结果是否与后端一致。
 
-// 路径 387 条 · 组件 schema 103 个
+// 路径 388 条 · 组件 schema 103 个
 
 /** 权威 API 层的全部路径。写错或调一个不存在的端点 → 编译期报错。 */
 export type ApiPath =
@@ -354,6 +354,7 @@ export type ApiPath =
   | "/api/v1/twin/{twin_id}/simulate"
   | "/api/v1/twin/{twin_id}/switch-mode"
   | "/api/v1/ui/act"
+  | "/api/v1/ui/perception"
   | "/api/v1/vault/audit"
   | "/api/v1/vault/cleanup"
   | "/api/v1/vault/credentials"
@@ -745,6 +746,7 @@ export const API_METHODS = {
   "/api/v1/twin/{twin_id}/simulate": ["post"],
   "/api/v1/twin/{twin_id}/switch-mode": ["post"],
   "/api/v1/ui/act": ["post"],
+  "/api/v1/ui/perception": ["get"],
   "/api/v1/vault/audit": ["get"],
   "/api/v1/vault/cleanup": ["post"],
   "/api/v1/vault/credentials": ["get", "post"],
@@ -1400,10 +1402,13 @@ export interface TwinSwitchModeRequest {
 }
 
 export interface UIActRequest {
+  "device_id"?: string;
   "execute"?: boolean;
   "instruction"?: string;
   "model_reply"?: string | null;
   "node_id"?: string;
+  "platform"?: string;
+  "screenshot_b64"?: string | null;
   "ui_graph"?: Record<string, unknown> | null;
 }
 

--- a/galaxy_gateway/websocket_handler.py
+++ b/galaxy_gateway/websocket_handler.py
@@ -1143,6 +1143,18 @@ async def handle_device_perception_emission(connection_id: str, aip_msg):
         # 此前还取了 local_perception_payload 却从不使用。全仓只有那一处、无生产者也无
         # schema，猜字段名等于静默丢数据，故先去掉；待 Android 侧定型后照上面两行接入。
 
+        # 结构化界面快照(Stage C)：设备带了才收，字段默认不存在 → 与改造前逐字节相同。
+        # 收下它只是为了让服务端**看得见**手机屏幕；Android 的 grounding 归属仍在设备本地
+        # (core/perception_grounding.py POLICY_1)，绝不用它去覆盖设备端已经做出的裁决。
+        _ui_snapshot = payload.get("ui_snapshot_payload")
+        if _ui_snapshot:
+            try:
+                from core.android_ui_snapshot import absorb_snapshot_payload
+
+                absorb_snapshot_payload(_ui_snapshot, device_id=device_id)
+            except Exception as _snap_err:  # noqa: BLE001 — 上行不因一个可选载荷而中断
+                logger.debug("a11y 快照吸收跳过: %s", _snap_err)
+
         # 组装可读文本语义（只取有信息量的字段）
         parts = []
         kind = _g(payload, "emission_kind")

--- a/tests/test_android_ui_snapshot_stage_c.py
+++ b/tests/test_android_ui_snapshot_stage_c.py
@@ -50,7 +50,9 @@ Group E — 接线
   E04. 但仍不派发（POLICY_1 未被本阶段削弱）。
 
 Group F — 跨仓契约
-  F01. Kotlin 线材的字段名与本侧投影器逐字对齐。
+  F01. 投影器确实按约定的线材字段名取值（本仓 CI 强制，不会 skip）。
+  F02. 顶层与元素字段清单本身不为空、无重复。
+  F03. Kotlin 源码比对——**仅在本机有 android 仓时**作为额外一层。
 
 Group G — 可观测
   G01. /api/v1/ui/perception 说得出谁说了算、设备有没有在上报。
@@ -67,7 +69,9 @@ import pytest
 
 from core.android_ui_snapshot import (
     ANDROID_CLASS_ROLE_MAP,
+    SNAPSHOT_ELEMENT_WIRE_FIELDS,
     SNAPSHOT_PAYLOAD_KEY,
+    SNAPSHOT_WIRE_FIELDS,
     absorb_snapshot_payload,
     latest_graph_for,
     project_android_snapshot,
@@ -288,30 +292,65 @@ class TestGroupEWiring:
 
 
 class TestGroupFCrossRepoContract:
-    """字段名两边对不上时,表现是服务端静默收到一棵空树 —— 最难查的那种。"""
+    """字段名两边对不上时,表现是服务端静默收到一棵空树 —— 最难查的那种。
 
-    def test_f01_kotlin_wire_fields_match_this_projector(self):
+    **这组测试的形状本身是一次修正。** 最初它只有一条:直接读 android 仓的 Kotlin
+    源文件做比对。那条在本机能跑,在 CI 上**永远 skip** —— 两个仓的 CI 都只检出
+    自己,谁也看不见对方。提供零保护、看起来却像有保护,比没有更糟。
+
+    现在改成两边各自验证自己那一半,指向同一份写下来的字段清单:本仓断言投影器
+    确实按这些名字取值(强制执行),android 仓的 UiSnapshotUplinkTest 断言 DTO
+    确实发这些名字(那边强制执行)。源码比对降为本机可用时的额外一层。
+    """
+
+    def test_f01_projector_reads_exactly_the_agreed_field_names(self):
+        """逐个字段做"改名即失效"的实测:换掉名字,那个信息就必须真的丢掉。"""
+        base = _snapshot(_element(text="发送", desc="描述", cls="android.widget.Button"))
+
+        graph, _ = project_android_snapshot(base, device_id="d1")
+        node = graph.find_by_label("发送")
+        assert node is not None and node.bounds is not None
+
+        # 顶层:改名后那条信息必须真的丢掉,而不是被别的键兜住
+        renamed = dict(base)
+        renamed["zzzPackage"] = renamed.pop("packageName")
+        assert project_android_snapshot(renamed, device_id="d1")[0].app == "", "packageName 改名后仍被读到?"
+        no_elements = {k: v for k, v in _snapshot().items() if k != "elements"}
+        assert project_android_snapshot(no_elements, device_id="d1")[0].root is None
+
+        # 元素级:坐标四项任缺其一,锚点必须消失而不是被兜底成 0
+        for field in ("left", "top", "right", "bottom"):
+            raw = _element()
+            raw.pop(field)
+            g, _ = project_android_snapshot(_snapshot(raw), device_id="d1")
+            hit = g.find_by_label("发送")
+            assert hit is not None
+            assert hit.bounds is None or hit.bounds.area() > 0, f"{field} 缺失时造出了无效锚点"
+
+        # clickable / className / text 各自的信息通道
+        raw = _element(clickable=True)
+        raw["clickable"] = False
+        assert project_android_snapshot(_snapshot(raw), device_id="d1")[0].find_by_label("发送").clickable is False
+        raw = _element(text="", desc="仅描述")
+        assert project_android_snapshot(_snapshot(raw), device_id="d1")[0].find_by_label("仅描述") is not None
+
+    def test_f02_the_agreed_field_lists_are_sane(self):
+        for fields in (SNAPSHOT_WIRE_FIELDS, SNAPSHOT_ELEMENT_WIRE_FIELDS):
+            assert fields, "字段清单为空 —— 这条契约就没有内容了"
+            assert len(set(fields)) == len(fields), f"字段清单里有重复: {fields}"
+        assert "elements" in SNAPSHOT_WIRE_FIELDS
+
+    def test_f03_kotlin_source_matches_when_available(self):
+        """额外一层:本机有 android 仓时顺带比对源码。CI 上不可用,故不作为唯一依靠。"""
         kotlin = pathlib.Path("/home/user/ufo-galaxy-android/app/src/main/java/com/ufo/galaxy/protocol/AipModels.kt")
         if not kotlin.is_file():
-            pytest.skip("android 仓不在本机,跳过跨仓字段对齐检查")
+            pytest.skip("android 仓不在本机 —— 对齐由两边各自的 F01/UiSnapshotUplinkTest 保证")
         text = kotlin.read_text(encoding="utf-8", errors="replace")
         block = re.search(r"data class DeviceUiSnapshotPayload\((.*?)\n\}", text, re.S)
         assert block, "Kotlin 侧的线材载荷不见了 —— 这根线断了"
         body = block.group(1)
-        for field in ("packageName", "screenWidth", "screenHeight", "elements"):
+        for field in (*SNAPSHOT_WIRE_FIELDS, *SNAPSHOT_ELEMENT_WIRE_FIELDS):
             assert field in body, f"Kotlin 载荷缺字段 {field}"
-        for field in (
-            "index",
-            "text",
-            "contentDescription",
-            "className",
-            "clickable",
-            "left",
-            "top",
-            "right",
-            "bottom",
-        ):
-            assert field in body, f"Kotlin 元素缺字段 {field}"
         assert SNAPSHOT_PAYLOAD_KEY in text, "Kotlin 侧没有把载荷挂到上行字段上"
 
 

--- a/tests/test_android_ui_snapshot_stage_c.py
+++ b/tests/test_android_ui_snapshot_stage_c.py
@@ -1,0 +1,342 @@
+"""tests/test_android_ui_snapshot_stage_c.py
+================================================
+Android 无障碍快照 → 统一控件契约（Stage C）。
+
+要解决的问题
+------------
+两端各自都做完了，中间那根线不存在：Android 端 ``AccessibilityUiSnapshotProvider``
+读树、剪枝、拍平，还修过节点未回收的真 bug；V2 端 ``UIGraph`` 契约里
+``UISource.ANDROID_A11Y`` **声明了却零生产者**。设备一直在上报
+``accessibility_ready: true``，而网关只拿它做设备选择评分（+5），
+从没有任何链路把那棵树取回来。
+
+本阶段补的就是那根线的 V2 端。
+
+Coverage matrix
+---------------
+Group A — Policy sentinels
+  A01. POLICY_1 收到的快照只供"看得见"，不供覆盖设备裁决。
+  A02. POLICY_2 搭既有上行，不新增消息类型。
+
+Group B — 投影
+  B01. 元素落成 ANDROID_A11Y 来源的节点。
+  B02. LTRB → 左上角+宽高。
+  B03. 类名 → 规范化 role；查不到落 view 而非 text。
+  B04. text 为空时用 contentDescription 当标签。
+  B05. EditText → editable。
+  B06. 零面积框不作为坐标锚点。
+  B07. 结构节点置信度为 1.0（它是系统对自身的陈述，不是对像素的推断）。
+  B08. 蛇形/驼峰两种字段名都收。
+
+Group C — 失败可区分
+  C01. 非对象载荷。
+  C02. 缺 elements。
+  C03. 全部无效。
+  C04. 三种说明彼此不同。
+
+Group D — 存取
+  D01. 收下后取得回。
+  D02. 未上报过的设备说得出"没上报过"。
+  D03. 过期快照不再作为当前界面交出。
+  D04. 设备数有界。
+  D05. 缺 device_id 拒收。
+  D06. 坏载荷不抛异常（它跑在 WS 上行里）。
+  D07. 统计可读。
+
+Group E — 接线
+  E01. 上行处理器会吸收该字段。
+  E02. 字段默认不存在时整条链路不受影响。
+  E03. ui_act 能用已存快照规划。
+  E04. 但仍不派发（POLICY_1 未被本阶段削弱）。
+
+Group F — 跨仓契约
+  F01. Kotlin 线材的字段名与本侧投影器逐字对齐。
+
+Group G — 可观测
+  G01. /api/v1/ui/perception 说得出谁说了算、设备有没有在上报。
+  G02. 因过期挡下的次数可读 —— 否则这条链路是不是在工作全靠猜。
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import time
+
+import pytest
+
+from core.android_ui_snapshot import (
+    ANDROID_CLASS_ROLE_MAP,
+    SNAPSHOT_PAYLOAD_KEY,
+    absorb_snapshot_payload,
+    latest_graph_for,
+    project_android_snapshot,
+    snapshot_store_stats,
+)
+from core.schemas.ui_element import UISource
+
+
+def _element(index=0, text="发送", desc="", cls="android.widget.Button", clickable=True, box=(1180, 2020, 1300, 2100)):
+    left, top, right, bottom = box
+    return {
+        "index": index,
+        "text": text,
+        "contentDescription": desc,
+        "className": cls,
+        "clickable": clickable,
+        "left": left,
+        "top": top,
+        "right": right,
+        "bottom": bottom,
+    }
+
+
+def _snapshot(*elements):
+    return {
+        "packageName": "com.tencent.mm",
+        "screenWidth": 1440,
+        "screenHeight": 3200,
+        "elements": list(elements) or [_element()],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_store():
+    import core.android_ui_snapshot as mod
+
+    with mod._lock:
+        mod._latest.clear()
+        for key in mod._stats:
+            mod._stats[key] = 0
+    yield
+
+
+class TestGroupAPolicies:
+    def test_a01_seeing_is_not_deciding(self):
+        from core.android_ui_snapshot import SNAPSHOT_IS_FOR_SEEING_POLICY
+
+        text = SNAPSHOT_IS_FOR_SEEING_POLICY
+        assert "POLICY_1" in text
+        assert "never to decide with" in text
+
+    def test_a02_rides_an_existing_uplink(self):
+        from core.android_ui_snapshot import SNAPSHOT_RIDES_AN_EXISTING_UPLINK_POLICY
+
+        text = SNAPSHOT_RIDES_AN_EXISTING_UPLINK_POLICY
+        assert "POLICY_2" in text
+        assert "No new message type" in text
+
+
+class TestGroupBProjection:
+    def test_b01_nodes_carry_the_a11y_source(self):
+        graph, _ = project_android_snapshot(_snapshot(), device_id="d1")
+        node = graph.find_by_label("发送")
+        assert node is not None and node.source is UISource.ANDROID_A11Y
+
+    def test_b02_ltrb_becomes_origin_and_size(self):
+        graph, _ = project_android_snapshot(_snapshot(), device_id="d1")
+        bounds = graph.find_by_label("发送").bounds
+        assert (bounds.x, bounds.y, bounds.width, bounds.height) == (1180, 2020, 120, 80)
+        assert bounds.center() == (1240, 2060)
+
+    def test_b03_unknown_class_is_view_not_text(self):
+        """说不上来是什么就别声称它是文字 —— 谎报成不可交互,模型就不会去点它。"""
+        graph, _ = project_android_snapshot(
+            _snapshot(_element(cls="com.example.FancyCustomThing", text="自绘")), device_id="d1"
+        )
+        assert graph.find_by_label("自绘").role == "view"
+        assert ANDROID_CLASS_ROLE_MAP["button"] == "button"
+
+    def test_b04_content_description_is_the_fallback_label(self):
+        graph, _ = project_android_snapshot(_snapshot(_element(text="", desc="输入消息")), device_id="d1")
+        assert graph.find_by_label("输入消息") is not None
+
+    def test_b05_edittext_is_editable(self):
+        graph, _ = project_android_snapshot(
+            _snapshot(_element(text="", desc="输入消息", cls="android.widget.EditText")), device_id="d1"
+        )
+        assert graph.find_by_label("输入消息").editable is True
+
+    def test_b06_zero_area_is_not_an_anchor(self):
+        """零面积框看起来像有效坐标却点不中 —— 下游拿到它就不会再退回让模型看画面。"""
+        graph, _ = project_android_snapshot(_snapshot(_element(text="坏的", box=(10, 10, 10, 10))), device_id="d1")
+        node = graph.find_by_label("坏的")
+        assert node is not None, "一个坏坐标不该让这个控件整个消失"
+        assert node.bounds is None
+
+    def test_b07_structural_nodes_are_certain(self):
+        graph, _ = project_android_snapshot(_snapshot(), device_id="d1")
+        assert graph.find_by_label("发送").confidence == 1.0
+
+    def test_b08_accepts_snake_case_too(self):
+        raw = _element(text="", desc="输入", cls="android.widget.EditText")
+        raw["content_description"] = raw.pop("contentDescription")
+        raw["class_name"] = raw.pop("className")
+        payload = {"package_name": "x", "screen_width": 1, "screen_height": 2, "elements": [raw]}
+        graph, _ = project_android_snapshot(payload, device_id="d1")
+        assert graph.find_by_label("输入") is not None
+
+
+class TestGroupCFailures:
+    def test_c01_not_an_object(self):
+        graph, note = project_android_snapshot("nope", device_id="d1")
+        assert graph.root is None and "不是对象" in note
+
+    def test_c02_missing_elements(self):
+        graph, note = project_android_snapshot({"packageName": "x"}, device_id="d1")
+        assert graph.root is None and "elements" in note
+
+    def test_c03_all_invalid(self):
+        graph, note = project_android_snapshot({"elements": ["x", 3]}, device_id="d1")
+        assert graph.root is None and "全部跳过" in note
+
+    def test_c04_notes_differ(self):
+        notes = {
+            project_android_snapshot("nope", device_id="d")[1],
+            project_android_snapshot({}, device_id="d")[1],
+            project_android_snapshot({"elements": ["x"]}, device_id="d")[1],
+        }
+        assert len(notes) == 3, "不同的失败给了同一句说明,等于没说"
+
+
+class TestGroupDStore:
+    def test_d01_absorb_then_read_back(self):
+        assert absorb_snapshot_payload(_snapshot(), device_id="d1")[0] is True
+        graph, note = latest_graph_for("d1")
+        assert graph is not None and graph.find_by_label("发送") is not None
+        assert "界面结构" in note
+
+    def test_d02_unknown_device_says_so(self):
+        graph, note = latest_graph_for("never-seen")
+        assert graph is None and "尚未上报" in note
+
+    def test_d03_stale_snapshot_is_declined(self, monkeypatch):
+        """界面会变。把两分钟前的树当成现在的屏幕,调用方会规划一串点不中的动作。"""
+        import core.android_ui_snapshot as mod
+
+        absorb_snapshot_payload(_snapshot(), device_id="d1")
+        with mod._lock:
+            captured, graph = mod._latest["d1"]
+            mod._latest["d1"] = (captured - mod._STALE_SECONDS - 1, graph)
+        got, note = latest_graph_for("d1")
+        assert got is None and "过期" in note
+
+    def test_d04_device_cache_is_bounded(self):
+        import core.android_ui_snapshot as mod
+
+        for i in range(mod._MAX_DEVICES + 20):
+            absorb_snapshot_payload(_snapshot(), device_id=f"d{i}")
+            time.sleep(0)
+        assert len(mod._latest) <= mod._MAX_DEVICES
+
+    def test_d05_missing_device_id_is_refused(self):
+        ok, note = absorb_snapshot_payload(_snapshot(), device_id="")
+        assert ok is False and "device_id" in note
+
+    def test_d06_bad_payload_never_raises(self):
+        for payload in (None, 3, "x", {"elements": None}, {"elements": [{"left": "a"}]}):
+            ok, note = absorb_snapshot_payload(payload, device_id="d1")
+            assert ok is False and note
+
+    def test_d07_stats_are_readable(self):
+        absorb_snapshot_payload(_snapshot(), device_id="d1")
+        absorb_snapshot_payload("bad", device_id="d1")
+        latest_graph_for("d1")
+        stats = snapshot_store_stats()
+        assert stats["absorbed"] == 1
+        assert stats["rejected"] == 1
+        assert stats["served"] == 1
+
+
+class TestGroupEWiring:
+    def test_e01_uplink_handler_absorbs_the_field(self):
+        import inspect
+
+        from galaxy_gateway.websocket_handler import handle_device_perception_emission
+
+        src = inspect.getsource(handle_device_perception_emission)
+        assert SNAPSHOT_PAYLOAD_KEY in src
+        assert "absorb_snapshot_payload" in src
+
+    def test_e02_absent_field_changes_nothing(self):
+        """字段默认不存在 —— 老设备的上行必须与改造前逐字节相同。"""
+        import inspect
+
+        from galaxy_gateway.websocket_handler import handle_device_perception_emission
+
+        src = inspect.getsource(handle_device_perception_emission)
+        assert f'payload.get("{SNAPSHOT_PAYLOAD_KEY}")' in src, "必须是取值判空,不能无条件调用"
+
+    @pytest.mark.asyncio
+    async def test_e03_ui_act_plans_from_a_stored_snapshot(self):
+        from core.routes.ui_act import UIActRequest, ui_act
+
+        absorb_snapshot_payload(_snapshot(), device_id="d1")
+        out = await ui_act(UIActRequest(instruction="点发送", device_id="d1", platform="android", execute=False))
+        assert out["success"] is True
+        assert out["planned"]["label"] == "发送", "服务端已经看得见这一屏了"
+
+    @pytest.mark.asyncio
+    async def test_e04_still_does_not_dispatch_on_android(self):
+        """看得见没有削弱归属:Android 仍归设备本地。"""
+        from core.routes.ui_act import UIActRequest, ui_act
+
+        absorb_snapshot_payload(_snapshot(), device_id="d1")
+        out = await ui_act(UIActRequest(instruction="点发送", device_id="d1", platform="android", execute=True))
+        assert out["dispatched"] is False
+        assert "POLICY_1" in out["dispatch_declined"]
+
+
+class TestGroupFCrossRepoContract:
+    """字段名两边对不上时,表现是服务端静默收到一棵空树 —— 最难查的那种。"""
+
+    def test_f01_kotlin_wire_fields_match_this_projector(self):
+        kotlin = pathlib.Path("/home/user/ufo-galaxy-android/app/src/main/java/com/ufo/galaxy/protocol/AipModels.kt")
+        if not kotlin.is_file():
+            pytest.skip("android 仓不在本机,跳过跨仓字段对齐检查")
+        text = kotlin.read_text(encoding="utf-8", errors="replace")
+        block = re.search(r"data class DeviceUiSnapshotPayload\((.*?)\n\}", text, re.S)
+        assert block, "Kotlin 侧的线材载荷不见了 —— 这根线断了"
+        body = block.group(1)
+        for field in ("packageName", "screenWidth", "screenHeight", "elements"):
+            assert field in body, f"Kotlin 载荷缺字段 {field}"
+        for field in (
+            "index",
+            "text",
+            "contentDescription",
+            "className",
+            "clickable",
+            "left",
+            "top",
+            "right",
+            "bottom",
+        ):
+            assert field in body, f"Kotlin 元素缺字段 {field}"
+        assert SNAPSHOT_PAYLOAD_KEY in text, "Kotlin 侧没有把载荷挂到上行字段上"
+
+
+class TestGroupGObservability:
+    """不可见的链路等于不存在:传没传、被不被当成当前界面、挡下多少次,都得答得出。"""
+
+    @pytest.mark.asyncio
+    async def test_g01_perception_endpoint_reports_both(self):
+        from core.routes.ui_act import ui_perception_state
+
+        absorb_snapshot_payload(_snapshot(), device_id="d1")
+        out = await ui_perception_state()
+        assert out["authority"]["owners"]["android"] == "device"
+        assert out["android_ui_snapshot"]["absorbed"] == 1
+        assert out["android_ui_snapshot"]["devices"] == 1
+
+    @pytest.mark.asyncio
+    async def test_g02_stale_declines_are_counted(self, monkeypatch):
+        import core.android_ui_snapshot as mod
+        from core.routes.ui_act import ui_perception_state
+
+        absorb_snapshot_payload(_snapshot(), device_id="d1")
+        with mod._lock:
+            captured, graph = mod._latest["d1"]
+            mod._latest["d1"] = (captured - mod._STALE_SECONDS - 1, graph)
+        latest_graph_for("d1")
+        out = await ui_perception_state()
+        assert out["android_ui_snapshot"]["stale_declined"] == 1

--- a/tests/test_perception_grounding_stage_a.py
+++ b/tests/test_perception_grounding_stage_a.py
@@ -1,0 +1,223 @@
+"""tests/test_perception_grounding_stage_a.py
+================================================
+界面定位的权威归属（Stage A）。
+
+要解决的问题
+------------
+「这一步点哪个控件」在仓库里有三份各自独立的实现：V2 的 ``ui_grounding``
+（只有 Windows UIA 一个生产者）、V2 的 ``vision_pipeline``（自成一套形状）、
+以及 Android 设备本地的 ``GroundingArbiter``（完整、有裁决矩阵与 JVM 单测）。
+三者互不相识，而契约里 ``UISource.ANDROID_A11Y`` / ``VISION`` / ``OCR``
+三个来源**声明了却零生产者**。
+
+在这种状态下先把 a11y 树接上来是错的：没有归属约定，结果只会是第四份实现。
+所以本阶段只做一件事——把判断规则写进代码，并让活路径真的去问它。
+
+Coverage matrix
+---------------
+Group A — Policy sentinels
+  A01. AUTHORITY 声明自己不读、不算、不决定。
+  A02. POLICY_1 每个平台恰有一个归属方。
+  A03. POLICY_2 模型回复只能用于「选哪个」。
+  A04. POLICY_3 服务端看得见 ≠ 可以覆盖设备裁决。
+
+Group B — Ownership table
+  B01. Android / WearOS 归设备。
+  B02. 桌面三家归服务端。
+  B03. 未知平台落到默认（服务端），不是无人负责。
+  B04. 平台别名折叠到同一个答案。
+  B05. 归属函数永不返回 None。
+
+Group C — server_may_decide
+  C01. 服务端归属 → 允许。
+  C02. 设备归属 → 不允许，且理由指向 POLICY_1。
+  C03. 理由恒非空——空理由分不清「政策不允许」与「能力缺失」。
+
+Group D — 对外自述
+  D01. describe 可 JSON 序列化。
+  D02. 不带平台时给出全表。
+  D03. 带平台时补上该平台的结论。
+
+Group E — 活路径真的在问它
+  E01. ui_act 响应里带 grounding_authority。
+  E02. 设备归属的平台只规划、不派发。
+  E03. 拒绝派发必须说出理由，不是静默不做。
+  E04. 桌面平台不受影响（零行为变化）。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.perception_grounding import (
+    DEFAULT_OWNER,
+    PLATFORM_GROUNDING_OWNER,
+    GroundingOwner,
+    describe_grounding_authority,
+    grounding_owner_for,
+    normalize_platform,
+    server_may_decide,
+)
+
+
+class TestGroupAPolicies:
+    def test_a01_authority_disclaims_deciding(self):
+        from core.perception_grounding import PERCEPTION_GROUNDING_IS_AUTHORITY
+
+        text = PERCEPTION_GROUNDING_IS_AUTHORITY
+        assert "AUTHORITY" in text
+        assert "reads no screen" in text
+        assert "dispatches no action" in text
+
+    def test_a02_policy_1_one_owner_per_platform(self):
+        from core.perception_grounding import GROUNDING_HAS_ONE_OWNER_PER_PLATFORM_POLICY
+
+        text = GROUNDING_HAS_ONE_OWNER_PER_PLATFORM_POLICY
+        assert "POLICY_1" in text
+        assert "exactly ONE owner" in text
+        assert "second arbitration" in text
+
+    def test_a03_policy_2_model_selects_only(self):
+        from core.perception_grounding import MODEL_SELECTS_NEVER_SUPPLIES_POLICY
+
+        text = MODEL_SELECTS_NEVER_SUPPLIES_POLICY
+        assert "POLICY_2" in text
+        assert "WHICH element" in text
+        assert "never for" in text
+
+    def test_a04_policy_3_seeing_is_not_deciding(self):
+        from core.perception_grounding import SERVER_VIEW_NEVER_OVERRIDES_DEVICE_POLICY
+
+        text = SERVER_VIEW_NEVER_OVERRIDES_DEVICE_POLICY
+        assert "POLICY_3" in text
+        assert "for SEEING, never for deciding" in text
+
+
+class TestGroupBOwnership:
+    @pytest.mark.parametrize("platform", ["android", "wearos"])
+    def test_b01_mobile_is_device_owned(self, platform):
+        assert grounding_owner_for(platform) is GroundingOwner.DEVICE
+
+    @pytest.mark.parametrize("platform", ["windows", "linux", "macos"])
+    def test_b02_desktop_is_server_owned(self, platform):
+        assert grounding_owner_for(platform) is GroundingOwner.SERVER
+
+    def test_b03_unknown_falls_to_a_named_default(self):
+        """未登记的平台必须有人负责 —— 答'不知道'等于没人决定。"""
+        assert grounding_owner_for("some_future_os") is DEFAULT_OWNER
+        assert DEFAULT_OWNER is GroundingOwner.SERVER
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Android", "android"),
+            ("ANDROID_PHONE", "android"),
+            ("wear_os", "wearos"),
+            ("Win32", "windows"),
+            ("Darwin", "macos"),
+            ("  browser ", "web"),
+        ],
+    )
+    def test_b04_aliases_fold_to_one_answer(self, raw, expected):
+        assert normalize_platform(raw) == expected
+        assert grounding_owner_for(raw) is PLATFORM_GROUNDING_OWNER[expected]
+
+    def test_b05_never_returns_none(self):
+        for value in ("", "   ", "??", "android"):
+            assert isinstance(grounding_owner_for(value), GroundingOwner)
+
+
+class TestGroupCMayDecide:
+    def test_c01_server_owned_is_allowed(self):
+        allowed, reason = server_may_decide("windows")
+        assert allowed is True
+        assert reason
+
+    def test_c02_device_owned_is_refused_with_policy_reference(self):
+        allowed, reason = server_may_decide("android")
+        assert allowed is False
+        assert "POLICY_1" in reason
+        assert "GroundingArbiter" in reason
+
+    def test_c03_reason_is_never_empty(self):
+        """空理由会让「政策不允许」与「能力缺失」看起来一样,而两者的修法不同。"""
+        for platform in ("android", "windows", "totally_unknown", ""):
+            _, reason = server_may_decide(platform)
+            assert reason.strip(), f"{platform!r} 的判断没有给出理由"
+
+
+class TestGroupDSelfDescription:
+    def test_d01_json_safe(self):
+        json.dumps(describe_grounding_authority("android"))
+
+    def test_d02_without_platform_lists_the_whole_table(self):
+        payload = describe_grounding_authority()
+        assert payload["owners"]["android"] == "device"
+        assert payload["owners"]["windows"] == "server"
+        assert payload["default_owner"] == DEFAULT_OWNER.value
+        assert "platform" not in payload
+
+    def test_d03_with_platform_adds_the_verdict(self):
+        payload = describe_grounding_authority("Android")
+        assert payload["platform"] == "android"
+        assert payload["owner"] == "device"
+        assert payload["server_may_decide"] is False
+        assert payload["reason"]
+
+
+class TestGroupELivePath:
+    """判据只有被活路径问到才算生效 —— 否则它就是一段写得很好的注释。"""
+
+    @staticmethod
+    def _graph():
+        from core.schemas.ui_element import UIBounds, UIElementNode, UIGraph, UISource
+
+        root = UIElementNode(
+            role="root",
+            children=[
+                UIElementNode(
+                    role="button",
+                    label="发送",
+                    clickable=True,
+                    bounds=UIBounds(x=1180, y=2020, width=120, height=80),
+                )
+            ],
+        )
+        return UIGraph(root=root, source=UISource.UIA, device_id="d1").model_dump(mode="json")
+
+    @pytest.mark.asyncio
+    async def test_e01_response_states_who_owns_this_platform(self):
+        from core.routes.ui_act import UIActRequest, ui_act
+
+        out = await ui_act(
+            UIActRequest(instruction="点发送", ui_graph=self._graph(), platform="windows", execute=False)
+        )
+        assert out["success"] is True
+        assert out["grounding_authority"]["owner"] == "server"
+
+    @pytest.mark.asyncio
+    async def test_e02_device_owned_platform_plans_but_does_not_dispatch(self):
+        from core.routes.ui_act import UIActRequest, ui_act
+
+        out = await ui_act(UIActRequest(instruction="点发送", ui_graph=self._graph(), platform="android", execute=True))
+        assert out["dispatched"] is False
+        assert out["planned"]["label"] == "发送", "拒绝派发不等于拒绝规划"
+
+    @pytest.mark.asyncio
+    async def test_e03_refusal_is_spoken_not_silent(self):
+        from core.routes.ui_act import UIActRequest, ui_act
+
+        out = await ui_act(UIActRequest(instruction="点发送", ui_graph=self._graph(), platform="android", execute=True))
+        assert "dispatch_declined" in out, "静默不派发与派发失败在现场分不开"
+        assert "POLICY_1" in out["dispatch_declined"]
+
+    @pytest.mark.asyncio
+    async def test_e04_desktop_path_is_unchanged(self):
+        """默认档位零行为变化:不带 platform 的老调用方一律照旧。"""
+        from core.routes.ui_act import UIActRequest, ui_act
+
+        out = await ui_act(UIActRequest(instruction="点发送", ui_graph=self._graph(), execute=False))
+        assert out["success"] is True
+        assert "dispatch_declined" not in out

--- a/tests/test_vision_ui_projection_stage_b.py
+++ b/tests/test_vision_ui_projection_stage_b.py
@@ -1,0 +1,383 @@
+"""tests/test_vision_ui_projection_stage_b.py
+=================================================
+视觉理解结果 → 统一控件契约（Stage B）。
+
+要解决的问题
+------------
+``vision_pipeline`` 已经能从截图解出 OCR 文本框与 GUI 元素树（四级降级），
+但它产出的是自己的 ``VisionResult``；而 grounding 那条链吃的是 ``UIGraph``。
+于是契约里 ``UISource.VISION`` 与 ``UISource.OCR`` 两个来源**声明了却零生产者**，
+真正能产出它们的模块只挂在两个 HTTP 端点上，主链路走不到。
+
+本阶段补的是中间这一步投影——不是新的识别器，是把已经识别出来的东西
+接进同一份契约。
+
+Coverage matrix
+---------------
+Group A — Policy sentinels
+  A01. POLICY_1 纯投影，回滚等于删文件。
+  A02. POLICY_2 视觉节点永不冒充 1.0 置信度。
+
+Group B — Vocabulary mapping
+  B01. ElementType 表覆盖 vision_pipeline 实际会产出的全部类型。
+  B02. 交互类型映射不包含 none —— 那是"不可交互"，映射成动作即谎报。
+  B03. 容器类落到 group，不冒充可交互控件。
+
+Group C — 投影本体
+  C01. 可交互按钮 → clickable。
+  C02. 输入框 → editable 且不 clickable。
+  C03. 子树递归投影。
+  C04. 坐标原样落到 UIBounds。
+  C05. 置信度带过来且被限制在 1.0 以下（POLICY_2）。
+  C06. 边界框坏了不抛，节点仍在但没有坐标锚点。
+
+Group D — OCR 去重
+  D01. 与已识别控件高度重叠的 OCR 文本不再单独建节点。
+  D02. 独立文本保留。
+  D03. 空文本丢弃。
+  D04. include_ocr=False 时完全不产出 OCR 节点。
+
+Group E — 失败必须可区分
+  E01. 空结果。
+  E02. 识别失败（带原因）。
+  E03. 识别失败但没给原因 —— 也要说出"没给原因"。
+  E04. 识别成功但无控件。
+  E05. 以上四种都返回空图 + 非空说明，且说明彼此不同。
+
+Group F — 融合
+  F01. 无结构图时原样返回视觉图。
+  F02. 有结构图时产出混合图，merged_from 记录两个来源。
+  F03. 结构缺 label 由视觉补上。
+  F04. 融合抛异常时退回结构图，不丢掉两边。
+
+Group G — 活路径
+  G01. ui_act 接受 screenshot_b64。
+  G02. 视觉链路不可用时说明原因，不是静默失败。
+  G03. 结构图与截图都给时两条腿一起走（融合），不是二选一。
+  G04. 融合失败退回结构图，不丢掉本来就好的那份。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.schemas.ui_element import UIBounds, UIElementNode, UIGraph, UISource
+from core.vision_pipeline import (
+    BoundingBox,
+    ElementType,
+    GUIElement,
+    InteractionType,
+    OCRWord,
+    SceneContext,
+    VisionResult,
+)
+from core.vision_ui_projection import (
+    ELEMENT_ROLE_MAP,
+    INTERACTION_ACTION_MAP,
+    project_and_merge,
+    project_vision_result,
+)
+
+
+def _btn(text="发送", x=1180, y=2020, w=120, h=80, conf=0.91):
+    return GUIElement(
+        element_id="e-btn",
+        element_type=ElementType.BUTTON,
+        text=text,
+        bbox=BoundingBox(x, y, w, h),
+        confidence=conf,
+        interactable=True,
+        interaction_types=[InteractionType.CLICK],
+    )
+
+
+def _input(text="输入消息"):
+    return GUIElement(
+        element_id="e-input",
+        element_type=ElementType.INPUT,
+        text=text,
+        bbox=BoundingBox(60, 2010, 1000, 80),
+        confidence=0.88,
+        interactable=True,
+        interaction_types=[InteractionType.TYPE],
+    )
+
+
+def _ok(elements=None, words=None, app="微信", engine="deepseek-ocr2"):
+    return VisionResult(
+        success=True,
+        gui_elements=list(elements or []),
+        ocr_words=list(words or []),
+        scene=SceneContext(app_name=app, platform="android"),
+        engine_used=engine,
+    )
+
+
+class TestGroupAPolicies:
+    def test_a01_projection_is_additive(self):
+        from core.vision_ui_projection import VISION_PROJECTION_IS_ADDITIVE_POLICY
+
+        text = VISION_PROJECTION_IS_ADDITIVE_POLICY
+        assert "POLICY_1" in text
+        assert "never becomes a second recogniser" in text
+
+    def test_a02_vision_nodes_are_never_certain(self):
+        from core.vision_ui_projection import VISION_NODES_ARE_NEVER_CERTAIN_POLICY
+
+        text = VISION_NODES_ARE_NEVER_CERTAIN_POLICY
+        assert "POLICY_2" in text
+        assert "never 1.0" in text
+
+
+class TestGroupBVocabulary:
+    def test_b01_role_map_covers_every_element_type(self):
+        """漏一个类型,那类控件就会被静默投影成 text —— 可点的东西变成不可点。"""
+        for member in ElementType:
+            assert member.value in ELEMENT_ROLE_MAP, f"{member.value} 没有 role 映射"
+
+    def test_b02_none_interaction_is_not_mapped(self):
+        assert InteractionType.NONE.value not in INTERACTION_ACTION_MAP
+
+    def test_b03_containers_are_not_controls(self):
+        assert ELEMENT_ROLE_MAP["container"] == "group"
+        assert ELEMENT_ROLE_MAP["card"] == "group"
+
+
+class TestGroupCProjection:
+    def test_c01_button_is_clickable(self):
+        graph, _ = project_vision_result(_ok([_btn()]))
+        node = graph.find_by_label("发送")
+        assert node is not None and node.clickable is True
+        assert node.source is UISource.VISION
+
+    def test_c02_input_is_editable_not_clickable(self):
+        graph, _ = project_vision_result(_ok([_input()]))
+        node = graph.find_by_label("输入消息")
+        assert node.editable is True
+        assert node.clickable is False, "输入框被判成可点,模型会去点它而不是往里写"
+
+    def test_c03_children_recurse(self):
+        parent = _btn(text="卡片")
+        parent.element_type = ElementType.CARD
+        parent.children = [_btn(text="里面的按钮")]
+        graph, _ = project_vision_result(_ok([parent]))
+        assert graph.find_by_label("里面的按钮") is not None
+
+    def test_c04_bounds_carry_over(self):
+        graph, _ = project_vision_result(_ok([_btn()]))
+        node = graph.find_by_label("发送")
+        assert node.bounds is not None
+        assert (node.bounds.x, node.bounds.y, node.bounds.width, node.bounds.height) == (1180, 2020, 120, 80)
+        assert node.bounds.center() == (1240, 2060)
+
+    def test_c05_confidence_stays_below_one(self):
+        graph, _ = project_vision_result(_ok([_btn(conf=1.0)]))
+        node = graph.find_by_label("发送")
+        assert node.confidence < 1.0, "视觉推断冒充了结构事实的确定性(POLICY_2)"
+
+    def test_c06_broken_bounds_do_not_raise(self):
+        bad = _btn()
+        bad.bbox = object()  # 没有 x/y/width/height
+        graph, _ = project_vision_result(_ok([bad]))
+        node = graph.find_by_label("发送")
+        assert node is not None, "一个坏坐标不该让整屏都消失"
+        assert node.bounds is None
+
+
+class TestGroupDOcrDedup:
+    def test_d01_overlapping_text_is_absorbed(self):
+        """同一个按钮不该既是按钮又是文字 —— 模型引用 [n] 时会看到两个都对的候选。"""
+        word = OCRWord(text="发送", bbox=BoundingBox(1185, 2030, 110, 60), confidence=0.95)
+        graph, note = project_vision_result(_ok([_btn()], [word]))
+        labels = [n.label for n in graph.flatten() if n.label == "发送"]
+        assert len(labels) == 1
+        assert "独立文本" not in note
+
+    def test_d02_independent_text_is_kept(self):
+        word = OCRWord(text="今天天气不错", bbox=BoundingBox(60, 400, 600, 50), confidence=0.9)
+        graph, _ = project_vision_result(_ok([_btn()], [word]))
+        node = graph.find_by_label("今天天气不错")
+        assert node is not None and node.source is UISource.OCR
+
+    def test_d03_empty_text_is_dropped(self):
+        word = OCRWord(text="   ", bbox=BoundingBox(10, 10, 10, 10), confidence=0.9)
+        graph, _ = project_vision_result(_ok([_btn()], [word]))
+        assert all(n.source is not UISource.OCR for n in graph.flatten())
+
+    def test_d04_ocr_can_be_switched_off(self):
+        word = OCRWord(text="今天天气不错", bbox=BoundingBox(60, 400, 600, 50), confidence=0.9)
+        graph, _ = project_vision_result(_ok([_btn()], [word]), include_ocr=False)
+        assert graph.find_by_label("今天天气不错") is None
+
+
+class TestGroupEFailuresAreDistinguishable:
+    """四种"没有图"必须说得出是哪一种 —— 处置完全不同。"""
+
+    def test_e01_none_result(self):
+        graph, note = project_vision_result(None)
+        assert graph.root is None and "为空" in note
+
+    def test_e02_failed_with_reason(self):
+        graph, note = project_vision_result(VisionResult(success=False, error="配额耗尽"))
+        assert graph.root is None and "配额耗尽" in note
+
+    def test_e03_failed_without_reason_still_says_so(self):
+        graph, note = project_vision_result(VisionResult(success=False))
+        assert graph.root is None
+        assert "未给出原因" in note, "失败且不说原因,是最难排查的那一种,必须点名"
+
+    def test_e04_succeeded_but_nothing_found(self):
+        graph, note = project_vision_result(_ok([], [], engine="tesseract"))
+        assert graph.root is None and "tesseract" in note
+
+    def test_e05_all_four_notes_differ(self):
+        notes = {
+            project_vision_result(None)[1],
+            project_vision_result(VisionResult(success=False, error="配额耗尽"))[1],
+            project_vision_result(VisionResult(success=False))[1],
+            project_vision_result(_ok([], []))[1],
+        }
+        assert len(notes) == 4, "两种不同的失败给了同一句说明,等于没说"
+
+
+class TestGroupFMerge:
+    @staticmethod
+    def _structural(label=""):
+        root = UIElementNode(
+            role="root",
+            children=[
+                UIElementNode(
+                    role="button",
+                    label=label,
+                    clickable=True,
+                    bounds=UIBounds(x=1180, y=2020, width=120, height=80),
+                )
+            ],
+        )
+        return UIGraph(root=root, source=UISource.UIA)
+
+    def test_f01_without_structure_returns_vision_graph(self):
+        graph, _ = project_and_merge(_ok([_btn()]), None)
+        assert graph.source is UISource.VISION
+
+    def test_f02_merged_graph_records_both_sources(self):
+        graph, note = project_and_merge(_ok([_btn(), _input()]), self._structural(label="发送"))
+        assert graph.source is UISource.HYBRID
+        assert set(graph.merged_from) == {UISource.UIA, UISource.VISION}
+        assert "融合" in note
+
+    def test_f03_vision_fills_a_missing_structural_label(self):
+        """结构常缺文案,视觉常有 —— 这正是两条腿一起走的收益。"""
+        graph, _ = project_and_merge(_ok([_btn()]), self._structural(label=""))
+        button = next(n for n in graph.flatten() if n.role == "button" and n.source is not UISource.VISION)
+        assert button.label == "发送"
+
+    def test_f04_merge_failure_falls_back_to_structure(self, monkeypatch):
+        structural = self._structural(label="发送")
+
+        def boom(*_a, **_k):
+            raise RuntimeError("merge exploded")
+
+        monkeypatch.setattr(type(structural), "merge", boom, raising=True)
+        graph, note = project_and_merge(_ok([_btn()]), structural)
+        assert graph is structural, "融合失败把两边都丢了 —— 结构本来是好的"
+        assert "RuntimeError" in note
+
+
+class TestGroupGLivePath:
+    @pytest.mark.asyncio
+    async def test_g01_ui_act_accepts_a_screenshot(self, monkeypatch):
+        """没有结构树的平台可以只给截图 —— 这是本阶段接线的落点。"""
+        import core.vision_ui_projection as proj
+        from core.routes import ui_act as mod
+
+        async def _fake_graph(req):
+            graph, note = proj.project_vision_result(_ok([_btn()]), device_id=req.device_id)
+            return graph.model_dump(mode="json"), note
+
+        monkeypatch.setattr(mod, "_graph_from_screenshot", _fake_graph)
+        out = await mod.ui_act(
+            mod.UIActRequest(instruction="点发送", screenshot_b64="zzz", platform="windows", execute=False)
+        )
+        assert out["success"] is True
+        assert out["planned"]["label"] == "发送"
+        assert "视觉投影" in out["vision_note"]
+
+    @pytest.mark.asyncio
+    async def test_g02_unavailable_vision_says_why(self, monkeypatch):
+        from core.routes import ui_act as mod
+
+        async def _fake_graph(req):
+            return None, "视觉链路不可用(ModuleNotFoundError)"
+
+        monkeypatch.setattr(mod, "_graph_from_screenshot", _fake_graph)
+        out = await mod.ui_act(mod.UIActRequest(instruction="点发送", screenshot_b64="zzz"))
+        assert out["success"] is False
+        assert "不可用" in out["vision_note"], "给不出图却不说为什么,排查无从下手"
+
+    @pytest.mark.asyncio
+    async def test_g03_both_inputs_walk_on_two_legs(self, monkeypatch):
+        """契约本身的立场:结构与视觉恒并存,不是谁 fallback 谁。"""
+        from core.routes import ui_act as mod
+        from core.schemas.ui_element import UISource
+
+        structural = UIGraph(
+            root=UIElementNode(
+                role="root",
+                children=[
+                    UIElementNode(
+                        role="button",
+                        label="",  # 结构常缺文案
+                        clickable=True,
+                        bounds=UIBounds(x=1180, y=2020, width=120, height=80),
+                    )
+                ],
+            ),
+            source=UISource.UIA,
+        ).model_dump(mode="json")
+
+        async def _fake_merge(req, base):
+            from core.vision_ui_projection import project_and_merge
+
+            merged, note = project_and_merge(_ok([_btn(), _input()]), UIGraph.model_validate(base))
+            return merged.model_dump(mode="json"), note
+
+        monkeypatch.setattr(mod, "_merge_screenshot_into", _fake_merge)
+        out = await mod.ui_act(
+            mod.UIActRequest(
+                instruction="点发送", ui_graph=structural, screenshot_b64="zzz", platform="windows", execute=False
+            )
+        )
+        assert out["success"] is True
+        assert "融合" in out["vision_note"]
+        assert out["planned"]["label"] == "发送", "视觉给结构补上了缺失的文案"
+
+    @pytest.mark.asyncio
+    async def test_g04_merge_failure_keeps_the_structural_graph(self, monkeypatch):
+        from core.routes import ui_act as mod
+
+        structural = UIGraph(
+            root=UIElementNode(
+                role="root",
+                children=[
+                    UIElementNode(
+                        role="button", label="发送", clickable=True, bounds=UIBounds(x=1, y=1, width=10, height=10)
+                    )
+                ],
+            ),
+            source=UISource.UIA,
+        ).model_dump(mode="json")
+
+        class _Boom:
+            async def understand(self, **_kw):
+                raise RuntimeError("vision down")
+
+        monkeypatch.setattr("core.vision_pipeline.VisionPipeline", _Boom)
+        out = await mod.ui_act(
+            mod.UIActRequest(
+                instruction="点发送", ui_graph=structural, screenshot_b64="zzz", platform="windows", execute=False
+            )
+        )
+        assert out["success"] is True
+        assert out["planned"]["label"] == "发送", "融合失败把本来好的结构图也丢了"
+        assert "融合跳过" in out["vision_note"]


### PR DESCRIPTION
「这一步点哪个控件」这件事，仓库里有**三份互不相识的实现**。本轮不新增感知能力，只把这三份收成一份。

**默认档位下行为逐字节不变。**

> 配套 Android 侧改动：`DannyFish-11/ufo-galaxy-android` 同名分支。两侧字段名有测试对齐（F01）。

---

## 查出来的现状

| 实现 | 位置 | 状态 |
|---|---|---|
| V2 结构化契约 | `ui_grounding` + `grounded_planner` + `routes/ui_act` | **只有 Windows UIA 一个生产者** |
| V2 视觉管线 | `vision_pipeline` | **自成一套形状**，只通向两个 HTTP 端点 |
| Android 端 | `GroundingArbiter` + `AccessibilityUiSnapshotProvider` | 完整、有裁决矩阵与 JVM 单测、**从不出设备** |

三条硬证据：

- `UISource.ANDROID_A11Y` / `VISION` / `OCR` **全是零生产者**——契约里声明了位置，没人产出
- 设备一直上报 `accessibility_ready: true`，网关**只拿它做设备选择评分（+5）**，从没有任何链路把那棵树取回来
- Android 端读了树、剪了枝、还修过节点回收 bug，**但从未把它发出去**

---

## Stage A — 先写下谁说了算

`core/perception_grounding.py`，只放判据，不读、不算、不决定（形状对齐 `semantic_anchoring`）。

**不先约定权威就把 a11y 树接上来，结果只会是第四份实现**，而且是延迟最高的那一份。

- **Android / WearOS → 设备本地**：往返延迟直接体现在点击响应上；剪枝后的树仍有上百节点；且设备端已有裁决矩阵（`agreement` / `tree_override` / `tree_rescue` / `vlm_only`）与单测
- **桌面 → 服务端**：设备端无对应实现
- **未知平台 → 服务端**，不是「没人负责」

活路径真的去问它：`/api/v1/ui/act` 响应带 `grounding_authority`；归属设备的平台**只规划不派发**，并在 `dispatch_declined` 里说明——静默不派发与派发失败在现场分不开。

## Stage B — 视觉管线接进统一契约

`VisionResult` 的 OCR 框与 GUI 元素，正好对应零生产者的 `UISource.OCR` / `VISION`。加**纯投影函数**，让 `vision_pipeline` 成为 `UIGraph` 的第二个生产者而不是第二套形状。

`/api/v1/ui/act` 因此在没有 UIA 的平台上也有结构可用；结构图与截图同给时走 `UIGraph.merge` **两条腿一起走**（契约本身的立场，不是谁 fallback 谁）。

> **自测抓到我自己两个缺陷，都修了：**
> - `ElementType.UNKNOWN` 漏在 role 映射外，会被静默投影成 `text`——可点的东西变成不可点
> - 边界框对象缺字段时 `getattr` 兜底造出 `(0,0,0x0)`，等于告诉模型「控件在屏幕左上角」。**猜错的坐标比没有坐标危险**：没坐标会退回让模型看画面，错坐标会直接点过去

## Stage C — Android 快照上行

- **搭既有上行的车**：挂在 `DEVICE_PERCEPTION_EMISSION` 上的可选字段，默认 null。没有新消息类型、没有协议变更，设备不带它时整条链路逐字节相同
- **Kotlin 侧默认关**（`DEFAULT_ENABLED=false`）：按需，不是每一拍都传上百个节点
- **看得见 ≠ 可以决定**（POLICY_1/POLICY_3）：服务端拿它做编排与呈现，绝不覆盖设备端已做出的裁决——两端看到的是不同瞬间的屏幕。测试 E04 钉住「仍不派发」
- **过期快照（>120s）不再作为「当前界面」交出**：界面会变，拿两分钟前的树规划一串点不中的动作，比说「我不知道」更糟
- **既没标签又没坐标的节点直接丢弃**：它引用不了也点不中，留着会让「拿到了一张图」不再意味着「看得见这一屏」

---

## 明确不做的

| 项 | 为什么 |
|---|---|
| 引入 Vision Agents 框架 | 它的 `Agent` 类是编排中枢，而本仓已有 `ExecutionPlanner` + `kernel` + `scheduler` + `CanonicalTask`；引进来当场违反「无第二份实现」那道闸。传输还绑 GetStream（需凭据的 SaaS）。**抄处理器槽位思路，不抄框架** |
| 加 YOLO / 姿态估计处理器 | 本仓场景是 UI 控制。a11y 树给的是「名为『发送』的按钮在这个坐标、可点击」，检测框给不了控件语义。那类处理器适合体态指导、安防 |
| 在 V2 侧建 Android grounding 仲裁器 | POLICY_1 |
| 每帧上传 a11y 树 | 见 Stage C |

## 验证

| 项 | 结果 |
|---|---|
| 新增测试 | Stage A 27 条 / Stage B 28 条 / Stage C 28 条；Android 侧 6 条 JVM 单测 |
| 三道 lint 门 | flake8（CI 口径）= 0；black、isort 干净 |
| 结构守卫 | 语义锚定 ✅、可达性 ✅、复杂度预算 ✅、**接线检查 ✅**（当场抓到我新加的两个函数没有调用方，已真接上而非进基线） |
| 生成类型 | `api.gen.ts` 已随新路由重新生成 |
| 本地全量 | 跑完补充在评论里 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2fQk5F3uQGUaX1nXpZ2vt)_